### PR TITLE
ncar compatible previous history merger

### DIFF
--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -945,13 +945,7 @@ contains
     new_patch%frac_burnt         = 0._r8  
     new_patch%total_tree_area    = 0.0_r8  
     new_patch%NCL_p              = 1
-
-    new_patch%leaf_litter_in(:)  = 0._r8
-    new_patch%leaf_litter_out(:) = 0._r8
-
-    new_patch%root_litter_in(:)  = 0._r8
-    new_patch%root_litter_out(:) = 0._r8
-
+ 
   end subroutine create_patch
 
   ! ============================================================================


### PR DESCRIPTION
The head of NCAR/fates-release (which had a flat non-history) was merged into the most similar commit hash, and resolved and then merged up to tag sci-1.3.0 api-1.0.0. This allows a unified history that both NCAR and NGEET can use for public releases.

Code review: performed initial merge and conflict resolution with @ckoven.

This merger effectively changes no code.
Tests were still run on cheyenne and all passed; including aux_clm45, see:

EDIT: see https://github.com/NGEET/fates-release/pull/1

