### PR TITLE
Bugfix to biomass calculation on inventory initialization

### DIFF
--- a/main/FatesInventoryInitMod.F90
+++ b/main/FatesInventoryInitMod.F90
@@ -862,8 +862,8 @@ contains
 
       temp_cohort%pft         = c_pft
       temp_cohort%n           = c_nplant * cpatch%area
-      temp_cohort%hite        = Hite(temp_cohort)
       temp_cohort%dbh         = c_dbh
+      temp_cohort%hite        = Hite(temp_cohort)
       temp_cohort%canopy_trim = 1.0_r8
       temp_cohort%bdead       = Bdead(temp_cohort)
       temp_cohort%balive      = Bleaf(temp_cohort)*(1.0_r8 + EDPftvarcon_inst%allom_l2fr(c_pft) &


### PR DESCRIPTION
I noticed that biomass is really low (~1 kg C / m2) during a test I did of the inventory initialization at BCI, even though basal area and other variables are reasonable.  I traced it down to a bug in the order of operations during the inventory initialization sequence: the allometry function Hite is called before the cohort's DBH is set to that of the inventory value, which means that the cohort's height is set based on the minimum cohort recruitment DBH.  Then the biomass allometry is called, and is using the short height.  So all the trees are stumpy and so have little biomass.  I changed the order of operations and the resulting biomass on the first timestep seems much more reasonable (~11 kg C/m2).

I haven't formally tested this yet because, as far as I know, there is no testing coverage of this code in the test suite.  But I confirm that it does actually work and produces a result that is different and more reasonable.