### PR TITLE
Fixed uninitialized dhdd

### DIFF
--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -235,7 +235,7 @@ contains
     
     call bleaf(currentcohort%dbh,currentcohort%hite,ft,currentcohort%canopy_trim,tar_bl)
     call bfineroot(currentcohort%dbh,currentcohort%hite,ft,currentcohort%canopy_trim,tar_br)
-    call bsap_allom(currentcohort%dbh,currentcohort%hite,ft,currentcohort%canopy_trim,tar_bsw)
+    call bsap_allom(currentcohort%dbh,ft,currentcohort%canopy_trim,tar_bsw)
 
     leaf_frac = tar_bl/(tar_bl+tar_br+tar_bsw)
     bfr_per_leaf = tar_br/tar_bl

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -885,7 +885,7 @@ contains
     call bfineroot(currentCohort%dbh,currentCohort%hite,ipft,currentCohort%canopy_trim,b_fineroot)
     
     ! Calculate sapwood biomass
-    call bsap_allom(currentCohort%dbh,currentCohort%hite,ipft,currentCohort%canopy_trim,b_sap)
+    call bsap_allom(currentCohort%dbh,ipft,currentCohort%canopy_trim,b_sap)
 
     target_balive = b_leaf + b_fineroot + b_sap
 
@@ -1055,7 +1055,7 @@ contains
                   currentCohort%canopy_trim,b_leaf,db_leaf_dd)
        call bfineroot(currentCohort%dbh,currentCohort%hite,ipft, &
                       currentCohort%canopy_trim,b_fineroot,db_fineroot_dd)
-       call bsap_allom(currentCohort%dbh,currentCohort%hite,ipft, &
+       call bsap_allom(currentCohort%dbh,ipft, &
                        currentCohort%canopy_trim,b_sap,db_sap_dd)
 
        ! Total change in alive biomass relative to dead biomass [kgC/kgC]
@@ -1190,7 +1190,7 @@ contains
        ! Initialize balive (leaf+fineroot+sapwood)
        call bleaf(temp_cohort%dbh,temp_cohort%hite,ft,temp_cohort%canopy_trim,b_leaf)
        call bfineroot(temp_cohort%dbh,temp_cohort%hite,ft,temp_cohort%canopy_trim,b_fineroot)
-       call bsap_allom(temp_cohort%dbh,temp_cohort%hite,ft,temp_cohort%canopy_trim,b_sapwood)
+       call bsap_allom(temp_cohort%dbh,ft,temp_cohort%canopy_trim,b_sapwood)
 
        call bag_allom(temp_cohort%dbh,temp_cohort%hite,ft,b_aboveground)
        call bcr_allom(temp_cohort%dbh,temp_cohort%hite,ft,b_coarseroot)

--- a/biogeochem/FatesAllometryMod.F90
+++ b/biogeochem/FatesAllometryMod.F90
@@ -377,15 +377,15 @@ contains
   ! Generic sapwood biomass interface
   ! ============================================================================
 
-  subroutine bsap_allom(d,h,ipft,canopy_trim,bsap,dbsapdd)
+  subroutine bsap_allom(d,ipft,canopy_trim,bsap,dbsapdd)
     
     real(r8),intent(in)           :: d         ! plant diameter [cm]
-    real(r8),intent(in)           :: h         ! plant height   [m]
     integer(i4),intent(in)        :: ipft      ! PFT index
     real(r8),intent(in)           :: canopy_trim
     real(r8),intent(out)          :: bsap      ! plant leaf biomass [kgC]
     real(r8),intent(out),optional :: dbsapdd   ! change leaf bio per d [kgC/cm]
 
+    real(r8) :: h         ! Plant height [m]
     real(r8) :: dhdd
     real(r8) :: blmax
     real(r8) :: dblmaxdd
@@ -401,6 +401,7 @@ contains
        ! ---------------------------------------------------------------------
     case(1,2) !"constant","dlinear") 
 
+       call h_allom(d,ipft,h,dhdd)
        if(test_b4b)then
           call bleaf(d,h,ipft,canopy_trim,blmax,dblmaxdd)
        else

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -384,7 +384,7 @@ contains
        call bfineroot(temp_cohort%dbh,temp_cohort%hite,pft,temp_cohort%canopy_trim,b_fineroot)
 
        ! Calculate sapwood biomass
-       call bsap_allom(temp_cohort%dbh,temp_cohort%hite,pft,temp_cohort%canopy_trim,b_sapwood)
+       call bsap_allom(temp_cohort%dbh,pft,temp_cohort%canopy_trim,b_sapwood)
        
        temp_cohort%balive = b_leaf + b_fineroot + b_sapwood
 

--- a/main/FatesInventoryInitMod.F90
+++ b/main/FatesInventoryInitMod.F90
@@ -889,7 +889,7 @@ contains
       call bfineroot(temp_cohort%dbh,temp_cohort%hite,c_pft,temp_cohort%canopy_trim,b_fineroot)
       
       ! Calculate sapwood biomass
-      call bsap_allom(temp_cohort%dbh,temp_cohort%hite,c_pft,temp_cohort%canopy_trim,b_sapwood)
+      call bsap_allom(temp_cohort%dbh,c_pft,temp_cohort%canopy_trim,b_sapwood)
       
       temp_cohort%balive = b_leaf + b_fineroot + b_sapwood
       


### PR DESCRIPTION
The subroutine for sapwood allometry was using dhdd (change in height per change in diameter) to calculate change in sapwood per change in diameter.  dhdd was not being initialized, now it is.

Code review:
Test suite: fates test suite on cheyenne/intel
Base fates Hash: 9a436f6
Base fates-clm hash: b753898
Test namelist changes: none
Test answer changes: bug fix - should change answers
Test summary: Expected PASS, log:
```
./cs.status.20180118_132732_qvlg2q | grep FAIL
  FAIL ERP_Ld9.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesAllVars COMPARE_base_rest
  FAIL ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesFinif45 COMPARE_base_rest
  FAIL ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesLogging COMPARE_base_rest
  FAIL ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesPPhys COMPARE_base_rest
  FAIL ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesST3 COMPARE_base_rest
  FAIL SMS_Lm6.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesFinif45 MEMLEAK memleak detected,   FAIL SMS_Ly2.1x1_brazil.ICLM45ED.cheyenne_intel.clm-FatesFini1x1br MEMLEAK memleak detected, memory went from 135.140000 to 156.010000 in 11129 days

```
 