### PR TITLE
Fix to NPP partitioning bug

### DIFF
--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -1436,10 +1436,10 @@ end subroutine flush_hvars
                   associate( scpf => ccohort%size_by_pft_class, &
                              scls => ccohort%size_class )
 
-!                    hio_gpp_si_scpf(io_si,scpf)      = hio_gpp_si_scpf(io_si,scpf)      + &
-!                                                       n_perm2*ccohort%gpp_acc_hold  ! [kgC/m2/yr]
-!                    hio_npp_totl_si_scpf(io_si,scpf) = hio_npp_totl_si_scpf(io_si,scpf) + &
-!                                                       ccohort%npp_acc_hold *n_perm2
+                    hio_gpp_si_scpf(io_si,scpf)      = hio_gpp_si_scpf(io_si,scpf)      + &
+                                                       n_perm2*ccohort%gpp_acc_hold  ! [kgC/m2/yr]
+                    hio_npp_totl_si_scpf(io_si,scpf) = hio_npp_totl_si_scpf(io_si,scpf) + &
+                                                       ccohort%npp_acc_hold *n_perm2
 !                    hio_npp_leaf_si_scpf(io_si,scpf) = hio_npp_leaf_si_scpf(io_si,scpf) + &
 !                                                       ccohort%npp_leaf*n_perm2
 !                    hio_npp_fnrt_si_scpf(io_si,scpf) = hio_npp_fnrt_si_scpf(io_si,scpf) + &


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
This is a temporary fix to the bug that made it into master, see #325.  Diagnostics on the partitioning of NPP are not being calculated correctly, and a mass conservation check is causing tests to FAIL.  The proposed fix is to turn off this check, as the soon PR'd refactor of allocation makes this problem obsolete.

### Collaborators:
@ckoven 

### Expectation of Answer Changes:
Answers are not expected to change, although apparently, master was not completing its runs.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x ] I have updated the in-code documentation AND wiki accordingly.
- [x ] I have read the [**CONTRIBUTING**](https://github.com/rgknox/fates/blob/rgknox-new-PR-template/CONTRIBUTING.md) document.
- [x ] FATES PASS/FAIL regression tests were run
- [x] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

FATES-CLM (or) HLM test hash-tag: b753898

Regression tests pass expected:

Test Output:

```
clmed-tests/fates.cheyenne.intel.Cb753898-F38d2e83-npppartition-bugfix-v2> ./cs.status.20180125_154743_tups4k | grep FAIL
ERP_Ld9.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesAllVars (Overall: FAIL), details:
  FAIL ERP_Ld9.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesAllVars COMPARE_base_rest
ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesFinif45 (Overall: FAIL), details:
  FAIL ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesFinif45 COMPARE_base_rest
ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesLogging (Overall: FAIL), details:
  FAIL ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesLogging COMPARE_base_rest
ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesPPhys (Overall: FAIL), details:
  FAIL ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesPPhys COMPARE_base_rest
ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesST3 (Overall: FAIL), details:
  FAIL ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesST3 COMPARE_base_rest
SMS_Ly2.1x1_brazil.ICLM45ED.cheyenne_intel.clm-FatesFini1x1br (Overall: FAIL), details:
  FAIL SMS_Ly2.1x1_brazil.ICLM45ED.cheyenne_intel.clm-FatesFini1x1br MEMLEAK memleak detected, memory went from 135.150000 to 156.020000 in 11129 days


```

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 