### PR TITLE
Create ED test suite for cime test driver

### DIFF
--- a/components/clm/cimetest/testlist_clm.xml
+++ b/components/clm/cimetest/testlist_clm.xml
@@ -487,6 +487,7 @@
     </grid>
     <grid name="f09_g16">
       <test name="ERI_D_Ld9">
+        <machine compiler="ed" testtype="ed" testmods="clm/default">ed</machine>
         <machine compiler="intel" testtype="aux_clm_ys_pgi" testmods="clm/default">edison</machine>
         <machine compiler="intel" testtype="aux_clm45" testmods="clm/default">yellowstone</machine>
         <machine compiler="pgi" testtype="aux_clm45" testmods="clm/default">yellowstone</machine>
@@ -498,30 +499,6 @@
       </test>
     </grid>
     <grid name="f10_f10">
-       <test name="SMS_D_Ld3">
-          <machine compiler="intel" testtype="aux_clm_short" testmods="clm/default">yellowstone</machine>
-          <machine compiler="gnu" testtype="aux_clm_short" testmods="clm/default">yellowstone</machine>
-          <machine compiler="pgi" testtype="aux_clm_short" testmods="clm/default">yellowstone</machine>
-          <machine compiler="intel" testtype="aux_clm45" testmods="clm/default">yellowstone</machine>
-          <machine compiler="gnu" testtype="aux_clm45" testmods="clm/default">yellowstone</machine>
-          <machine compiler="pgi" testtype="aux_clm45" testmods="clm/default">yellowstone</machine>
-       </test>
-       <test name="ERS_D_Ld3">
-          <machine compiler="intel" testtype="aux_clm_short" testmods="clm/default">yellowstone</machine>
-          <machine compiler="gnu" testtype="aux_clm_short" testmods="clm/default">yellowstone</machine>
-          <machine compiler="pgi" testtype="aux_clm_short" testmods="clm/default">yellowstone</machine>
-          <machine compiler="intel" testtype="aux_clm45" testmods="clm/default">yellowstone</machine>
-          <machine compiler="gnu" testtype="aux_clm45" testmods="clm/default">yellowstone</machine>
-          <machine compiler="pgi" testtype="aux_clm45" testmods="clm/default">yellowstone</machine>
-       </test>
-       <test name="ERP_D_Ld3_P15x2">
-          <machine compiler="intel" testtype="aux_clm_short" testmods="clm/default">yellowstone</machine>
-          <machine compiler="gnu" testtype="aux_clm_short" testmods="clm/default">yellowstone</machine>
-          <machine compiler="pgi" testtype="aux_clm_short" testmods="clm/default">yellowstone</machine>
-          <machine compiler="intel" testtype="aux_clm45" testmods="clm/default">yellowstone</machine>
-          <machine compiler="gnu" testtype="aux_clm45" testmods="clm/default">yellowstone</machine>
-          <machine compiler="pgi" testtype="aux_clm45" testmods="clm/default">yellowstone</machine>
-       </test>
       <test name="CME_Ld1">
         <machine compiler="intel" testtype="aux_testsystem" testmods="clm/default">yellowstone</machine>
       </test>
@@ -538,6 +515,14 @@
         <machine compiler="intel" testtype="aux_clm_ys_pgi">edison</machine>
         <machine compiler="intel" testtype="aux_clm45" testmods="clm/drydepnomegan">yellowstone</machine>
         <machine compiler="pgi" testtype="aux_clm45">yellowstone</machine>
+      </test>
+      <test name="ERP_D_Ld3_P15x2">
+        <machine compiler="gnu" testtype="aux_clm45" testmods="clm/default">yellowstone</machine>
+        <machine compiler="intel" testtype="aux_clm45" testmods="clm/default">yellowstone</machine>
+        <machine compiler="pgi" testtype="aux_clm45" testmods="clm/default">yellowstone</machine>
+        <machine compiler="gnu" testtype="aux_clm_short" testmods="clm/default">yellowstone</machine>
+        <machine compiler="intel" testtype="aux_clm_short" testmods="clm/default">yellowstone</machine>
+        <machine compiler="pgi" testtype="aux_clm_short" testmods="clm/default">yellowstone</machine>
       </test>
       <test name="ERP_D_Ld5">
         <machine compiler="intel" testtype="aux_clm_ys_intel" testmods="clm/rootlit">edison</machine>
@@ -558,11 +543,28 @@
       <test name="ERP_P15x2_D">
         <machine compiler="gnu" testtype="aux_clm45" testmods="clm/snowlayers_12" comment="Can be removed once we change the CLM5 default to have more than 5 snow layers (at which point we will be testing 5 layers with CLM45 and more than 5 with CLM5)">yellowstone</machine>
       </test>
+      <test name="ERS_D_Ld3">
+        <machine compiler="gnu" testtype="aux_clm45" testmods="clm/default">yellowstone</machine>
+        <machine compiler="intel" testtype="aux_clm45" testmods="clm/default">yellowstone</machine>
+        <machine compiler="pgi" testtype="aux_clm45" testmods="clm/default">yellowstone</machine>
+        <machine compiler="gnu" testtype="aux_clm_short" testmods="clm/default">yellowstone</machine>
+        <machine compiler="intel" testtype="aux_clm_short" testmods="clm/default">yellowstone</machine>
+        <machine compiler="pgi" testtype="aux_clm_short" testmods="clm/default">yellowstone</machine>
+      </test>
       <test name="PEM_Ld1">
         <machine compiler="intel" testtype="aux_testsystem" testmods="clm/default">yellowstone</machine>
       </test>
       <test name="SMS_D_Ld1_P24x1">
         <machine compiler="nag" testtype="aux_clm45" testmods="clm/oldhyd">hobart</machine>
+      </test>
+      <test name="SMS_D_Ld3">
+        <machine compiler="ed" testtype="ed" testmods="clm/default">ed</machine>
+        <machine compiler="gnu" testtype="aux_clm45" testmods="clm/default">yellowstone</machine>
+        <machine compiler="intel" testtype="aux_clm45" testmods="clm/default">yellowstone</machine>
+        <machine compiler="pgi" testtype="aux_clm45" testmods="clm/default">yellowstone</machine>
+        <machine compiler="gnu" testtype="aux_clm_short" testmods="clm/default">yellowstone</machine>
+        <machine compiler="intel" testtype="aux_clm_short" testmods="clm/default">yellowstone</machine>
+        <machine compiler="pgi" testtype="aux_clm_short" testmods="clm/default">yellowstone</machine>
       </test>
       <test name="SMS_Lm1_D">
         <machine compiler="intel" testtype="aux_clm45" testmods="clm/snowlayers_3_monthly" comment="nlevsno less than 5 is not important scientifically, but is useful for making sure no code assumes that there are 5 snow layers (because this should result in an array bounds exception); this test can be removed once CLM5 is released and most new branches are based off of CLM5 (which will have a runtime-set number of snow layers, rather than assuming 5 snow layers)... until then, I want this test to catch any new code that assumes 5 snow layers">yellowstone</machine>
@@ -700,26 +702,52 @@
   <compset name="ICLM45ED">
     <grid name="1x1_brazil">
       <test name="ERS_D_Mmpi-serial_Ld5">
+        <machine compiler="ed" testtype="ed" testmods="clm/edTest">ed</machine>
         <machine compiler="gnu" testtype="aux_clm45" testmods="clm/edTest">yellowstone</machine>
         <machine compiler="intel" testtype="aux_clm45" testmods="clm/edTest">yellowstone</machine>
       </test>
     </grid>
     <grid name="5x5_amazon">
+      <test name="ERS_D_Ld5">
+        <machine compiler="ed" testtype="ed" testmods="clm/edTest">ed</machine>
+      </test>
       <test name="SMS_D_Mmpi-serial_Ld5">
+        <machine compiler="ed" testtype="ed" testmods="clm/edTest">ed</machine>
         <machine compiler="nag" testtype="aux_clm45" testmods="clm/edTest">hobart</machine>
         <machine compiler="pgi" testtype="aux_clm45" testmods="clm/edTest">yellowstone</machine>
       </test>
     </grid>
+    <grid name="f09_g16">
+      <test name="ERS_D_Ld5">
+        <machine compiler="ed" testtype="ed" testmods="clm/edTest">ed</machine>
+      </test>
+    </grid>
     <grid name="f10_f10">
+      <test name="ERS_D_Ld5">
+        <machine compiler="ed" testtype="ed" testmods="clm/edTest">ed</machine>
+      </test>
+      <test name="SMS_D_Ld5">
+        <machine compiler="ed" testtype="ed" testmods="clm/edTest">ed</machine>
+      </test>
       <test name="SMS_Ld5">
+        <machine compiler="ed" testtype="ed" testmods="clm/edTest">ed</machine>
         <machine compiler="intel" testtype="aux_clm45" testmods="clm/edTest">yellowstone</machine>
         <machine compiler="pgi" testtype="aux_clm45" testmods="clm/edTest">yellowstone</machine>
       </test>
     </grid>
     <grid name="f19_g16">
+      <test name="ERS_D_Ld5">
+        <machine compiler="ed" testtype="ed" testmods="clm/edTest">ed</machine>
+      </test>
       <test name="SMS_Ld5">
+        <machine compiler="ed" testtype="ed" testmods="clm/edTest">ed</machine>
         <machine compiler="gnu" testtype="aux_clm45" testmods="clm/edTest">yellowstone</machine>
         <machine compiler="intel" testtype="aux_clm45" testmods="clm/edTest">yellowstone</machine>
+      </test>
+    </grid>
+    <grid name="f45_g37">
+      <test name="ERS_D_Ld5">
+        <machine compiler="ed" testtype="ed" testmods="clm/edTest">ed</machine>
       </test>
     </grid>
   </compset>
@@ -897,10 +925,6 @@
   </compset>
   <compset name="ICRUCLM50BGC">
     <grid name="f10_f10">
-       <test name="ERP_D_P15x2_Ld3">
-          <machine compiler="intel" testtype="aux_clm45" testmods="clm/flexibleCN">yellowstone</machine>
-          <machine compiler="intel" testtype="aux_clm45" testmods="clm/luna">yellowstone</machine>
-       </test>
       <test name="ERI_D_Ld9">
         <machine compiler="intel" testtype="aux_clm_ys_intel" testmods="clm/default">edison</machine>
         <machine compiler="intel" testtype="aux_clm45" testmods="clm/default">yellowstone</machine>
@@ -914,6 +938,10 @@
         <machine compiler="gnu" testtype="aux_clm45" testmods="clm/default">yellowstone</machine>
         <machine compiler="intel" testtype="aux_clm45" testmods="clm/reduceOutput">yellowstone</machine>
         <machine compiler="pgi" testtype="aux_clm45" testmods="clm/reduceOutput">yellowstone</machine>
+      </test>
+      <test name="ERP_D_P15x2_Ld3">
+        <machine compiler="intel" testtype="aux_clm45" testmods="clm/flexibleCN">yellowstone</machine>
+        <machine compiler="intel" testtype="aux_clm45" testmods="clm/luna">yellowstone</machine>
       </test>
       <test name="ERP_Ld5_P24x1">
         <machine compiler="nag" testtype="aux_clm45" testmods="clm/reduceOutput">hobart</machine>


### PR DESCRIPTION
Create ED test list based on the ED test in the clm test suite and
additional tests being run by Stef Muszala. To run the ED test suite
with baseline comparison:

```
cd cime/scripts
execca ./create_test -xml_category ed \
    -mach yellowstone -compiler intel \
    -xml_mach ed -xml_compiler ed \
    -compare clm4_5_1_r120 \
    -testroot /glade/scratch/andre/tests-ed-20160106-1745 \
    -testid 01061745-edp
```

Repeat the command for each compiler on a machine.
Note: there are many failing tests on the ed-clm master branch. Some of
these will be fixed when the most recent muszala-ed4x5fix branch is
merged. At that point any remaining broken tests will be added to the
expected failures file or removed.

Note: there are also some additional unrelated diffs created when the
manage_testlist tool automatically cleaned up the testlist file.

User interface changes: none

Code review: none

Test suite: ed
Test baseline: clm4_5_1_r120
Test namelist changes: none
Test status: bit for bit

```
FAIL ERS_D_Mmpi-serial_Ld5.1x1_brazil.ICLM45ED.yellowstone_pgi.clm-edTest.clm2.h0.nc : test compare clm2.h0 (.base and .rest files)
FAIL ERS_D_Mmpi-serial_Ld5.1x1_brazil.ICLM45ED.yellowstone_pgi.clm-edTest.cpl.hi.nc : test compare cpl.hi (.base and .rest files)
FAIL ERS_D_Mmpi-serial_Ld5.1x1_brazil.ICLM45ED.yellowstone_pgi.clm-edTest : test functionality summary (ERS_test)

RUN ERS_D_Ld5.f10_f10.ICLM45ED.yellowstone_pgi.clm-edTest.C.01061745-edp
RUN ERS_D_Ld5.f45_g37.ICLM45ED.yellowstone_pgi.clm-edTest.C.01061745-edp
RUN ERS_D_Ld5.5x5_amazon.ICLM45ED.yellowstone_pgi.clm-edTest.C.01061745-edp
RUN ERS_D_Ld5.f19_g16.ICLM45ED.yellowstone_pgi.clm-edTest.C.01061745-edp
RUN ERS_D_Ld5.f09_g16.ICLM45ED.yellowstone_pgi.clm-edTest.C.01061745-edp

RUN ERS_D_Ld5.f10_f10.ICLM45ED.yellowstone_gnu.clm-edTest.C.01061745-edg
RUN ERS_D_Ld5.f45_g37.ICLM45ED.yellowstone_gnu.clm-edTest.C.01061745-edg
RUN SMS_Ld5.f10_f10.ICLM45ED.yellowstone_gnu.clm-edTest.C.01061745-edg
RUN ERS_D_Ld5.5x5_amazon.ICLM45ED.yellowstone_gnu.clm-edTest.C.01061745-edg
RUN ERS_D_Ld5.f19_g16.ICLM45ED.yellowstone_gnu.clm-edTest.C.01061745-edg
RUN ERS_D_Ld5.f09_g16.ICLM45ED.yellowstone_gnu.clm-edTest.C.01061745-edg

RUN ERS_D_Ld5.f10_f10.ICLM45ED.yellowstone_intel.clm-edTest.C.01061745-edi
RUN ERS_D_Ld5.f45_g37.ICLM45ED.yellowstone_intel.clm-edTest.C.01061745-edi
RUN ERS_D_Ld5.5x5_amazon.ICLM45ED.yellowstone_intel.clm-edTest.C.01061745-edi
RUN ERS_D_Ld5.f19_g16.ICLM45ED.yellowstone_intel.clm-edTest.C.01061745-edi
RUN ERS_D_Ld5.f09_g16.ICLM45ED.yellowstone_intel.clm-edTest.C.01061745-edi
```
