### PR TITLE
Increase in bin resolution for size- and age-resolved outputs

### DIFF
--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -106,16 +106,23 @@ module EDTypesMod
 
   !the lower limit of the size classes of ED cohorts
   !0-10,10-20...
-  integer, parameter :: nlevsclass_ed = 13    ! Number of dbh size classes for size structure analysis
-                                              ! |0-1,1-2,2-3,3-4,4-5,5-10,10-20,20-30,30-40,40-50,50-60,60-70,70-80,80-90,90-100,100+|
+  ! integer, parameter :: nlevsclass_ed = 13    ! Number of dbh size classes for size structure analysis
+  !                                             ! |0-1,1-2,2-3,3-4,4-5,5-10,10-20,20-30,30-40,40-50,50-60,60-70,70-80,80-90,90-100,100+|
 !  real(r8), parameter, dimension(16) ::  sclass_ed  = (/0.0_r8,1.0_r8,2.0_r8,3.0_r8,4.0_r8,5.0_r8,10.0_r8,20.0_r8,30.0_r8,40.0_r8, &
 !                                                       50.0_r8,60.0_r8,70.0_r8,80.0_r8,90.0_r8,100.0_r8/)
 
-  real(r8), parameter, dimension(nlevsclass_ed) ::  sclass_ed  = (/0.0_r8,5.0_r8,10.0_r8,15.0_r8,20.0_r8,30.0_r8,40.0_r8, &
-                                                       50.0_r8,60.0_r8,70.0_r8,80.0_r8,90.0_r8,100.0_r8/)
+  ! real(r8), parameter, dimension(nlevsclass_ed) ::  sclass_ed  = (/0.0_r8,5.0_r8,10.0_r8,15.0_r8,20.0_r8,30.0_r8,40.0_r8, &
+  !                                                      50.0_r8,60.0_r8,70.0_r8,80.0_r8,90.0_r8,100.0_r8/)
 
-  integer, parameter :: nlevage_ed = 7  ! Number of patch-age classes for age structured analyses
-  real(r8), parameter, dimension(nlevage_ed) ::  ageclass_ed  = (/0.0_r8,1.0_r8,2._r8,5.0_r8,10.0_r8,20.0_r8,50.0_r8/)
+  ! exponential bins, starting at 1cm
+  integer, parameter :: nlevsclass_ed = 26    ! Number of dbh size classes for size structure analysis
+  real(r8), parameter, dimension(nlevsclass_ed) ::  sclass_ed  = (/0._r8, 1._r8, 1.22140276_r8, 1.4918247_r8, 1.8221188_r8, 2.22554093_r8, &
+       2.71828183_r8, 3.32011692_r8, 4.05519997_r8, 4.95303242_r8, 6.04964746_r8, 7.3890561_r8, 9.0250135_r8, 11.02317638_r8, 13.46373804_r8, &
+       16.44464677_r8, 20.08553692_r8, 24.5325302_r8, 29.96410005_r8, 36.59823444_r8, 44.70118449_r8, 54.59815003_r8, 66.68633104_r8, 81.45086866_r8, &
+       99.48431564_r8, 121.51041752_r8/)
+
+  integer, parameter :: nlevage_ed = 8  ! Number of patch-age classes for age structured analyses
+  real(r8), parameter, dimension(nlevage_ed) ::  ageclass_ed  = (/0.0_r8,1.0_r8,2._r8,5.0_r8,10.0_r8,20.0_r8,50.0_r8,100._r8/)
   
 
  !  integer, parameter :: nlevsclass_ed = 17


### PR DESCRIPTION
This PR is a minor change to increase the resolution of size and age bins.  For the size bins, the change is from 13 round-numbered bins to 26 exponentially-spaced bins, starting at 1cm diameter. The advantage of using exponentially-spaced bins is that, since we expect a power-law size distributions in number density (in units of n cm-1 ha-1) and diameter, it means that log(n per bin) should be linear, so is convenient for plotting.

For the age bin, the only change is to add a 100-year age bin cutoff, to distinguish between 50-100 and >100 year patches.

This is all purely diagnostic so shouldn't change any dynamics other than the history output on the size and age-resolved variables.

Note that this might be overkill on the size distribution bins, so if people would rather put in a switch to choose between different resolutions, that'd be fine with me.  If so, @rgknox, could you add that to the list of switches in #240?

testing:
using ED test suite on Lawrencium lr3.
some fails due to memory usage increases (the first is just the weird one I saw with the other PRs), which may be indicative that the memory cost on this isn't totally trivial and so supports the switch option.

```
[cdkoven@n0000 ed.lbl-lr3.intel.6dc576d_e30b14d]$ ./cs.status.1707201016 | grep FAIL
  FAIL ERI_D_Ld9.f09_g16.ICLM45BGC.lbl-lr3_intel.clm-default BASELINE
  FAIL SMS_D_Ld5.f45_f45.ICLM45ED.lbl-lr3_intel.clm-edTest MEMCOMP Error: Memory usage increase > 10% from baseline
  FAIL SMS_D_Lm6.f45_f45.ICLM45ED.lbl-lr3_intel.clm-edTest MEMCOMP Error: Memory usage increase > 10% from baseline
  FAIL SMS_D_Mmpi-serial_Ld5.5x5_amazon.ICLM45ED.lbl-lr3_intel.clm-edTest MEMCOMP Error: Memory usage increase > 10% from baseline
  FAIL SMS_Ld5.f19_g16.ICLM45ED.lbl-lr3_intel.clm-edTest MEMCOMP Error: Memory usage increase > 10% from baseline
```
