### PR TITLE
make some structured history variables default-on

### DIFF
--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -187,7 +187,7 @@ module FatesHistoryInterfaceMod
   integer, private :: ih_ddbh_canopy_si_scls
   integer, private :: ih_ddbh_understory_si_scls
   integer, private :: ih_agb_si_scls
-  integer, private :: ih_b_si_scls
+  integer, private :: ih_biomass_si_scls
 
   ! mortality vars
   integer, private :: ih_m1_si_scls
@@ -1232,7 +1232,7 @@ end subroutine flush_hvars
                hio_m7_si_scls          => this%hvars(ih_m7_si_scls)%r82d, &                  
                hio_ba_si_scls          => this%hvars(ih_ba_si_scls)%r82d, &
                hio_agb_si_scls          => this%hvars(ih_agb_si_scls)%r82d, &
-               hio_b_si_scls          => this%hvars(ih_b_si_scls)%r82d, &
+               hio_biomass_si_scls          => this%hvars(ih_biomass_si_scls)%r82d, &
                hio_nplant_si_scls         => this%hvars(ih_nplant_si_scls)%r82d, &
                hio_nplant_canopy_si_scls         => this%hvars(ih_nplant_canopy_si_scls)%r82d, &
                hio_nplant_understory_si_scls     => this%hvars(ih_nplant_understory_si_scls)%r82d, &
@@ -1513,7 +1513,7 @@ end subroutine flush_hvars
                     hio_agb_si_scls(io_si,scls) = hio_agb_si_scls(io_si,scls) + &
                          ccohort%b * ccohort%n * EDPftvarcon_inst%allom_agb_frac(ccohort%pft) * AREA_INV
 
-                    hio_b_si_scls(io_si,scls) = hio_b_si_scls(io_si,scls) + &
+                    hio_biomass_si_scls(io_si,scls) = hio_biomass_si_scls(io_si,scls) + &
                          ccohort%b * ccohort%n * AREA_INV
 
                     ! update size-class x patch-age related quantities
@@ -3399,7 +3399,7 @@ end subroutine flush_hvars
     call this%set_history_var(vname='BIOMASS_SCLS', units = 'kgC/m2',               &
           long='Total biomass by size class', use_default='inactive',   &
           avgflag='A', vtype=site_size_r8, hlms='CLM:ALM', flushval=0.0_r8,    &
-          upfreq=1, ivar=ivar, initialize=initialize_variables, index = ih_b_si_scls )
+          upfreq=1, ivar=ivar, initialize=initialize_variables, index = ih_biomass_si_scls )
 
     call this%set_history_var(vname='DEMOTION_RATE_SCLS', units = 'indiv/ha/yr',               &
           long='demotion rate from canopy to understory by size class', use_default='inactive',   &


### PR DESCRIPTION
This PR consists of some minor code changes that make a handful of the more generally useful structured history variables default-on.  Addresses #298. 

The complete list of structured history variables that are output by default now is below.  I didn't include any of the SCPF variables in the end because they can get large, so instead I took the relevant quantities that had only been on SCPF dimension (M1, etc) and made SCLS versions of them.

AGB_SCLS
BA_SCLS
DDBH_CANOPY_SCLS
DDBH_UNDERSTORY_SCLS
M1_SCLS
M2_SCLS
M3_SCLS
M4_SCLS
M5_SCLS
M6_SCLS
M7_SCLS
MORTALITY_CANOPY_SCLS
MORTALITY_UNDERSTORY_SCLS
NPLANT_SCLS
NPLANT_CANOPY_SCLS
NPLANT_UNDERSTORY_SCLS
NPLANT_SCAG
CANOPY_AREA_BY_AGE
LAI_BY_AGE
PATCH_AREA_BY_AGE

EDIT. Comparisons of 8d085c9 against baseline of 2c6e73c

```
fates-clm-tests/fates.cheyenne.intel.b753898_8d085c9> ./cs.status.1711271646 | grep FAIL
ERP_Ld3.f09_g16.ICLM45ED.cheyenne_intel.clm-FatesShortList (Overall: FAIL), details:
  FAIL ERP_Ld3.f09_g16.ICLM45ED.cheyenne_intel.clm-FatesShortList RUN time=102
ERP_Ld9.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesAllVars (Overall: FAIL), details:
  FAIL ERP_Ld9.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesAllVars COMPARE_base_rest
ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesFinif45 (Overall: FAIL), details:
  FAIL ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesFinif45 COMPARE_base_rest
ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesLogging (Overall: FAIL), details:
  FAIL ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesLogging COMPARE_base_rest
ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesPPhys (Overall: FAIL), details:
  FAIL ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesPPhys COMPARE_base_rest
ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesST3 (Overall: FAIL), details:
  FAIL ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesST3 COMPARE_base_rest
SMS_Lm6.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesFinif45 (Overall: FAIL), details:
  FAIL SMS_Lm6.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesFinif45 MEMLEAK memleak detected, memory went from 184.080000 to 249.820000 in 528 days
SMS_Ly2.1x1_brazil.ICLM45ED.cheyenne_intel.clm-FatesFini1x1br (Overall: FAIL), details:
  FAIL SMS_Ly2.1x1_brazil.ICLM45ED.cheyenne_intel.clm-FatesFini1x1br MEMLEAK memleak detected, memory went from 135.140000 to 156.010000 in 11129 days
```

EDIT.  I re-ran the one with the runtime fail above, and it now passes:
```
fates-clm-tests/fates.cheyenne.intel.b753898_8d085c9> ./cs.status.1711271646 | grep ERP_Ld3.f09_g16.ICLM45ED.cheyenne_intel.clm-FatesShortList
ERP_Ld3.f09_g16.ICLM45ED.cheyenne_intel.clm-FatesShortList (Overall: PASS), details:
  PASS ERP_Ld3.f09_g16.ICLM45ED.cheyenne_intel.clm-FatesShortList CREATE_NEWCASE
  PASS ERP_Ld3.f09_g16.ICLM45ED.cheyenne_intel.clm-FatesShortList XML
  PASS ERP_Ld3.f09_g16.ICLM45ED.cheyenne_intel.clm-FatesShortList SETUP
  PASS ERP_Ld3.f09_g16.ICLM45ED.cheyenne_intel.clm-FatesShortList SHAREDLIB_BUILD time=24
  PASS ERP_Ld3.f09_g16.ICLM45ED.cheyenne_intel.clm-FatesShortList NLCOMP
  PASS ERP_Ld3.f09_g16.ICLM45ED.cheyenne_intel.clm-FatesShortList MODEL_BUILD time=106
  PASS ERP_Ld3.f09_g16.ICLM45ED.cheyenne_intel.clm-FatesShortList RUN time=131
  PASS ERP_Ld3.f09_g16.ICLM45ED.cheyenne_intel.clm-FatesShortList COMPARE_base_rest
  PASS ERP_Ld3.f09_g16.ICLM45ED.cheyenne_intel.clm-FatesShortList GENERATE
  PASS ERP_Ld3.f09_g16.ICLM45ED.cheyenne_intel.clm-FatesShortList BASELINE
  PASS ERP_Ld3.f09_g16.ICLM45ED.cheyenne_intel.clm-FatesShortList TPUTCOMP
  PASS ERP_Ld3.f09_g16.ICLM45ED.cheyenne_intel.clm-FatesShortList MEMLEAK insuffiencient data for memleak test
```