### PR TITLE
Spitfire updates to params and fuel moisture calc

### DIFF
--- a/components/clm/src/ED/main/EDTypesMod.F90
+++ b/components/clm/src/ED/main/EDTypesMod.F90
@@ -54,8 +54,9 @@ module EDTypesMod
   integer , parameter :: NFSC                 = NCWD+2     ! number fuel size classes  (really this is a mix of cwd size classes, leaf litter, and grass types)
   integer,  parameter :: lg_sf                = 6          ! array index of live grass pool for spitfire
   integer,  parameter :: dl_sf                = 1          ! array index of dead leaf pool for spitfire (dead grass and dead leaves)
+  integer,  parameter :: tw_sf                = 2          ! array index of twig pool for spitfire
   integer,  parameter :: tr_sf                = 5          ! array index of dead trunk pool for spitfire
-  integer,  parameter :: lb_sf                = 4          ! array index of lrge branch pool for spitfire 
+  integer,  parameter :: lb_sf                = 4          ! array index of large branch pool for spitfire 
   real(r8), parameter :: fire_threshold       = 35.0_r8    ! threshold for fires that spread or go out. KWm-2
 
   ! COHORT FUSION          


### PR DESCRIPTION
Development to correct equations to literature and code clarity.
1.Litter moisture of trunk corrected from zero to calculated value
of fuel_moisture/MEF. Confirmed ROS and intensity calcualtions
do not use trunk, but calculated trunk litter moisture needed for
fuel_consumption routine
2.Remove 0.45 multipliers on fuel_bulkd. Needs to be in
kgBiomass/m2. No need to convert to carbon and convert back to biomass.
3.fuel_moisture corrected to (dg_sf:lb_sf) for fuel classes
1,2,3,4 per Thonicke et al 2010.
4.Add twig parameter tw_sf=2 (fuel class 2) and update instances
of (dl_sf+1) to new twig parameter (tw_sf) where appropraite

Fixes:
User interface changes?: No
Code review: JKShuman
Test suite: SMS_D_Ld5.f10_f10.ICLM45ED.yellowstone_intel.clm-edTest
Test baseline:ed-clm-8f2c36e
Test namelist changes:no
Test answer changes: bit for bit
Test summary: PASS

Test suite: ERS_D_Ld5.f10_f10.ICLM45ED.yellowstone_intel.clm-edFire
Test baseline:ed-clm-8f2c36e
Test namelist changes:no
Test answer changes: bit for bit
Test summary: PASS for functionality,
              FAIL: not bit for bit with ed-clm-8f2c36e as expected

[ 50 character, one line summary ]

[ Description of the changes in this commit. It should be enough
  information for someone not following this development to understand. 
  Lines should be wrapped at about 72 characters. ]

Fixes: [NGT-ED Github issue #]

User interface changes?: [Yes (describe what changes), No]

Code review: [Names]

Test suite: [suite name, machine, compilers]
Test baseline: [changeset id]
Test namelist changes:
Test answer changes: [bit for bit, roundoff, climate changing]

Test summary: [Remove 'PASS' fields]
