### PR TITLE
merge to clm4_5_9_r183

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,109 @@
 ===============================================================
+Tag name:  clm4_5_9_r183
+Originator(s):  erik (Erik Kluzek)
+Date: Sat Jul  2 18:23:09 MDT 2016
+One-line Summary: Decomposition is not water limited after reaching a field capacity parameter (maxpsi_hr) rather 
+                  than only at soil saturation
+
+Purpose of changes
+------------------
+
+Replaces the hard-coded assumption present in prior versions of the model that soil respiration was 
+water-limited whenever it fell below saturation. Now it's no longer water-limited from maxpsi_hr up
+to saturation.
+
+This was due to a wrong interpretation/implementation of the following paper.
+
+Andren, O., and K. Paustian, 1987. Barley straw decomposition in the field: a comparison of models. Ecology, 68(5):1190-1200
+
+Also see notes in..
+
+http://bb.cgd.ucar.edu/cesm12z-clm45-important-bad-interpretation-maximum-rate-constant-soil-water-content
+
+Bugs fixed or introduced
+------------------------
+
+Bugs fixed (include bugzilla ID): 2324 Bad interpretation of maximum rate constant for soil water content in SoilbiogeochemDecompCascade
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users: None
+
+Changes to CLM's user interface: None
+
+Changes made to namelist defaults: new params files
+
+Changes to the datasets: parameter files
+
+Substantial timing or memory changes: None
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance):
+   maxpsi_hr is a scalar constant but read in on the parameter file (should change to namelist)
+
+Changes to tests or testing: Removed RTM ESMF test
+
+Code reviewed by: self, ckoven, dlawren
+
+CLM testing: regular
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    yellowstone - OK (70 comparision tests fail, because of the new params files)
+
+  unit-tests (components/clm/src):
+
+    yellowstone - PASS
+
+  regular tests (aux_clm40, aux_clm45):
+
+    yellowstone_intel - OK
+    yellowstone_pgi - OK
+    yellowstone_gnu (clm45 only) - OK
+    hobart_nag - PASS
+
+CLM tag used for the baseline comparisons:  clm4_5_8_r182
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: Yes, for CLM4_5/CLM5_0 for BGC and CN cases
+
+  Summarize any changes to answers:
+    - what code configurations: clm4_5 and clm5_0 with BGC or CN
+    - what platforms/compilers: all
+    - nature of change: should be similar climate 
+
+    Charlie Koven did some work with sensitivity analysis to find a good value for maxpsi_hr
+
+Detailed list of changes
+------------------------
+
+List any svn externals directories updated (cime, rtm, mosart, cism, etc.): rtm
+
+    rtm to rtm1_0_57 -- remove ESMF test
+
+List all files eliminated: None
+
+List all files added and what they do: None
+
+List all existing files that have been modified, and describe the changes:
+
+   M components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml -- new params file with maxpsi_hr on them
+
+   M components/clm/src/soilbiogeochem/SoilBiogeochemDecompCascadeBGCMod.F90 - Use maxpsi_hr from params file
+       rather than max soil saturation
+   M components/clm/src/soilbiogeochem/SoilBiogeochemDecompCascadeCNMod.F90 -- Use maxpsi_hr from params file
+       rather than max soil saturation
+
+===============================================================
+===============================================================
 Tag name:  clm4_5_8_r182
 Originator(s):  erik (Erik Kluzek)
 Date: Fri Jun 24 23:33:36 MDT 2016

--- a/SVN_EXTERNAL_DIRECTORIES
+++ b/SVN_EXTERNAL_DIRECTORIES
@@ -1,5 +1,5 @@
 cime					https://github.com/CESM-Development/cime/tags/clm4_5_8_r180_cime4.5.14
 components/clm/tools/shared/gen_domain  https://github.com/CESM-Development/cime/tags/clm4_5_8_r180_cime4.5.14/tools/mapping/gen_domain_files
 components/cism                         https://svn-ccsm-models.cgd.ucar.edu/glc/trunk_tags/cism2_1_17
-components/rtm                          https://svn-ccsm-models.cgd.ucar.edu/rivrtm/trunk_tags/rtm1_0_56
+components/rtm                          https://svn-ccsm-models.cgd.ucar.edu/rivrtm/trunk_tags/rtm1_0_57
 components/mosart                       https://svn-ccsm-models.cgd.ucar.edu/mosart/trunk_tags/mosart1_0_16

--- a/SVN_EXTERNAL_DIRECTORIES.orig
+++ b/SVN_EXTERNAL_DIRECTORIES.orig
@@ -1,5 +1,5 @@
 cime					https://github.com/CESM-Development/cime/tags/clm4_5_8_r180_cime4.5.14
 components/clm/tools/shared/gen_domain  https://github.com/CESM-Development/cime/tags/clm4_5_8_r180_cime4.5.14/tools/mapping/gen_domain_files
 components/cism                         https://svn-ccsm-models.cgd.ucar.edu/glc/trunk_tags/cism2_1_17
-components/rtm                          https://svn-ccsm-models.cgd.ucar.edu/rivrtm/trunk_tags/rtm1_0_56
+components/rtm                          https://svn-ccsm-models.cgd.ucar.edu/rivrtm/trunk_tags/rtm1_0_57
 components/mosart                       https://svn-ccsm-models.cgd.ucar.edu/mosart/trunk_tags/mosart1_0_16

--- a/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
+++ b/components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml
@@ -220,9 +220,9 @@ attributes from the config_cache.xml file (with keys converted to upper-case).
 <!-- The default filenames are given relative to the root directory
      for the CLM2 data in the CESM distribution -->
 <!-- Plant function types (relative to {csmdata}) -->
-<paramfile phys="clm5_0" use_ed=".false.">lnd/clm2/paramdata/clm5_params.c160316.nc</paramfile>
-<paramfile phys="clm4_5" use_ed=".false.">lnd/clm2/paramdata/clm_params.c160225.nc</paramfile>
-<paramfile phys="clm4_5" use_ed=".true." >lnd/clm2/paramdata/clm_params_ed.c160225.nc</paramfile>
+<paramfile phys="clm5_0" use_ed=".false.">lnd/clm2/paramdata/clm5_params.c160701a.nc</paramfile>
+<paramfile phys="clm4_5" use_ed=".false.">lnd/clm2/paramdata/clm_params.c160701.nc</paramfile>
+<paramfile phys="clm4_5" use_ed=".true." >lnd/clm2/paramdata/clm_params_ed.c160805.nc</paramfile>
 
 <!-- ========================================================================================  -->
 <!-- clm 5.0 BGC nitrogen model                                                                -->

--- a/components/clm/doc/ChangeLog
+++ b/components/clm/doc/ChangeLog
@@ -1,4 +1,109 @@
 ===============================================================
+Tag name:  clm4_5_9_r183
+Originator(s):  erik (Erik Kluzek)
+Date: Sat Jul  2 18:23:09 MDT 2016
+One-line Summary: Decomposition is not water limited after reaching a field capacity parameter (maxpsi_hr) rather 
+                  than only at soil saturation
+
+Purpose of changes
+------------------
+
+Replaces the hard-coded assumption present in prior versions of the model that soil respiration was 
+water-limited whenever it fell below saturation. Now it's no longer water-limited from maxpsi_hr up
+to saturation.
+
+This was due to a wrong interpretation/implementation of the following paper.
+
+Andren, O., and K. Paustian, 1987. Barley straw decomposition in the field: a comparison of models. Ecology, 68(5):1190-1200
+
+Also see notes in..
+
+http://bb.cgd.ucar.edu/cesm12z-clm45-important-bad-interpretation-maximum-rate-constant-soil-water-content
+
+Bugs fixed or introduced
+------------------------
+
+Bugs fixed (include bugzilla ID): 2324 Bad interpretation of maximum rate constant for soil water content in SoilbiogeochemDecompCascade
+
+Notes of particular relevance for users
+---------------------------------------
+
+Caveats for users: None
+
+Changes to CLM's user interface: None
+
+Changes made to namelist defaults: new params files
+
+Changes to the datasets: parameter files
+
+Substantial timing or memory changes: None
+
+Notes of particular relevance for developers: (including Code reviews and testing)
+---------------------------------------------
+
+Caveats for developers (e.g., code that is duplicated that requires double maintenance):
+   maxpsi_hr is a scalar constant but read in on the parameter file (should change to namelist)
+
+Changes to tests or testing: Removed RTM ESMF test
+
+Code reviewed by: self, ckoven, dlawren
+
+CLM testing: regular
+
+ [PASS means all tests PASS and OK means tests PASS other than expected fails.]
+
+  build-namelist tests:
+
+    yellowstone - OK (70 comparision tests fail, because of the new params files)
+
+  unit-tests (components/clm/src):
+
+    yellowstone - PASS
+
+  regular tests (aux_clm40, aux_clm45):
+
+    yellowstone_intel - OK
+    yellowstone_pgi - OK
+    yellowstone_gnu (clm45 only) - OK
+    hobart_nag - PASS
+
+CLM tag used for the baseline comparisons:  clm4_5_8_r182
+
+
+Answer changes
+--------------
+
+Changes answers relative to baseline: Yes, for CLM4_5/CLM5_0 for BGC and CN cases
+
+  Summarize any changes to answers:
+    - what code configurations: clm4_5 and clm5_0 with BGC or CN
+    - what platforms/compilers: all
+    - nature of change: should be similar climate 
+
+    Charlie Koven did some work with sensitivity analysis to find a good value for maxpsi_hr
+
+Detailed list of changes
+------------------------
+
+List any svn externals directories updated (cime, rtm, mosart, cism, etc.): rtm
+
+    rtm to rtm1_0_57 -- remove ESMF test
+
+List all files eliminated: None
+
+List all files added and what they do: None
+
+List all existing files that have been modified, and describe the changes:
+
+   M components/clm/bld/namelist_files/namelist_defaults_clm4_5.xml -- new params file with maxpsi_hr on them
+
+   M components/clm/src/soilbiogeochem/SoilBiogeochemDecompCascadeBGCMod.F90 - Use maxpsi_hr from params file
+       rather than max soil saturation
+   M components/clm/src/soilbiogeochem/SoilBiogeochemDecompCascadeCNMod.F90 -- Use maxpsi_hr from params file
+       rather than max soil saturation
+
+===============================================================
+===============================================================
 Tag name:  clm4_5_8_r182
 Originator(s):  erik (Erik Kluzek)
 Date: Fri Jun 24 23:33:36 MDT 2016

--- a/components/clm/doc/ChangeSum
+++ b/components/clm/doc/ChangeSum
@@ -1,5 +1,6 @@
 Tag                   Who      Date  Summary
 ============================================================================================================================
+   clm4_5_9_r183     erik 07/02/2016 Decomposition is not water limited after reaching a field capacity parameter (maxpsi_hr) rather than only at soil saturation
    clm4_5_8_r182     erik 06/24/2016 Bring in option for plant hydraulic stress for clm50
    clm4_5_8_r181     erik 06/17/2016 Update cime version which fixes several issues and changes answers
    clm4_5_8_r180    sacks 06/06/2016 Refactor dyn_cnbal_patch

--- a/components/clm/doc/UsersGuide/clm_ug.xml
+++ b/components/clm/doc/UsersGuide/clm_ug.xml
@@ -162,7 +162,7 @@ The purpose of this guide is to instruct both the novice and experienced user, a
 </para>
 </abstract>
 
-<releaseinfo>$URL: https://svn-ccsm-models.cgd.ucar.edu/clm2/trunk_tags/clm4_5_8_r182/components/clm/doc/UsersGuide/clm_ug.xml $</releaseinfo>
+<releaseinfo>$URL: https://svn-ccsm-models.cgd.ucar.edu/clm2/trunk_tags/clm4_5_9_r183/components/clm/doc/UsersGuide/clm_ug.xml $</releaseinfo>
 
 <date>&build_date;</date>
                      

--- a/components/clm/src/soilbiogeochem/SoilBiogeochemDecompCascadeBGCMod.F90
+++ b/components/clm/src/soilbiogeochem/SoilBiogeochemDecompCascadeBGCMod.F90
@@ -71,6 +71,7 @@ module SoilBiogeochemDecompCascadeBGCMod
 
      real(r8) :: k_frag_bgc   !fragmentation rate for CWD
      real(r8) :: minpsi_bgc   !minimum soil water potential for heterotrophic resp
+     real(r8) :: maxpsi_bgc   !maximum soil water potential for heterotrophic resp
      
      integer  :: nsompools = 3
 
@@ -200,6 +201,11 @@ contains
     call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
     if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
     params_inst%minpsi_bgc=tempr 
+
+    tString='maxpsi_hr'
+    call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
+    if ( .not. readv ) call endrun(msg=trim(errCode)//trim(tString)//errMsg(__FILE__, __LINE__))
+    params_inst%maxpsi_bgc=tempr 
 
     tString='cwd_flig'
     call ncd_io(trim(tString),tempr, 'read', ncid, readvar=readv)
@@ -642,7 +648,8 @@ contains
     catanf(t1) = 11.75_r8 +(29.7_r8 / SHR_CONST_PI) * atan( SHR_CONST_PI * 0.031_r8  * ( t1 - 15.4_r8 ))
 
     associate(                                                           &
-         sucsat         => soilstate_inst%sucsat_col                   , & ! Input:  [real(r8) (:,:)   ]  minimum soil suction (mm)                              
+         minpsi         => params_inst%minpsi_bgc                      , & ! Input:  [real(r8)         ]  minimum soil suction (mm)
+         maxpsi         => params_inst%maxpsi_bgc                      , & ! Input:  [real(r8)         ]  maximum soil suction (mm)
          soilpsi        => soilstate_inst%soilpsi_col                  , & ! Input:  [real(r8) (:,:)   ]  soil water potential in each soil layer (MPa)          
 
          alt_indx       => canopystate_inst%alt_indx_col               , & ! Input:  [integer  (:)     ]  current depth of thaw                                     
@@ -853,7 +860,6 @@ contains
             do fc = 1,num_soilc
                c = filter_soilc(fc)
                if (j==1) w_scalar(c,:) = 0._r8
-               maxpsi = sucsat(c,j) * (-9.8e-6_r8)
                psi = min(soilpsi(c,j),maxpsi)
                ! decomp only if soilpsi is higher than minpsi
                if (psi > minpsi) then
@@ -948,7 +954,6 @@ contains
          do j = 1,nlevdecomp
             do fc = 1,num_soilc
                c = filter_soilc(fc)
-               maxpsi = sucsat(c,j) * (-9.8e-6_r8)
                psi = min(soilpsi(c,j),maxpsi)
                ! decomp only if soilpsi is higher than minpsi
                if (psi > minpsi) then

--- a/components/clm/src_clm40/main/findHistFields.pl
+++ b/components/clm/src_clm40/main/findHistFields.pl
@@ -180,7 +180,7 @@ sub XML_Header {
   my $filename    = shift;
 
   print STDERR " Write out header to history fields file to: $outfilename\n";
-  my $svnurl = '$URL: https://svn-ccsm-models.cgd.ucar.edu/clm2/trunk_tags/clm4_5_8_r182/components/clm/src_clm40/main/findHistFields.pl $';
+  my $svnurl = '$URL: https://svn-ccsm-models.cgd.ucar.edu/clm2/trunk_tags/clm4_5_9_r183/components/clm/src_clm40/main/findHistFields.pl $';
   my $svnid  = '$Id: findHistFields.pl 69899 2015-04-10 20:45:24Z erik $';
   print $outfh <<"EOF";
 <?xml version="1.0"?>

--- a/components/clm/tools/clm4_0/interpinic/src/interpinic.F90
+++ b/components/clm/tools/clm4_0/interpinic/src/interpinic.F90
@@ -1389,7 +1389,7 @@ contains
     character(len= 5) :: zone
     character(len=18) :: datetime
     character(len=256):: version = &
-         "$HeadURL: https://svn-ccsm-models.cgd.ucar.edu/clm2/trunk_tags/clm4_5_8_r182/components/clm/tools/clm4_0/interpinic/src/interpinic.F90 $"
+         "$HeadURL: https://svn-ccsm-models.cgd.ucar.edu/clm2/trunk_tags/clm4_5_9_r183/components/clm/tools/clm4_0/interpinic/src/interpinic.F90 $"
     character(len=256)  :: revision_id = "$Id: interpinic.F90 55582 2013-11-23 21:15:59Z erik $"
     character(len=16)   :: logname
     character(len=16)   :: hostname

--- a/components/clm/tools/clm4_0/mksurfdata_map/src/mkfileMod.F90
+++ b/components/clm/tools/clm4_0/mksurfdata_map/src/mkfileMod.F90
@@ -93,7 +93,7 @@ contains
          'Source', len_trim(str), trim(str)), subname)
 
     str = &
-'$HeadURL: https://svn-ccsm-models.cgd.ucar.edu/clm2/trunk_tags/clm4_5_8_r182/components/clm/tools/clm4_0/mksurfdata_map/src/mkfileMod.F90 $'
+'$HeadURL: https://svn-ccsm-models.cgd.ucar.edu/clm2/trunk_tags/clm4_5_9_r183/components/clm/tools/clm4_0/mksurfdata_map/src/mkfileMod.F90 $'
     call check_ret(nf_put_att_text (ncid, NF_GLOBAL, &
          'Version', len_trim(str), trim(str)), subname)
 

--- a/components/clm/tools/clm4_5/mksurfdata_map/src/mkfileMod.F90
+++ b/components/clm/tools/clm4_5/mksurfdata_map/src/mkfileMod.F90
@@ -92,7 +92,7 @@ contains
          'Source', len_trim(str), trim(str)), subname)
 
     str = &
-'$HeadURL: https://svn-ccsm-models.cgd.ucar.edu/clm2/trunk_tags/clm4_5_8_r182/components/clm/tools/clm4_5/mksurfdata_map/src/mkfileMod.F90 $'
+'$HeadURL: https://svn-ccsm-models.cgd.ucar.edu/clm2/trunk_tags/clm4_5_9_r183/components/clm/tools/clm4_5/mksurfdata_map/src/mkfileMod.F90 $'
     call check_ret(nf_put_att_text (ncid, NF_GLOBAL, &
          'Version', len_trim(str), trim(str)), subname)
 

--- a/components/clm/tools/shared/mkmapdata/rmdups.ncl
+++ b/components/clm/tools/shared/mkmapdata/rmdups.ncl
@@ -118,7 +118,7 @@ begin
     nco@history = nco@history + " Removed duplicate weights from mapping file with: rmdups.ncl "
     nco@rmdups_Logname       = logname;
     nco@rmdups_mod_date      = ldate;
-    nco@rmdups_version       = "$HeadURL: https://svn-ccsm-models.cgd.ucar.edu/clm2/trunk_tags/clm4_5_8_r182/components/clm/tools/shared/mkmapdata/rmdups.ncl $";
+    nco@rmdups_version       = "$HeadURL: https://svn-ccsm-models.cgd.ucar.edu/clm2/trunk_tags/clm4_5_9_r183/components/clm/tools/shared/mkmapdata/rmdups.ncl $";
     nco@rmdups_revision_id   = "$Id: rmdups.ncl 47629 2013-05-31 08:59:50Z erik $";
 
     print("Successfully removed duplicate weights from mapping file" );

--- a/components/clm/tools/shared/mkmapgrids/mkscripgrid.ncl
+++ b/components/clm/tools/shared/mkmapgrids/mkscripgrid.ncl
@@ -158,7 +158,7 @@ end
   nc = addfile( outfilename, "w" );
   nc@history = ldate+": create using mkscripgrid.ncl";
   nc@comment = "Ocean is assumed to non-existant at this point";
-  nc@Version = "$HeadURL: https://svn-ccsm-models.cgd.ucar.edu/clm2/trunk_tags/clm4_5_8_r182/components/clm/tools/shared/mkmapgrids/mkscripgrid.ncl $";
+  nc@Version = "$HeadURL: https://svn-ccsm-models.cgd.ucar.edu/clm2/trunk_tags/clm4_5_9_r183/components/clm/tools/shared/mkmapgrids/mkscripgrid.ncl $";
   nc@Revision = "$Id: mkscripgrid.ncl 72547 2015-08-25 16:28:29Z erik $";
   if ( printn )then
     print( "================================================================================================" );

--- a/components/clm/tools/shared/ncl_scripts/getco2_historical.ncl
+++ b/components/clm/tools/shared/ncl_scripts/getco2_historical.ncl
@@ -109,7 +109,7 @@ begin
    fileattdef ( nco, ncg );
    nco@history  = ldate+": Convert by getco2_historical.ncl";
    nco@source   = "Convert from:"+ghgfile;
-   nco@Version  = "$HeadURL: https://svn-ccsm-models.cgd.ucar.edu/clm2/trunk_tags/clm4_5_8_r182/components/clm/tools/shared/ncl_scripts/getco2_historical.ncl $";
+   nco@Version  = "$HeadURL: https://svn-ccsm-models.cgd.ucar.edu/clm2/trunk_tags/clm4_5_9_r183/components/clm/tools/shared/ncl_scripts/getco2_historical.ncl $";
    nco@Revision = "$Id: getco2_historical.ncl 69995 2015-04-14 20:26:21Z erik $";
    ;
    ; Set static variables

--- a/components/rtm/cime_config/testdefs/testlist_rtm.xml
+++ b/components/rtm/cime_config/testdefs/testlist_rtm.xml
@@ -35,10 +35,6 @@
       </test>
     </grid>
     <grid name="f19_g16">
-      <test name="ERP_D_E_Ld5">
-        <machine compiler="intel" testtype="aux_clm_ys_intel" testmods="rtm/rtmOnIceOff">edison</machine>
-        <machine compiler="intel" testtype="aux_clm45" testmods="rtm/rtmOnIceOff">yellowstone</machine>
-      </test>
       <test name="ERP_Ld5">
         <machine compiler="intel" testtype="aux_clm_ys_pgi" testmods="rtm/rtmOnFloodOnEffvelOff">edison</machine>
         <machine compiler="intel" testtype="aux_clm_ys_pgi" testmods="rtm/rtmOnIceOn">edison</machine>

--- a/components/rtm/doc/ChangeLog
+++ b/components/rtm/doc/ChangeLog
@@ -1,4 +1,12 @@
 ===============================================================
+Tag name:  rtm1_0_57
+Originator(s): erik
+Date: Jul 01, 2016
+One-line Summary: Remove ESMF test
+
+M       cime_config/testdefs/testlist_rtm.xml
+
+===============================================================
 Tag name:  rtm1_0_56
 Originator(s): erik
 Date: Apr 14, 2016


### PR DESCRIPTION
Merge clm4_5_9_r183, commit '8f127bc3', into andre-ed-clm-16x

User interface changes: requires updated parameters file.

Test suite:
    ed - yellowstone gnu, intel, pgi
        baseline - none
    clm_short_{45|50} - yellowstone gnu, intel, pgi
        baseline - clm4_5_9_r183

Test status: all tests pass

RGK:

Test suite:
     ed - lawrencium-lr3, intel
        baseline - none
    clm_short_{45|50} - lawrencium-lr3, intel
        baseline - none
