### PR TITLE
fix to logic in restarting when using a prior case's restart

### DIFF
--- a/components/clm/src/main/clm_initializeMod.F90
+++ b/components/clm/src/main/clm_initializeMod.F90
@@ -647,7 +647,7 @@ contains
     ! Initialise the ED model state structure
     ! --------------------------------------------------------------
    
-    if ( use_ed .and. .not.is_restart() ) then
+    if ( use_ed .and. .not.is_restart() .and. finidat == ' ') then
 
        call clm_fates%init_coldstart(waterstate_inst,canopystate_inst)
        


### PR DESCRIPTION
fix to properly restart when using finidat from a prior case

Fixes: [NGT-ED Github issue #165 ]

User interface changes?: [No]

Code review: [just me so far, @rgknox -- could you double check that this makes sense to you too?]

Test suite: ED test suite on lawrencium-lr3
Test baseline: don't have any recent baselines, so didn't run; I can't imagine this would be an issue but please double-check when testing on Yellowstone
Test namelist changes: none
Test answer changes: ought to be b4b

Test summary: all smoke, restart, etc tests pass
