### PR TITLE
Fix litter_in and litter_out units/definitions

### DIFF
--- a/components/clm/src/ED/main/FatesHistoryInterfaceMod.F90
+++ b/components/clm/src/ED/main/FatesHistoryInterfaceMod.F90
@@ -1545,11 +1545,11 @@ contains
             ! put litter_in flux onto site level variable so as to be able to append site-level distubance-related input flux after patch loop
             hio_litter_in_si(io_si) = hio_litter_in_si(io_si) + &
                  (sum(cpatch%CWD_AG_in) +sum(cpatch%leaf_litter_in) + sum(cpatch%root_litter_in)) &
-                 * 1.e3_r8 * cpatch%area * AREA_INV * years_per_day * days_per_sec
+                 * g_per_kg * cpatch%area * AREA_INV * years_per_day * days_per_sec
             ! keep litter_out at patch level
             hio_litter_out_pa(io_pa)           = (sum(cpatch%CWD_AG_out)+sum(cpatch%leaf_litter_out) &
                  + sum(cpatch%root_litter_out)) &
-                 * 1.e3_r8 * patch_scaling_scalar * years_per_day * days_per_sec
+                 * g_per_kg * patch_scaling_scalar * years_per_day * days_per_sec
             
             hio_seeds_in_pa(io_pa)             = sum(cpatch%seeds_in) * &
                  g_per_kg * patch_scaling_scalar * years_per_day * days_per_sec


### PR DESCRIPTION
fixed a pre-existing unit error in litter_out and and unit/definition error in litter_in.  these are separate from the changes in #193 because they lead to answer changes to those fields, which are in the regression test.

pull in only after #193 has been merged as the changes are on top of those.

Fixes: [NGT-ED Github issue #] None

User interface changes?: No

Code review: Just me so far

Test suite: lawrencium ed tests
Test baseline: a5dc8da
Test namelist changes: n/a
Test answer changes: changes for those fields

Test summary: [Remove 'PASS' fields]

[cdkoven@n0001 ed.lawrencium-lr3.intel.856e9ce]$ ./cimeteststatus | grep -e FAIL -e PEND -e RUN
FAIL SMS_Ld5.f10_f10.ICLM45ED.lawrencium-lr3_intel.clm-edTest.clm2.h0.nc : baseline compare clm2.h0 (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL SMS_Ld5.f10_f10.ICLM45ED.lawrencium-lr3_intel.clm-edTest : baseline compare summary (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL SMS_D_Mmpi-serial_Ld5.5x5_amazon.ICLM45ED.lawrencium-lr3_intel.clm-edTest.clm2.h0.nc : baseline compare clm2.h0 (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL SMS_D_Mmpi-serial_Ld5.5x5_amazon.ICLM45ED.lawrencium-lr3_intel.clm-edTest : baseline compare summary (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL SMS_D_Lm6.f45_f45.ICLM45ED.lawrencium-lr3_intel.clm-edTest.clm2.h0.nc : baseline compare clm2.h0 (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL SMS_D_Lm6.f45_f45.ICLM45ED.lawrencium-lr3_intel.clm-edTest : baseline compare summary (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL ERS_D_Ld5.f10_f10.ICLM45ED.lawrencium-lr3_intel.clm-edFire.clm2.h0.nc : baseline compare clm2.h0 (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL ERS_D_Ld5.f10_f10.ICLM45ED.lawrencium-lr3_intel.clm-edFire : baseline compare summary (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL ERS_D_Ld5.f09_g16.ICLM45ED.lawrencium-lr3_intel.clm-edTest.clm2.h0.nc : baseline compare clm2.h0 (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL ERS_D_Ld5.f09_g16.ICLM45ED.lawrencium-lr3_intel.clm-edTest : baseline compare summary (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL ERS_D_Mmpi-serial_Ld5.1x1_brazil.ICLM45ED.lawrencium-lr3_intel.clm-edTest.clm2.h0.nc : baseline compare clm2.h0 (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL ERS_D_Mmpi-serial_Ld5.1x1_brazil.ICLM45ED.lawrencium-lr3_intel.clm-edTest : baseline compare summary (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL SMS_Ld5.f19_g16.ICLM45ED.lawrencium-lr3_intel.clm-edTest.clm2.h0.nc : baseline compare clm2.h0 (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL SMS_Ld5.f19_g16.ICLM45ED.lawrencium-lr3_intel.clm-edTest : baseline compare summary (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL ERS_D_Ld5.f45_g37.ICLM45ED.lawrencium-lr3_intel.clm-edTest.clm2.h0.nc : baseline compare clm2.h0 (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL ERS_D_Ld5.f45_g37.ICLM45ED.lawrencium-lr3_intel.clm-edTest : baseline compare summary (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL SMS_D_Ld5.f45_f45.ICLM45ED.lawrencium-lr3_intel.clm-edTest.clm2.h0.nc : baseline compare clm2.h0 (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL SMS_D_Ld5.f45_f45.ICLM45ED.lawrencium-lr3_intel.clm-edTest : baseline compare summary (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL ERS_D_Ld5.f19_g16.ICLM45ED.lawrencium-lr3_intel.clm-edTest.clm2.h0.nc : baseline compare clm2.h0 (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL ERS_D_Ld5.f19_g16.ICLM45ED.lawrencium-lr3_intel.clm-edTest : baseline compare summary (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL SMS_D_Ld5.f10_f10.ICLM45ED.lawrencium-lr3_intel.clm-edTest.clm2.h0.nc : baseline compare clm2.h0 (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL SMS_D_Ld5.f10_f10.ICLM45ED.lawrencium-lr3_intel.clm-edTest : baseline compare summary (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL ERS_D_Ld5.5x5_amazon.ICLM45ED.lawrencium-lr3_intel.clm-edTest.clm2.h0.nc : baseline compare clm2.h0 (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL ERS_D_Ld5.5x5_amazon.ICLM45ED.lawrencium-lr3_intel.clm-edTest : baseline compare summary (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL ERS_D_Ld5.f10_f10.ICLM45ED.lawrencium-lr3_intel.clm-edTest.clm2.h0.nc : baseline compare clm2.h0 (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 
FAIL ERS_D_Ld5.f10_f10.ICLM45ED.lawrencium-lr3_intel.clm-edTest : baseline compare summary (baseline: compare .base file with ed.lawrencium-lr3.intel.a5dc8da file) 

