### PR TITLE
bugfix - updated cohort siteptr during patch fusion

### DIFF
--- a/components/clm/src/ED/biogeochem/EDPatchDynamicsMod.F90
+++ b/components/clm/src/ED/biogeochem/EDPatchDynamicsMod.F90
@@ -1255,6 +1255,8 @@ contains
           rp%shortest => storesmallcohort    
 
           currentCohort%patchptr => rp
+          currentCohort%siteptr  => rp%siteptr
+
           currentCohort => nextc
 
           dp%shortest => currentCohort


### PR DESCRIPTION
This is a bugfix that updates the cohort's site pointer while is undergoing patch fusion.  Specifically, the cohort may be transferred to a new patch, and while its old patch was used to point to its site, but that old patch is gone.

Fixes: #111 

User interface changes?: no
Test suite: edTest
Test baseline: 8e8ebca
Test namelist changes: none
Test answer changes: none in tests, potential changes in long runs
Test summary: all PASS
