### PR TITLE
Bugfix: initializing patch level seed variables during patch creation

### DIFF
--- a/components/clm/src/ED/biogeochem/EDPatchDynamicsMod.F90
+++ b/components/clm/src/ED/biogeochem/EDPatchDynamicsMod.F90
@@ -982,6 +982,10 @@ contains
 
     currentPatch%canopy_layer_lai(:)        = 0.0_r8
 
+    currentPatch%seeds_in(:)                = 0.0_r8
+    currentPatch%seed_decay(:)              = 0.0_r8
+    currentPatch%seed_germination(:)        = 0.0_r8
+
     currentPatch%fab(:)                     = 0.0_r8
     currentPatch%sabs_dir(:)                = 0.0_r8
     currentPatch%sabs_dif(:)                = 0.0_r8


### PR DESCRIPTION
This is a fix to #122.  The fix is a small change-set.  Some patch level seed variables were inadvertently removed from being zero'd.  This re-instates their zero'ing.  

Fixes: #122 

User interface changes?: no
Code review: @ckoven (identified solution), self

Test suite: lawrencium-lr3 intel edTest,  yellowstone-gnu edTest (regressed against a6fec29)
Test baseline: a6fec29
Test namelist changes: none
Test answer changes: b4b

Test summary: all PASS
