### PR TITLE
fix dimension multiplexing on SCAG (size-class x age) dimension

### DIFF
--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -703,7 +703,7 @@ contains
 
      age_class         = get_age_class_index(age)
      
-     size_by_age_class = (age_class-1)*nlevage_ed + size_class
+     size_by_age_class = (age_class-1)*nlevsclass_ed + size_class
 
   end function get_sizeage_class_index
 


### PR DESCRIPTION
One-line fix to cohort-level size x age indexing for history variables on that dimension.  Since there are no default variables that are turned on on that dimension, there shouldn't be any detectable changes in a default run.  

But also I want to issue a PR as a test for how that work flows in the new split-repo infrastructure.

Fixes: #210 

Code review: just me so far.

Test Suite: ed-clm
Test Baseline: fates-clm: https://github.com/NGEET/fates-clm/commit/bc14fc28294ad029feb39f64c595e39266948d35, fates: 601eb87
Test run with fates-clm tag: https://github.com/NGEET/fates-clm/commit/bc14fc28294ad029feb39f64c595e39266948d35
Expected results: b4b
Test status:  The baseline test failure below is because the baseline had failed to generate a baseline.  Not sure what's going on with the TPUTCOMP fails. Otherwise all pass.

```
[cdkoven@n0000 ed.lbl-lr2.intel.bc14fc2_bfc5c8d]$ ./cs.status.1704241517 | grep -e FAIL        
  FAIL ERS_D_Ld5.f09_g16.ICLM45ED.lbl-lr2_intel.clm-edTest TPUTCOMP Error: Computation time increase > 25% from baseline
  FAIL SMS_D_Lm6.f45_f45.ICLM45ED.lbl-lr2_intel.clm-edTest BASELINE
  FAIL SMS_Ld5.f19_g16.ICLM45ED.lbl-lr2_intel.clm-edTest TPUTCOMP Error: Computation time increase > 25% from baseline
```