### PR TITLE
Update Spitfire cfa equation

### DIFF
--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -881,8 +881,8 @@ contains
                    if ((currentCohort%hite > 0.0_r8).and.(currentPatch%SH >=  &
                         (currentCohort%hite-currentCohort%hite*EDecophyscon%crown(currentCohort%pft)))) then 
 
-                           currentCohort%cfa =  (currentPatch%SH-currentCohort%hite* &
-                                EDecophyscon%crown(currentCohort%pft))/(currentCohort%hite-currentCohort%hite* &
+                           currentCohort%cfa =  (currentPatch%SH-currentCohort%hite*(1- &
+                                EDecophyscon%crown(currentCohort%pft)))/(currentCohort%hite* &
                                 EDecophyscon%crown(currentCohort%pft)) 
 
                    else 


### PR DESCRIPTION
Update equation of crown area affected by fire (cfa)
with correct value for crown length.
This pull comes after re-historying and porting to 
new version.

Fixes:
User interface changes?: No
Code review:JKShuman

Test suite: Full test suite Ed, short for CLM45, cheyenne, intel
Test baseline: fates-clm 601eb87
Test namelist changes: none
Test answer changes: bit for bit with non-fire fates-clm
Test summary: bit for bit for non-fire
              answer changing for fire, as expected