### PR TITLE
bug fixes to litterflux out and in

### DIFF
--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -1293,7 +1293,6 @@ contains
             currentPatch%fragmentation_scaler )
        currentPatch%root_litter_out(ft) = max(0.0_r8,currentPatch%root_litter(ft)* SF_val_max_decomp(dl_sf) * &
             currentPatch%fragmentation_scaler )
-
        if ( currentPatch%leaf_litter_out(ft)<0.0_r8.or.currentPatch%root_litter_out(ft)<0.0_r8)then
          write(fates_log(),*) 'root or leaf out is negative?',SF_val_max_decomp(dl_sf),currentPatch%fragmentation_scaler
        endif
@@ -1361,7 +1360,6 @@ contains
     real(r8) mass_convert    ! ED uses kg, CLM uses g
     integer           :: begp,endp
     integer           :: begc,endc                                    !bounds 
-    integer           :: ipa
     !------------------------------------------------------------------------
     real(r8) :: cinput_rootfr(1:numpft_ed, 1:hlm_numlevdecomp_full)      ! column by pft root fraction used for calculating inputs
     real(r8) :: croot_prof_perpatch(1:hlm_numlevdecomp_full)
@@ -1677,7 +1675,7 @@ contains
            end do !currentPatch
 
         end do  ! do sites(s)
-
+     
         do s = 1, nsites
            do j = 1, hlm_numlevdecomp                    
               ! time unit conversion


### PR DESCRIPTION
Litter flux out was not being averaged nor initialized correctly during the patch fusion and creation process.  This PR add that functionality.  Some minor numerical improvements were added to how weighting is applied to patch fusion, see inv_sum_area

Fixes: undocumented bug, BR 1x1 runs with gnu compilers will crash when heterotrophic respiration is output, this stems from bogus uninitialized litter flux values into the HLM

User interface changes?: no

Code review: discussions with @ckoven 

Test suite: lawrencium-lr3, intel: edTest, cheyenne, intel: edTest

CLM test-hash: 3a5d965
CLM base-hash: 3a5d965
FATES base-hash: b1befab

Test namelist changes:
Test answer changes: none

Test summary: cheyenne intel edtest, lawrencium intel edTest: all pass with expected baseline fails
