### PR TITLE
Updates to modify_fates_paramfile python script

### DIFF
--- a/tools/modify_fates_paramfile.py
+++ b/tools/modify_fates_paramfile.py
@@ -42,68 +42,72 @@ def main():
     args = parser.parse_args()
     #
     # work with the file in some random temprary place so that if something goes wrong nothing happens to original file and it doesn't make an output file
-    tempfilename = os.path.join(tempfile.mkdtemp(), 'temp_fates_param_file.nc')
+    tempdir = tempfile.mkdtemp()
+    tempfilename = os.path.join(tempdir, 'temp_fates_param_file.nc')
     #
-    shutil.copyfile(args.inputfname, tempfilename)
-    #
-    ncfile = nc.netcdf_file(tempfilename, 'a')
-    #
-    var = ncfile.variables[args.varname]
-    #
-    ### check to make sure that, if a PFT is specified, the variable has a PFT dimension, and if not, then it doesn't. and also that shape is reasonable.
-    ndim_file = len(var.dimensions)
-    ispftvar = False
-    # for purposes of current stat eof this script, assume 1D 
-    if ndim_file > 1:
-        raise ValueError('variable dimensionality is too high for this script')
-    if ndim_file < 1:
-        raise ValueError('variable dimensionality is too low for this script. FATES assumes even scalars have a 1-length dimension')
-    for i in range(ndim_file):
-        if var.dimensions[i] == 'fates_pft':
-            ispftvar = True
-            npft_file = var.shape[i]
-            pftdim = 0
-        elif var.dimensions[i] == 'fates_scalar':
-            npft_file = None
-            pftdim = None
-        else:
-            raise ValueError('variable is not on either the PFT or scalar dimension')
-    if args.pftnum == None and ispftvar:
-        raise ValueError('pft value is missing but variable has pft dimension.')
-    if args.pftnum != None and not ispftvar:
-        raise ValueError('pft value is present but variable does not have pft dimension.')
-    if args.pftnum != None and ispftvar:
-        if args.pftnum > npft_file:
-            raise ValueError('PFT specified ('+str(args.pftnum)+') is larger than the number of PFTs in the file ('+str(npft_file)+').')
-        if pftdim == 0:
+    try:
+        shutil.copyfile(args.inputfname, tempfilename)
+        #
+        ncfile = nc.netcdf_file(tempfilename, 'a')
+        #
+        var = ncfile.variables[args.varname]
+        #
+        ### check to make sure that, if a PFT is specified, the variable has a PFT dimension, and if not, then it doesn't. and also that shape is reasonable.
+        ndim_file = len(var.dimensions)
+        ispftvar = False
+        # for purposes of current stat eof this script, assume 1D 
+        if ndim_file > 1:
+            raise ValueError('variable dimensionality is too high for this script')
+        if ndim_file < 1:
+            raise ValueError('variable dimensionality is too low for this script. FATES assumes even scalars have a 1-length dimension')
+        for i in range(ndim_file):
+            if var.dimensions[i] == 'fates_pft':
+                ispftvar = True
+                npft_file = var.shape[i]
+                pftdim = 0
+            elif var.dimensions[i] == 'fates_scalar':
+                npft_file = None
+                pftdim = None
+            else:
+                raise ValueError('variable is not on either the PFT or scalar dimension')
+        if args.pftnum == None and ispftvar:
+            raise ValueError('pft value is missing but variable has pft dimension.')
+        if args.pftnum != None and not ispftvar:
+            raise ValueError('pft value is present but variable does not have pft dimension.')
+        if args.pftnum != None and ispftvar:
+            if args.pftnum > npft_file:
+                raise ValueError('PFT specified ('+str(args.pftnum)+') is larger than the number of PFTs in the file ('+str(npft_file)+').')
+            if pftdim == 0:
+                if not args.silent:
+                    print('replacing prior value of variable '+args.varname+', for PFT '+str(args.pftnum)+', which was '+str(var[args.pftnum-1])+', with new value of '+str(args.val))
+                var[args.pftnum-1] = args.val
+        elif args.pftnum == None and not ispftvar:
             if not args.silent:
-                print('replacing prior value of variable '+args.varname+', for PFT '+str(args.pftnum)+', which was '+str(var[args.pftnum-1])+', with new value of '+str(args.val))
-            var[args.pftnum-1] = args.val
-    elif args.pftnum == None and not ispftvar:
-        if not args.silent:
-            print('replacing prior value of variable '+args.varname+', which was '+str(var[:])+', with new value of '+str(args.val))
-        var[:] = args.val
-    else:
-        raise ValueError('Nothing happened somehow.')
-    #
-    #
-    ncfile.close()
-    #
-    #
-    # now move file from temprary location to final location
-    #
-    # check to see if output file exists
-    if os.path.isfile(args.outputfname):
-        if args.overwrite:
-            if not args.silent:
-                print('replacing file: '+args.outputfname)
-            os.remove(args.outputfname)
+                print('replacing prior value of variable '+args.varname+', which was '+str(var[:])+', with new value of '+str(args.val))
+            var[:] = args.val
         else:
-            raise ValueError('Output file already exists and overwrite flag not specified for filename: '+args.outputfname)
-    #
-    shutil.move(tempfilename, args.outputfname)
-
-
+            raise ValueError('Nothing happened somehow.')
+        #
+        #
+        ncfile.close()
+        #
+        #
+        # now move file from temprary location to final location
+        #
+        # check to see if output file exists
+        if os.path.isfile(args.outputfname):
+            if args.overwrite:
+                if not args.silent:
+                    print('replacing file: '+args.outputfname)
+                os.remove(args.outputfname)
+            else:
+                raise ValueError('Output file already exists and overwrite flag not specified for filename: '+args.outputfname)
+        #
+        shutil.move(tempfilename, args.outputfname)
+        shutil.rmtree(tempdir, ignore_errors=True)
+    except:
+        shutil.rmtree(tempdir, ignore_errors=True)
+        raise
 
 
 # =======================================================================================


### PR DESCRIPTION
Some updates / fixes to modify_fates_paramfile.py script

### Description:
A couple fixes/ improvements to modify_fates_paramfile.py.
(1) uses a temporary file so that if something goes wrong during the process the outcome is that no changes are made to any of the files that were initially present.
(2) fixed the logic for scalar parameters; FATES expectation is that they aren't actually scalars but arrays of length 1 and now the tool expects that as well.

### Collaborators:
n/a

### Expectation of Answer Changes:
None, python tool changes only.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [X ] I have updated the in-code documentation AND wiki accordingly.
- [ X] I have read the [**CONTRIBUTING**](https://github.com/rgknox/fates/blob/rgknox-new-PR-template/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
N/A: changes only to python tool so no testing needed
