### PR TITLE
Bugfix: clm history files always instantaneous with ED on

### DIFF
--- a/components/clm/src/main/clm_driver.F90
+++ b/components/clm/src/main/clm_driver.F90
@@ -693,32 +693,6 @@ contains
                cnveg_state_inst, cnveg_carbonflux_inst)
           call t_stopf('ecosysdyn')
 
-!       elseif (use_ed) then
-
-          ! call EDBGCDyn(bounds_clump, &
-          !      filter(nc)%num_soilc, filter(nc)%soilc, &
-          !      ed_clm_inst, &
-          !      soilbiogeochem_carbonflux_inst, soilbiogeochem_carbonstate_inst,         &
-          !      c13_soilbiogeochem_carbonflux_inst, c13_soilbiogeochem_carbonstate_inst, &
-          !      c14_soilbiogeochem_carbonflux_inst, c14_soilbiogeochem_carbonstate_inst, &
-          !      soilbiogeochem_state_inst,                                               &
-          !      soilbiogeochem_nitrogenflux_inst, soilbiogeochem_nitrogenstate_inst)
- 
-!          call EDBGCDyn(bounds_clump,                                                              &
-!               filter(nc)%num_soilc, filter(nc)%soilc,                                             &
-!               filter(nc)%num_soilp, filter(nc)%soilp,                                             &
-!               filter(nc)%num_pcropp, filter(nc)%pcropp, doalb,                                    &
-!               cnveg_state_inst,                                                                   &
-!               cnveg_carbonflux_inst, cnveg_carbonstate_inst,                                      &
-!               ed_clm_inst,                                                                        &
-!               soilbiogeochem_carbonflux_inst, soilbiogeochem_carbonstate_inst,                    &
-!               soilbiogeochem_state_inst,                                                          &
-!               soilbiogeochem_nitrogenflux_inst, soilbiogeochem_nitrogenstate_inst,                &
-!               c13_soilbiogeochem_carbonstate_inst, c13_soilbiogeochem_carbonflux_inst,            &
-!               c14_soilbiogeochem_carbonstate_inst, c14_soilbiogeochem_carbonflux_inst,            &
-!               atm2lnd_inst, waterstate_inst, waterflux_inst,                                      &
-!               canopystate_inst, soilstate_inst, temperature_inst, crop_inst, ch4_inst)
-
        end if
 
                 ! Prescribed biogeography - prescribed canopy structure, some prognostic carbon fluxes


### PR DESCRIPTION
Bugfix for incorrect ED history files. Changeset eb26be6 incorrectly
moved the history buffer updates inside an if (use_ed
.and. is_day_boundry) block. This caused all clm history variables to
only be written at the day boundary, giving the appearence of
instantaneous output. Discussin with clm SE group and Rosie proposed
removing the if block around the hist buff update and moving the call
to ed_driver earlier in the call sequence.

Fixes: #24

User interface changes?: Yes history output changes

Code review: self, clm SE discussion, needs further science review

Test suite: ed, yellowstone - intel, gnu, pgi
Test baseline: d8a9ee50
Test namelist changes: none
Test answer changes: yes, history output bug fix. order of operations
                     change (call to ed driver moved)?
Test summary: answer changing, baseline failures, expecetd failures
 in f09 and f10 restarts.
