### PR TITLE
Bug fixes: fusion loops, termination and layer indices

### DIFF
--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -383,10 +383,15 @@ contains
           enddo
           currentPatch%ncl_p = min(z,nclmax)
 
-       enddo !is there still excess area in any layer?      
+       enddo !is there still excess area in any layer?
+
+       ! Remove cohorts that are incredibly sparse
+       call terminate_cohorts(currentSite, currentPatch, 1)
 
        call fuse_cohorts(currentPatch, bc_in)
-       call terminate_cohorts(currentSite, currentPatch)
+
+       ! Remove cohorts for various other reasons
+       call terminate_cohorts(currentSite, currentPatch, 2)
 
        ! ----------- Check cohort area ------------------------------!
        do i = 1,z
@@ -605,8 +610,13 @@ contains
           endif
        enddo !is there still not enough canopy area in any layer?         
 
+       ! remove cohorts that are extremely sparse
+       call terminate_cohorts(currentSite, currentPatch, 1)
+
        call fuse_cohorts(currentPatch, bc_in)
-       call terminate_cohorts(currentSite, currentPatch)
+
+       ! remove cohorts for various other reasons
+       call terminate_cohorts(currentSite, currentPatch, 2)
 
        if(promswitch == 1)then
           !write(fates_log(),*) 'going into cohort check'

--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -117,7 +117,6 @@ contains
     call sizetype_class_index(new_cohort%dbh,new_cohort%pft, &
                               new_cohort%size_class,new_cohort%size_by_pft_class)
 
-    if ( DEBUG ) write(fates_log(),*) 'EDCohortDyn I ',bstore
 
     ! This routine may be called during restarts, and at this point in the call sequence
     ! the actual cohort data is unknown, as this is really only used for allocation
@@ -476,7 +475,7 @@ contains
     currentcohort%resp_acc_hold      = 0._r8
     currentcohort%carbon_balance     = 0._r8
     currentcohort%leaf_litter        = 0._r8
-    currentcohort%year_net_uptake(:) = 999 ! this needs to be 999, or trimming of new cohorts will break. 
+    currentcohort%year_net_uptake(:) = 999._r8 ! this needs to be 999, or trimming of new cohorts will break. 
     currentcohort%ts_net_uptake(:)   = 0._r8
     currentcohort%seed_prod          = 0._r8
     currentcohort%cfa                = 0._r8 
@@ -500,7 +499,7 @@ contains
   end subroutine zero_cohort
 
   !-------------------------------------------------------------------------------------!
-  subroutine terminate_cohorts( currentSite, patchptr )
+  subroutine terminate_cohorts( currentSite, patchptr, level )
     !
     ! !DESCRIPTION:
     ! terminates cohorts when they get too small      
@@ -512,6 +511,16 @@ contains
     ! !ARGUMENTS    
     type (ed_site_type) , intent(inout), target :: currentSite
     type (ed_patch_type), intent(inout), target :: patchptr
+    integer             , intent(in)            :: level
+
+    ! Important point regarding termination levels.  Termination is typically
+    ! called after fusion.  We do this so that we can re-capture the biomass that would
+    ! otherwise be lost from termination.  The biomass of a fused plant remains in the
+    ! live pool.  However, some plant number densities can be so low that they 
+    ! can cause numerical instabilities.  Thus, we call terminate_cohorts at level=1
+    ! before fusion to get rid of these cohorts that are so incredibly sparse, and then
+    ! terminate the remainder at level 2 for various other reasons.
+
     !
     ! !LOCAL VARIABLES:
     type (ed_patch_type)  , pointer :: currentPatch
@@ -529,16 +538,16 @@ contains
        nextc      => currentCohort%shorter    
        terminate = 0 
 
-       ! Check if number density is so low is breaks math
-       if (currentcohort%n <  min_n_safemath) then
+       ! Check if number density is so low is breaks math (level 1)
+       if (currentcohort%n <  min_n_safemath .and. level == 1) then
          terminate = 1
 	 if ( DEBUG ) then
              write(fates_log(),*) 'terminating cohorts 0',currentCohort%n/currentPatch%area,currentCohort%dbh
          endif
        endif
 
-       ! The rest of these are only allowed if we are not dealing with a recruit
-       if (.not.currentCohort%isnew) then
+       ! The rest of these are only allowed if we are not dealing with a recruit (level 2)
+       if (.not.currentCohort%isnew .and. level == 2) then
 
          ! Not enough n or dbh
          if  (currentCohort%n/currentPatch%area <= min_npm2 .or.	&  !
@@ -577,10 +586,10 @@ contains
                            currentCohort%bstore, currentCohort%n
             endif
 
-         endif
-       endif
+         endif 
+      endif    !  if (.not.currentCohort%isnew .and. level == 2) then
 
-       if (terminate == 1) then 
+      if (terminate == 1) then 
           ! preserve a record of the to-be-terminated cohort for mortality accounting
           if (currentCohort%canopy_layer .eq. 1) then
              levcan = 1
@@ -649,244 +658,297 @@ contains
 
   !-------------------------------------------------------------------------------------!
   subroutine fuse_cohorts(patchptr, bc_in)  
-    !
-    ! !DESCRIPTION:
-    ! Join similar cohorts to reduce total number            
-    !
-    ! !USES:
-    use EDTypesMod  , only :  nlevleaf
-    use EDParamsMod , only :  ED_val_cohort_fusion_tol
-    !
-    ! !ARGUMENTS    
-    type (ed_patch_type), intent(inout), target :: patchptr
-    type (bc_in_type), intent(in)               :: bc_in
-    !
-    ! !LOCAL VARIABLES:
-    type (ed_patch_type)  , pointer :: currentPatch
-    type (ed_cohort_type) , pointer :: currentCohort, nextc, nextnextc
-    integer  :: i  
-    integer  :: fusion_took_place
-    integer  :: maxcohorts !maximum total no of cohorts. Needs to be >numpft_edx2 
-    integer  :: iterate    !do we need to keep fusing to get below maxcohorts?
-    integer  :: nocohorts
-    real(r8) :: newn
-    real(r8) :: diff
-    real(r8) :: dynamic_fusion_tolerance
-    !----------------------------------------------------------------------
-    
-    !set initial fusion tolerance
-    dynamic_fusion_tolerance = ED_val_cohort_fusion_tol
-   
-    !This needs to be a function of the canopy layer, because otherwise, at canopy closure
-    !the number of cohorts doubles and very dissimilar cohorts are fused together
-    !because c_area and biomass are non-linear with dbh, this causes several mass inconsistancies
-    !in theory, all of this routine therefore causes minor losses of C and area, but these are below 
-    !detection limit normally. 
-    iterate = 1
-    fusion_took_place = 0   
-    currentPatch => patchptr
-    maxcohorts = maxCohortsPerPatch
-  
-    !---------------------------------------------------------------------!
-    !  Keep doing this until nocohorts <= maxcohorts                         !
-    !---------------------------------------------------------------------!
-    if (associated(currentPatch%shortest)) then  
-       do while(iterate == 1)
+     !
+     ! !DESCRIPTION:
+     ! Join similar cohorts to reduce total number            
+     !
+     ! !USES:
+     use EDTypesMod  , only :  nlevleaf
+     use EDParamsMod , only :  ED_val_cohort_fusion_tol
+     use shr_infnan_mod, only : nan => shr_infnan_nan, assignment(=)
+     !
+     ! !ARGUMENTS    
+     type (ed_patch_type), intent(inout), target :: patchptr
+     type (bc_in_type), intent(in)               :: bc_in
+     !
+     ! !LOCAL VARIABLES:
+     type (ed_patch_type)  , pointer :: currentPatch
+     type (ed_cohort_type) , pointer :: currentCohort, nextc, nextnextc
+     integer  :: i  
+     integer  :: fusion_took_place
+     integer  :: maxcohorts !maximum total no of cohorts. Needs to be >numpft_edx2 
+     integer  :: iterate    !do we need to keep fusing to get below maxcohorts?
+     integer  :: nocohorts
+     real(r8) :: newn
+     real(r8) :: diff
+     real(r8) :: dynamic_fusion_tolerance
 
-         currentCohort => currentPatch%tallest
+     logical, parameter :: FUSE_DEBUG = .false.   ! This debug is over-verbose
+                                                 ! and gets its own flag
 
-         ! The following logic continues the loop while the current cohort is not the shortest cohort
-         ! if they point to the same target (ie equivalence), then the loop ends.
-         ! This loop is different than the simple "continue while associated" loop in that
-         ! it omits the last cohort (because it has already been compared by that point)
+     !----------------------------------------------------------------------
 
-         do while ( .not.associated(currentCohort,currentPatch%shortest) )
+     !set initial fusion tolerance
+     dynamic_fusion_tolerance = ED_val_cohort_fusion_tol
 
-          nextc => currentPatch%tallest
+     !This needs to be a function of the canopy layer, because otherwise, at canopy closure
+     !the number of cohorts doubles and very dissimilar cohorts are fused together
+     !because c_area and biomass are non-linear with dbh, this causes several mass inconsistancies
+     !in theory, all of this routine therefore causes minor losses of C and area, but these are below 
+     !detection limit normally. 
+     iterate = 1
+     fusion_took_place = 0   
+     currentPatch => patchptr
+     maxcohorts = maxCohortsPerPatch
 
-          do while (associated(nextc))
-             nextnextc => nextc%shorter                      
-             diff = abs((currentCohort%dbh - nextc%dbh)/(0.5*(currentCohort%dbh + nextc%dbh)))  
+     !---------------------------------------------------------------------!
+     !  Keep doing this until nocohorts <= maxcohorts                         !
+     !---------------------------------------------------------------------!
 
-             !Criteria used to divide up the height continuum into different cohorts.
+     if (associated(currentPatch%shortest)) then  
+        do while(iterate == 1)
 
-             if (diff < dynamic_fusion_tolerance) then
+           currentCohort => currentPatch%tallest
 
-                ! Don't fuse a cohort with itself!
-                if (.not.associated(currentCohort,nextc) ) then
+           ! The following logic continues the loop while the current cohort is not the shortest cohort
+           ! if they point to the same target (ie equivalence), then the loop ends.
+           ! This loop is different than the simple "continue while associated" loop in that
+           ! it omits the last cohort (because it has already been compared by that point)
 
-                   if (currentCohort%pft == nextc%pft) then              
+           do while ( .not.associated(currentCohort,currentPatch%shortest) )
 
-                      ! check cohorts in same c. layer. before fusing
+              nextc => currentPatch%tallest
 
-                      if (currentCohort%canopy_layer == nextc%canopy_layer) then 
+              do while (associated(nextc))
+                 nextnextc => nextc%shorter                      
+                 diff = abs((currentCohort%dbh - nextc%dbh)/(0.5*(currentCohort%dbh + nextc%dbh)))  
 
-		      	 ! Note: because newly recruited cohorts that have not experienced
-			 ! a day yet will have un-known flux quantities or change rates
-			 ! we don't want them fusing with non-new cohorts.  We allow them
-			 ! to fuse with other new cohorts to keep the total number of cohorts
-			 ! down.
+                 !Criteria used to divide up the height continuum into different cohorts.
 
-                         if( .not.(currentCohort%isnew) .and. .not.(nextc%isnew) ) then
+                 if (diff < dynamic_fusion_tolerance) then
 
-                         newn = currentCohort%n + nextc%n
-                         fusion_took_place = 1         
-                             
+                    ! Don't fuse a cohort with itself!
+                    if (.not.associated(currentCohort,nextc) ) then
 
-                         currentCohort%balive    = (currentCohort%n*currentCohort%balive    + nextc%n*nextc%balive)/newn
-                         currentCohort%bdead     = (currentCohort%n*currentCohort%bdead     + nextc%n*nextc%bdead)/newn
+                       if (currentCohort%pft == nextc%pft) then              
 
-                         if ( DEBUG ) write(fates_log(),*) 'EDcohortDyn I ',currentCohort%bstore
+                          ! check cohorts in same c. layer. before fusing
 
-                         currentCohort%bstore    = (currentCohort%n*currentCohort%bstore    + nextc%n*nextc%bstore)/newn   
+                          if (currentCohort%canopy_layer == nextc%canopy_layer) then 
 
-                         if ( DEBUG ) write(fates_log(),*) 'EDcohortDyn II ',currentCohort%bstore
+                             ! Note: because newly recruited cohorts that have not experienced
+                             ! a day yet will have un-known flux quantities or change rates
+                             ! we don't want them fusing with non-new cohorts.  We allow them
+                             ! to fuse with other new cohorts to keep the total number of cohorts
+                             ! down.
 
-                         currentCohort%seed_prod = (currentCohort%n*currentCohort%seed_prod + nextc%n*nextc%seed_prod)/newn  
-                         currentCohort%root_md   = (currentCohort%n*currentCohort%root_md   + nextc%n*nextc%root_md)/newn   
-                         currentCohort%leaf_md   = (currentCohort%n*currentCohort%leaf_md   + nextc%n*nextc%leaf_md)/newn  
-                         currentCohort%laimemory = (currentCohort%n*currentCohort%laimemory + nextc%n*nextc%laimemory)/newn
-                         currentCohort%md        = (currentCohort%n*currentCohort%md        + nextc%n*nextc%md)/newn
+                             if( currentCohort%isnew.eqv.nextc%isnew ) then
 
-                         currentCohort%carbon_balance = (currentCohort%n*currentCohort%carbon_balance + &
-                              nextc%n*nextc%carbon_balance)/newn
+                                newn = currentCohort%n + nextc%n
+                                fusion_took_place = 1         
 
-                         currentCohort%storage_flux = (currentCohort%n*currentCohort%storage_flux + &
-                              nextc%n*nextc%storage_flux)/newn               
+                                if ( FUSE_DEBUG .and. currentCohort%isnew ) then
+                                   write(fates_log(),*) 'Fusing Two Cohorts'
+                                   write(fates_log(),*) 'newn: ',newn
+                                   write(fates_log(),*) 'Cohort I, Cohort II' 
+                                   write(fates_log(),*) 'n:',currentCohort%n,nextc%n
+                                   write(fates_log(),*) 'isnew:',currentCohort%isnew,nextc%isnew
+                                   write(fates_log(),*) 'balive:',currentCohort%balive,nextc%balive
+                                   write(fates_log(),*) 'bdead:',currentCohort%bdead,nextc%bdead
+                                   write(fates_log(),*) 'bstore:',currentCohort%bstore,nextc%bstore
+                                   write(fates_log(),*) 'laimemory:',currentCohort%laimemory,nextc%laimemory
+                                   write(fates_log(),*) 'b:',currentCohort%b,nextc%b
+                                   write(fates_log(),*) 'bsw:',currentCohort%bsw,nextc%bsw
+                                   write(fates_log(),*) 'bl:',currentCohort%bl ,nextc%bl
+                                   write(fates_log(),*) 'br:',currentCohort%br,nextc%br
+                                   write(fates_log(),*) 'hite:',currentCohort%hite,nextc%hite
+                                   write(fates_log(),*) 'dbh:',currentCohort%dbh,nextc%dbh
+                                   write(fates_log(),*) 'pft:',currentCohort%pft,nextc%pft
+                                   write(fates_log(),*) 'canopy_trim:',currentCohort%canopy_trim,nextc%canopy_trim
+                                   write(fates_log(),*) 'canopy_layer_yesterday:', &
+                                         currentCohort%canopy_layer_yesterday,nextc%canopy_layer_yesterday
+                                   do i=1, nlevleaf
+                                      write(fates_log(),*) 'leaf level: ',i,'year_net_uptake', &
+                                            currentCohort%year_net_uptake(i),nextc%year_net_uptake(i)
+                                   end do
+                                end if
+                                
+                                currentCohort%balive      = (currentCohort%n*currentCohort%balive      &
+                                      + nextc%n*nextc%balive)/newn
+                                currentCohort%bdead       = (currentCohort%n*currentCohort%bdead       &
+                                      + nextc%n*nextc%bdead)/newn
+                                currentCohort%bstore      = (currentCohort%n*currentCohort%bstore      &
+                                      + nextc%n*nextc%bstore)/newn   
+                                currentCohort%laimemory   = (currentCohort%n*currentCohort%laimemory   &
+                                      + nextc%n*nextc%laimemory)/newn
+                                currentCohort%b           = (currentCohort%n*currentCohort%b           &
+                                      + nextc%n*nextc%b)/newn
+                                currentCohort%bsw         = (currentCohort%n*currentCohort%bsw         &
+                                      + nextc%n*nextc%bsw)/newn
+                                currentCohort%bl          = (currentCohort%n*currentCohort%bl          &
+                                      + nextc%n*nextc%bl)/newn
+                                currentCohort%br          = (currentCohort%n*currentCohort%br          &
+                                      + nextc%n*nextc%br)/newn
+                                currentCohort%hite        = (currentCohort%n*currentCohort%hite        &
+                                      + nextc%n*nextc%hite)/newn         
+                                currentCohort%dbh         = (currentCohort%n*currentCohort%dbh         &
+                                      + nextc%n*nextc%dbh)/newn
+                                currentCohort%canopy_trim = (currentCohort%n*currentCohort%canopy_trim &
+                                      + nextc%n*nextc%canopy_trim)/newn
 
-                         currentCohort%b           = (currentCohort%n*currentCohort%b           + nextc%n*nextc%b)/newn
-                         currentCohort%bsw         = (currentCohort%n*currentCohort%bsw         + nextc%n*nextc%bsw)/newn
-                         currentCohort%bl          = (currentCohort%n*currentCohort%bl          + nextc%n*nextc%bl)/newn
+                                call sizetype_class_index(currentCohort%dbh,currentCohort%pft, &
+                                      currentCohort%size_class,currentCohort%size_by_pft_class)
 
-                         if ( DEBUG ) write(fates_log(),*) 'EDcohortDyn 569 ',currentCohort%br
-                         if ( DEBUG ) write(fates_log(),*) 'EDcohortDyn 570 ',currentCohort%n
-                         if ( DEBUG ) write(fates_log(),*) 'EDcohortDyn 571 ',nextc%br
-                         if ( DEBUG ) write(fates_log(),*) 'EDcohortDyn 572 ',nextc%n
+                                if(use_fates_plant_hydro) call FuseCohortHydraulics(currentCohort,nextc,bc_in,newn)
 
-                         currentCohort%br          = (currentCohort%n*currentCohort%br          + nextc%n*nextc%br)/newn
-                         currentCohort%hite        = (currentCohort%n*currentCohort%hite        + nextc%n*nextc%hite)/newn         
-                         currentCohort%dbh         = (currentCohort%n*currentCohort%dbh         + nextc%n*nextc%dbh)/newn
+                                ! recent canopy history
+                                currentCohort%canopy_layer_yesterday  = (currentCohort%n*currentCohort%canopy_layer_yesterday  + &
+                                      nextc%n*nextc%canopy_layer_yesterday)/newn
 
-                         currentCohort%gpp_acc     = (currentCohort%n*currentCohort%gpp_acc     + nextc%n*nextc%gpp_acc)/newn
+                                ! Flux and biophysics variables have not been calculated for recruits we just default to 
+                                ! their initization values, which should be the same for eahc
 
-                         if ( DEBUG ) write(fates_log(),*) 'EDcohortDyn III ',currentCohort%npp_acc
-                         if ( DEBUG ) write(fates_log(),*) 'EDcohortDyn IV ',currentCohort%resp_acc
+                                if ( .not.currentCohort%isnew) then
 
-                         currentCohort%npp_acc     = (currentCohort%n*currentCohort%npp_acc     + nextc%n*nextc%npp_acc)/newn
-                         currentCohort%resp_acc    = (currentCohort%n*currentCohort%resp_acc    + nextc%n*nextc%resp_acc)/newn
+                                   currentCohort%md             = (currentCohort%n*currentCohort%md        + &
+                                         nextc%n*nextc%md)/newn
+                                   currentCohort%seed_prod      = (currentCohort%n*currentCohort%seed_prod + &
+                                         nextc%n*nextc%seed_prod)/newn
+                                   currentCohort%root_md        = (currentCohort%n*currentCohort%root_md   + &
+                                         nextc%n*nextc%root_md)/newn
+                                   currentCohort%leaf_md        = (currentCohort%n*currentCohort%leaf_md   + &
+                                         nextc%n*nextc%leaf_md)/newn
+                                   currentCohort%carbon_balance = (currentCohort%n*currentCohort%carbon_balance + &
+                                         nextc%n*nextc%carbon_balance)/newn
+                                   currentCohort%storage_flux   = (currentCohort%n*currentCohort%storage_flux + &
+                                         nextc%n*nextc%storage_flux)/newn
+                                   currentCohort%gpp_acc        = (currentCohort%n*currentCohort%gpp_acc     + &
+                                         nextc%n*nextc%gpp_acc)/newn
+                                   currentCohort%npp_acc        = (currentCohort%n*currentCohort%npp_acc     + &
+                                         nextc%n*nextc%npp_acc)/newn
+                                   currentCohort%resp_acc       = (currentCohort%n*currentCohort%resp_acc    + &
+                                         nextc%n*nextc%resp_acc)/newn
+                                   currentCohort%resp_acc_hold  = &
+                                         (currentCohort%n*currentCohort%resp_acc_hold + &
+                                         nextc%n*nextc%resp_acc_hold)/newn
+                                   currentCohort%npp_acc_hold   = &
+                                         (currentCohort%n*currentCohort%npp_acc_hold + &
+                                         nextc%n*nextc%npp_acc_hold)/newn
+                                   currentCohort%gpp_acc_hold   = &
+                                         (currentCohort%n*currentCohort%gpp_acc_hold + &
+                                         nextc%n*nextc%gpp_acc_hold)/newn
 
-                         if ( DEBUG ) write(fates_log(),*) 'EDcohortDyn V ',currentCohort%npp_acc
-                         if ( DEBUG ) write(fates_log(),*) 'EDcohortDyn VI ',currentCohort%resp_acc
-                         
-                         currentCohort%resp_acc_hold = &
-                               (currentCohort%n*currentCohort%resp_acc_hold + &
-                               nextc%n*nextc%resp_acc_hold)/newn
-                         currentCohort%npp_acc_hold  = &
-                               (currentCohort%n*currentCohort%npp_acc_hold + &
-                               nextc%n*nextc%npp_acc_hold)/newn
-                         currentCohort%gpp_acc_hold  = &
-                               (currentCohort%n*currentCohort%gpp_acc_hold + &
-                               nextc%n*nextc%gpp_acc_hold)/newn
+                                   currentCohort%dmort          = (currentCohort%n*currentCohort%dmort       + &
+                                         nextc%n*nextc%dmort)/newn
+                                   currentCohort%fire_mort      = (currentCohort%n*currentCohort%fire_mort   + &
+                                         nextc%n*nextc%fire_mort)/newn
+                                   currentCohort%leaf_litter    = (currentCohort%n*currentCohort%leaf_litter + &
+                                         nextc%n*nextc%leaf_litter)/newn
 
-                         currentCohort%canopy_trim = (currentCohort%n*currentCohort%canopy_trim + nextc%n*nextc%canopy_trim)/newn
-			 currentCohort%dmort       = (currentCohort%n*currentCohort%dmort       + nextc%n*nextc%dmort)/newn
-                         currentCohort%fire_mort   = (currentCohort%n*currentCohort%fire_mort   + nextc%n*nextc%fire_mort)/newn
-                         currentCohort%leaf_litter = (currentCohort%n*currentCohort%leaf_litter + nextc%n*nextc%leaf_litter)/newn
+                                   ! mortality diagnostics
+                                   currentCohort%cmort = (currentCohort%n*currentCohort%cmort + nextc%n*nextc%cmort)/newn
+                                   currentCohort%hmort = (currentCohort%n*currentCohort%hmort + nextc%n*nextc%hmort)/newn
+                                   currentCohort%bmort = (currentCohort%n*currentCohort%bmort + nextc%n*nextc%bmort)/newn
+                                   currentCohort%imort = (currentCohort%n*currentCohort%imort + nextc%n*nextc%imort)/newn
+                                   currentCohort%fmort = (currentCohort%n*currentCohort%fmort + nextc%n*nextc%fmort)/newn
 
-                         ! mortality diagnostics
-                         currentCohort%cmort = (currentCohort%n*currentCohort%cmort + nextc%n*nextc%cmort)/newn
-                         currentCohort%hmort = (currentCohort%n*currentCohort%hmort + nextc%n*nextc%hmort)/newn
-                         currentCohort%bmort = (currentCohort%n*currentCohort%bmort + nextc%n*nextc%bmort)/newn
-                         currentCohort%imort = (currentCohort%n*currentCohort%imort + nextc%n*nextc%imort)/newn
-                         currentCohort%fmort = (currentCohort%n*currentCohort%fmort + nextc%n*nextc%fmort)/newn
+                                   ! npp diagnostics
+                                   currentCohort%npp_leaf  = (currentCohort%n*currentCohort%npp_leaf  + nextc%n*nextc%npp_leaf)/newn
+                                   currentCohort%npp_froot = (currentCohort%n*currentCohort%npp_froot + nextc%n*nextc%npp_froot)/newn
+                                   currentCohort%npp_bsw   = (currentCohort%n*currentCohort%npp_bsw   + nextc%n*nextc%npp_bsw)/newn
+                                   currentCohort%npp_bdead = (currentCohort%n*currentCohort%npp_bdead + nextc%n*nextc%npp_bdead)/newn
+                                   currentCohort%npp_bseed = (currentCohort%n*currentCohort%npp_bseed + nextc%n*nextc%npp_bseed)/newn
+                                   currentCohort%npp_store = (currentCohort%n*currentCohort%npp_store + nextc%n*nextc%npp_store)/newn
 
-                         ! npp diagnostics
-                         currentCohort%npp_leaf  = (currentCohort%n*currentCohort%npp_leaf  + nextc%n*nextc%npp_leaf)/newn
-                         currentCohort%npp_froot = (currentCohort%n*currentCohort%npp_froot + nextc%n*nextc%npp_froot)/newn
-                         currentCohort%npp_bsw   = (currentCohort%n*currentCohort%npp_bsw   + nextc%n*nextc%npp_bsw)/newn
-                         currentCohort%npp_bdead = (currentCohort%n*currentCohort%npp_bdead + nextc%n*nextc%npp_bdead)/newn
-                         currentCohort%npp_bseed = (currentCohort%n*currentCohort%npp_bseed + nextc%n*nextc%npp_bseed)/newn
-                         currentCohort%npp_store = (currentCohort%n*currentCohort%npp_store + nextc%n*nextc%npp_store)/newn
+                                   do i=1, nlevleaf     
+                                      if (currentCohort%year_net_uptake(i) == 999._r8 .or. nextc%year_net_uptake(i) == 999._r8) then
+                                         currentCohort%year_net_uptake(i) = &
+                                               min(nextc%year_net_uptake(i),currentCohort%year_net_uptake(i))
+                                      else
+                                         currentCohort%year_net_uptake(i) = (currentCohort%n*currentCohort%year_net_uptake(i) + &
+                                               nextc%n*nextc%year_net_uptake(i))/newn                
+                                      endif
+                                   enddo
 
-                         ! recent canopy history
-                         currentCohort%canopy_layer_yesterday  = (currentCohort%n*currentCohort%canopy_layer_yesterday  + &
-                              nextc%n*nextc%canopy_layer_yesterday)/newn
+                                end if !(currentCohort%isnew)
 
-                         do i=1, nlevleaf     
-                            if (currentCohort%year_net_uptake(i) == 999._r8 .or. nextc%year_net_uptake(i) == 999._r8) then
-                               currentCohort%year_net_uptake(i) = min(nextc%year_net_uptake(i),currentCohort%year_net_uptake(i))
-                            else
-                               currentCohort%year_net_uptake(i) = (currentCohort%n*currentCohort%year_net_uptake(i) + &
-                                  nextc%n*nextc%year_net_uptake(i))/newn                
-                            endif
-                         enddo
-                         
-                         if(use_fates_plant_hydro) call FuseCohortHydraulics(currentCohort,nextc,bc_in,newn)
-                         
-                         currentCohort%n = newn     
-                         !remove fused cohort from the list
-                         nextc%taller%shorter => nextnextc        
-                         if (.not. associated(nextc%shorter)) then !this is the shortest cohort. 
-                            currentPatch%shortest => nextc%taller
-                         else
-                            nextnextc%taller => nextc%taller
-                         endif
+                                currentCohort%n = newn     
+                                !remove fused cohort from the list
+                                nextc%taller%shorter => nextnextc        
+                                if (.not. associated(nextc%shorter)) then !this is the shortest cohort. 
+                                   currentPatch%shortest => nextc%taller
+                                else
+                                   nextnextc%taller => nextc%taller
+                                endif
 
-                         if (associated(nextc)) then       
-                            if(use_fates_plant_hydro) call DeallocateHydrCohort(nextc)
-                            deallocate(nextc)            
-                         endif
+                                if (associated(nextc)) then       
+                                   if(use_fates_plant_hydro) call DeallocateHydrCohort(nextc)
+                                   deallocate(nextc)            
+                                endif
 
-                         endif ! Not a recruit
+                             endif ! if( currentCohort%isnew.eqv.nextc%isnew ) then
 
-                      endif !canopy layer
-                   endif !pft
-                endif  !index no. 
-             endif !diff   
+                          endif !canopy layer
+                       endif !pft
+                    endif  !index no. 
+                 endif !diff   
 
-             if (associated(nextc)) then             
-                nextc => nextc%shorter    
-             else
-                nextc => nextnextc !if we have removed next
-             endif
+                 if (associated(nextc)) then             
+                    nextc => nextc%shorter    
+                 else
+                    nextc => nextnextc !if we have removed next
+                 endif
 
-          enddo !end checking nextc cohort loop
+              enddo !end checking nextc cohort loop
 
-          if (associated (currentCohort%shorter)) then
-             currentCohort => currentCohort%shorter
-          endif
-       enddo !end currentCohort cohort loop
+              if (associated (currentCohort%shorter)) then
+                 currentCohort => currentCohort%shorter
+              endif
+           enddo !end currentCohort cohort loop
 
-       !---------------------------------------------------------------------!
-       ! Is the number of cohorts larger than the maximum?                   !
-       !---------------------------------------------------------------------!   
-       nocohorts = 0
-       currentCohort => currentPatch%tallest
-       do while(associated(currentCohort))
-          nocohorts = nocohorts + 1
-          currentCohort => currentCohort%shorter
-       enddo
+           !---------------------------------------------------------------------!
+           ! Is the number of cohorts larger than the maximum?                   !
+           !---------------------------------------------------------------------!   
+           nocohorts = 0
+           currentCohort => currentPatch%tallest
+           do while(associated(currentCohort))
+              nocohorts = nocohorts + 1
+              currentCohort => currentCohort%shorter
+           enddo
 
-       if (nocohorts > maxcohorts) then
-          iterate = 1
-          !---------------------------------------------------------------------!
-          ! Making profile tolerance larger means that more fusion will happen  !
-          !---------------------------------------------------------------------!        
-          dynamic_fusion_tolerance = dynamic_fusion_tolerance * 1.1_r8
+           if (nocohorts > maxcohorts) then
+              iterate = 1
+              !---------------------------------------------------------------------!
+              ! Making profile tolerance larger means that more fusion will happen  !
+              !---------------------------------------------------------------------!        
+              dynamic_fusion_tolerance = dynamic_fusion_tolerance * 1.1_r8
 
-          write(fates_log(),*) 'maxcohorts exceeded',dynamic_fusion_tolerance
+              write(fates_log(),*) 'maxcohorts exceeded',dynamic_fusion_tolerance
 
-       else
-          iterate = 0
-       endif
+           else
+              iterate = 0
+           endif
 
-    enddo !do while nocohorts>maxcohorts
+           if ( dynamic_fusion_tolerance .gt. 100._r8) then
+              ! something has gone terribly wrong and we need to report what
+              write(fates_log(),*) 'exceeded reasonable expectation of cohort fusion.'
+              currentCohort => currentPatch%tallest
+              nocohorts = 0
+              do while(associated(currentCohort))
+                 write(fates_log(),*) 'cohort ', nocohorts, currentCohort%dbh, currentCohort%canopy_layer, currentCohort%n
+                 nocohorts = nocohorts + 1
+                 currentCohort => currentCohort%shorter
+              enddo
+              call endrun(msg=errMsg(sourcefile, __LINE__))
+           endif
 
-    endif ! patch. 
+        enddo !do while nocohorts>maxcohorts
 
-    if (fusion_took_place == 1) then  ! if fusion(s) occured sort cohorts 
-       call sort_cohorts(currentPatch)
-    endif
+     endif ! patch. 
+
+     if (fusion_took_place == 1) then  ! if fusion(s) occured sort cohorts 
+        call sort_cohorts(currentPatch)
+     endif
 
   end subroutine fuse_cohorts
 
@@ -1099,6 +1161,8 @@ contains
     n%status_coh      = o%status_coh               
     n%excl_weight     = o%excl_weight               
     n%prom_weight     = o%prom_weight               
+    n%size_class      = o%size_class
+    n%size_by_pft_class = o%size_by_pft_class
 
     ! CARBON FLUXES
     n%gpp_acc_hold    = o%gpp_acc_hold

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -401,10 +401,13 @@ contains
           !update area of donor patch
           currentPatch%area = currentPatch%area - patch_site_areadis
 
-          !sort out the cohorts, since some of them may be so small as to need removing. 
-
+          ! sort out the cohorts, since some of them may be so small as to need removing. 
+          ! the first call to terminate cohorts removes sparse number densities,
+          ! the second call removes for all other reasons (sparse culling must happen
+          ! before fusion)
+          call terminate_cohorts(currentSite, currentPatch, 1)
           call fuse_cohorts(currentPatch, bc_in)
-          call terminate_cohorts(currentSite, currentPatch)
+          call terminate_cohorts(currentSite, currentPatch, 2)
           call sort_cohorts(currentPatch)
 
           currentPatch => currentPatch%younger
@@ -420,8 +423,13 @@ contains
        currentPatch%younger       => new_patch
        currentSite%youngest_patch => new_patch
 
+       ! sort out the cohorts, since some of them may be so small as to need removing. 
+       ! the first call to terminate cohorts removes sparse number densities,
+       ! the second call removes for all other reasons (sparse culling must happen
+       ! before fusion)
+       call terminate_cohorts(currentSite, new_patch, 1)
        call fuse_cohorts(new_patch, bc_in)
-       call terminate_cohorts(currentSite, new_patch)
+       call terminate_cohorts(currentSite, new_patch, 2)
        call sort_cohorts(new_patch)
 
     endif !end new_patch area 

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -874,7 +874,6 @@ contains
     currentCohort%npp_froot = max(0.0_r8,min(currentCohort%npp_acc_hold*currentCohort%root_md/currentCohort%md, &
                                   currentCohort%root_md*EDecophyscon%leaf_stor_priority(currentCohort%pft)))
 
-
     if (Bleaf(currentCohort) > 0._r8)then
 
        if ( DEBUG ) write(fates_log(),*) 'EDphys A ',currentCohort%carbon_balance

--- a/main/EDMainMod.F90
+++ b/main/EDMainMod.F90
@@ -147,12 +147,15 @@ contains
           
           ! puts cohorts in right order
           call sort_cohorts(currentPatch)            
-          
+
+          ! kills cohorts that are too few
+          call terminate_cohorts(currentSite, currentPatch, 1)
+
           ! fuses similar cohorts
           call fuse_cohorts(currentPatch, bc_in )
           
-          ! kills cohorts that are too small
-          call terminate_cohorts(currentSite, currentPatch)
+          ! kills cohorts for various other reasons
+          call terminate_cohorts(currentSite, currentPatch, 2)
           
           
           currentPatch => currentPatch%younger
@@ -403,7 +406,9 @@ contains
     currentPatch => currentSite%oldest_patch
     do while(associated(currentPatch))
 
-       call terminate_cohorts(currentSite, currentPatch) 
+       ! Is termination really needed here? canopy_structure just called it several times! (rgk)
+       call terminate_cohorts(currentSite, currentPatch, 1) 
+       call terminate_cohorts(currentSite, currentPatch, 2) 
 
        ! FIX(SPM,040314) why is this needed for BFB restarts? Look into this at some point
        cohort_number = count_cohorts(currentPatch)  

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -97,8 +97,8 @@ module EDTypesMod
   real(r8), parameter :: min_patch_area = 0.001_r8   ! smallest allowable patch area before termination
   real(r8), parameter :: min_nppatch    = 1.0E-11_r8 ! minimum number of cohorts per patch (min_npm2*min_patch_area)
   real(r8), parameter :: min_n_safemath = 1.0E-15_r8 ! in some cases, we want to immediately remove super small
-                                                     ! number densities of cohorts to prevent FPEs, this is usually
-                                                     ! just relevant in the first day after recruitment
+                                                     ! number densities of cohorts to prevent FPEs
+
   character*4 yearchar                    
 
   ! special mode to cause PFTs to create seed mass of all currently-existing PFTs

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -2818,12 +2818,12 @@ contains
           upfreq=1, ivar=ivar, initialize=initialize_variables, index = ih_promotion_carbonflux_si )
 
     call this%set_history_var(vname='MORTALITY_CARBONFLUX_CANOPY', units = 'gC/m2/s',               &
-          long='flux of biomass carbon from live to dead pools from mortality of canopy plants', use_default='active',   &
+          long='flux of biomass carbon from live to dead pools from mortality of canopy plants', use_default='inactive',   &
           avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8,    &
           upfreq=1, ivar=ivar, initialize=initialize_variables, index = ih_canopy_mortality_carbonflux_si )
 
     call this%set_history_var(vname='MORTALITY_CARBONFLUX_UNDERSTORY', units = 'gC/m2/s',               &
-          long='flux of biomass carbon from live to dead pools from mortality of understory plants', use_default='active',   &
+          long='flux of biomass carbon from live to dead pools from mortality of understory plants',use_default='inactive',&
           avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8,    &
           upfreq=1, ivar=ivar, initialize=initialize_variables, index = ih_understory_mortality_carbonflux_si )
 


### PR DESCRIPTION
Bug fixes. Fix to infinite fusion loop by allowing new recruites to fuse with each other.  Added the ability of the c_area function to suppress large or small canopy layer indexes, as the function is called during the logic which promotes and demotes canopy layers, and is expected to have layers that are outside the expected range.  Added cohort size and size-type indices to the copy cohort routine.

Removed white-space changes from EDCanopystructure

Split termination to allow the safe-math portion to be calculated prior to fusion.

Removed the max(1,X) on canopy layer indices inside crown area calculations.

Turning off cnaopy mortality carbonflux as a default as well.

Addresses issues: #222, #223, #149

User interface changes: no
Code review: @ckoven contributed to 4). Also used @ckoven 's code for graceful exits when fusion can't be achieved, discussion with various parties in issues listed above
Test suite: lawrencium lr3, intel: edTest, clm_short_45, clm_short_50, 30+ year completion tests on 1x1 brazil
CLM test hash: 3a5d965
CLM base hash: 3a5d965
Fates test hash: 3b7f067
Fates base hash: b1befab

Test namelist changes: none

This branch was tested and approved via review, and has now been rebased to the licensed master.  

Test Results: 
lawrencium ed: B4B
cheyenne ed:  B4B

