### PR TITLE
bugfixes: canopy layer indexing, fusion, size indexing

### DIFF
--- a/biogeochem/EDGrowthFunctionsMod.F90
+++ b/biogeochem/EDGrowthFunctionsMod.F90
@@ -256,11 +256,11 @@ contains
     ! that are outside the number of alloted canopy spaces.  Ie, a two story canopy
     ! may have a third-story plant, if only for a moment.  However, these plants
     ! still need to generate a crown area to complete the promotion, demotion process.
-    ! So we allow layer index exceedence here and force it down to max and force it up
-    ! to 1 (rgk/cdk 05/2017)
+    ! So we allow layer index exceedence here and force it down to max.
+    ! (rgk/cdk 05/2017)
     ! ----------------------------------------------------------------------------------
 
-    can_layer_index = max(min(cohort_in%canopy_layer,nclmax),1)
+    can_layer_index = min(cohort_in%canopy_layer,nclmax)
 
     if(EDPftvarcon_inst%woody(cohort_in%pft) == 1)then 
        c_area = 3.142_r8 * cohort_in%n * &


### PR DESCRIPTION
This change group is a set of bug fixes.  There were roughly four bugs. 1) very small cohort number density counts were used in fusion prior to termination. The "safe math" part of termination was split from the rest of the cohort termination sequence and placed before fusion calls. 2) fusion was enabled for newly recruited cohorts, which prevents infinite loops in fusion, 3) canopy layer indices were forced to the range of 1-nclmax during the call to crown area calculations as those calculations are done within the loop that constrains cohort canopy layer to within the maximum range, and 4) cohort size class and size-pft class were added to the cohort copy procedure (thus preventing some un-initialized use cases).

Addresses issues: #222, #223, #149 

User interface changes: no
Code review: @ckoven contributed to 4). Also used @ckoven 's code for graceful exits when fusion can't be achieved, discussion with various parties in issues listed above
Test suite: lawrencium lr3, intel: edTest, clm_short_45, clm_short_50, 30+ year completion tests on 1x1 brazil
CLM test hash: eee5459
CLM base hash: eee5459
Fates test hash: defc5bb

Test namelist changes: none
Test answer changes: none, B4B   (Note that it is possible that small changes could had been generated due to the safe-math portion of termination being called prior to fusion, however cases for this type of termination must not had ocured in the regression tests)
Test summary: all PASS
