### PR TITLE
Changed to new FATES license file

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,34 +1,59 @@
-Copyright (c) 2013-2015, University Corporation for Atmospheric Research (UCAR)
-All rights reserved.
+Functionally Assembled Terrestrial Ecosystem Simulator (“FATES”)
 
-Developed by: 
-              University Corporation for Atmospheric Research - National Center for Atmospheric Research
-              https://www2.cesm.ucar.edu/working-groups/sewg
+Copyright (c) 2016-2017, The Regents of the University of California, through Lawrence
+Berkeley National Laboratory, University Corporation for Atmospheric Research, Los Alamos
+National Security, LLC (LANS), as operator of Los Alamos National Laboratory (LANL), and
+President and Fellows of Harvard College. All rights reserved.
 
-Permission is hereby granted, free of charge, to any person obtaining 
-a copy of this software and associated documentation files (the "Software"), 
-to deal with the Software without restriction, including without limitation 
-the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom 
-the Software is furnished to do so, subject to the following conditions:
+Copyright (c) 2013-2015, University Corporation for Atmospheric Research (UCAR). All
+rights reserved.
 
-    - Redistributions of source code must retain the above copyright notice, 
-      this list of conditions and the following disclaimers.
-    - Redistributions in binary form must reproduce the above copyright notice, 
-      this list of conditions and the following disclaimers in the documentation 
-      and/or other materials provided with the distribution.
-    - Neither the names of UCAR, or NCAR, 
-      nor the names of its contributors may be used to endorse or promote 
-      products derived from this Software without specific prior written permission.
+If you have questions about your rights to use or distribute this software, please contact
+Berkeley Lab's Innovation & Partnerships Office at IPO@lbl.gov.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
-POSSIBILITY OF SUCH DAMAGE.		
+NOTICE.  This Software was developed under funding from the U.S. Department of Energy and
+the U.S. Government consequently retains certain rights.  As such, the U.S. Government has
+been granted for itself and others acting on its behalf a paid-up, nonexclusive,
+irrevocable, worldwide license in the Software to reproduce, distribute copies to the
+public, prepare derivative works, and perform publicly and display publicly, and to permit
+other to do so.
+
+ Redistribution and use in source and binary forms, with or without modification, are
+ permitted provided that the following conditions are met:
+
+ (1) Redistributions of source code must retain the above copyright notice, this list of
+ conditions and the following disclaimer.
+
+ (2) Redistributions in binary form must reproduce the above copyright notice, this list
+ of conditions and the following disclaimer in the documentation and/or other materials
+ provided with the distribution.
+
+ (3) Neither the name of the University of California, Lawrence Berkeley National
+ Laboratory, University Corporation for Atmospheric Research, Los Alamos National
+ Security, LLC (LANS), as operator of Los Alamos National Laboratory (LANL), President and
+ Fellows of Harvard College, or the U.S. Dept. of Energy nor the names of its contributors
+ may be used to endorse or promote products derived from this software without specific
+ prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+You are under no obligation whatsoever to provide any bug fixes, patches, or upgrades to
+the features, functionality or performance of the source code ("Enhancements") to anyone;
+however, if you choose to make your Enhancements available either publicly, or directly to
+Lawrence Berkeley National Laboratory, without imposing a separate written license
+agreement for such Enhancements, then you hereby grant the following license to Lawrence
+Berkeley National Laboratory, University Corporation for Atmospheric Research, Los Alamos
+National Security, LLC (LANS), as operator of Los Alamos National Laboratory (LANL),
+President and Fellows of Harvard College, and the U.S. Dept. of Energy: a non-exclusive,
+royalty-free perpetual license to install, use, modify, prepare derivative works,
+incorporate into other computer software, distribute, and sublicense such enhancements or
+derivative works thereof, in binary and source code form.
+


### PR DESCRIPTION
We finally have agreement from each of the institutions that had contributed FATES code as of last year for the new license to be activated; this PR includes that new file.  The terms are the same as the old license (BSD 3 clause), but now it is copyright UC, UCAR, LANL, and Harvard rather than just UCAR.  The new language is cut and pasted from the email agreement that I got from LBL IP office, and I added the old copyright (2013-2015) into it as suggested by Ben.

I didn't test this PR because this is only a change to the license file.