### PR TITLE
Including cold stress/frost mortality #212

### DIFF
--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -436,7 +436,7 @@ contains
     currentCohort%root_md            = nan ! root  maintenance demand: kgC/indiv/year
     currentCohort%carbon_balance     = nan ! carbon remaining for growth and storage: kg/indiv/year
     currentCohort%dmort              = nan ! proportional mortality rate. (year-1)
-    currentCohort%lmort_logging      = nan
+    currentCohort%lmort_direct       = nan
     currentCohort%lmort_infra        = nan
     currentCohort%lmort_collateral   = nan
 
@@ -514,7 +514,7 @@ contains
     currentcohort%dmort              = 0._r8 
     currentcohort%gscan              = 0._r8 
     currentcohort%treesai            = 0._r8  
-    currentCohort%lmort_logging      = 0._r8
+    currentCohort%lmort_direct       = 0._r8
     currentCohort%lmort_infra        = 0._r8
     currentCohort%lmort_collateral   = 0._r8
     !    currentCohort%npp_leaf  = 0._r8
@@ -866,8 +866,8 @@ contains
 
                                    currentCohort%dmort          = (currentCohort%n*currentCohort%dmort       + &
                                          nextc%n*nextc%dmort)/newn
-                                   currentCohort%lmort_logging          = (currentCohort%n*currentCohort%lmort_logging       + &
-                                         nextc%n*nextc%lmort_logging)/newn
+                                   currentCohort%lmort_direct         = (currentCohort%n*currentCohort%lmort_direct       + &
+                                         nextc%n*nextc%lmort_direct)/newn
                                    currentCohort%lmort_infra          = (currentCohort%n*currentCohort%lmort_infra       + &
                                          nextc%n*nextc%lmort_infra)/newn
                                    currentCohort%lmort_collateral          = (currentCohort%n*currentCohort%lmort_collateral + &
@@ -886,8 +886,8 @@ contains
                                    currentCohort%frmort = (currentCohort%n*currentCohort%frmort + nextc%n*nextc%frmort)/newn
 
                                    ! logging mortality, Yi Xu
-                                   currentCohort%lmort_logging = (currentCohort%n*currentCohort%lmort_logging + &
-                                         nextc%n*nextc%lmort_logging)/newn
+                                   currentCohort%lmort_direct = (currentCohort%n*currentCohort%lmort_direct + &
+                                         nextc%n*nextc%lmort_direct)/newn
                                    currentCohort%lmort_collateral = (currentCohort%n*currentCohort%lmort_collateral + &
                                          nextc%n*nextc%lmort_collateral)/newn
                                    currentCohort%lmort_infra = (currentCohort%n*currentCohort%lmort_infra + &
@@ -1260,7 +1260,7 @@ contains
     n%root_md         = o%root_md
     n%carbon_balance  = o%carbon_balance
     n%dmort           = o%dmort
-    n%lmort_logging   = o%lmort_logging
+    n%lmort_direct    = o%lmort_direct
     n%lmort_infra     = o%lmort_infra
     n%lmort_collateral= o%lmort_collateral
     n%seed_prod       = o%seed_prod
@@ -1278,7 +1278,7 @@ contains
     n%frmort = o%frmort
 
     ! logging mortalities, Yi Xu
-    n%lmort_logging=o%lmort_logging
+    n%lmort_direct=o%lmort_direct
     n%lmort_collateral =o%lmort_collateral
     n%lmort_infra =o%lmort_infra
 

--- a/biogeochem/EDLoggingMortalityMod.F90
+++ b/biogeochem/EDLoggingMortalityMod.F90
@@ -3,15 +3,16 @@ module EDLoggingMortalityMod
 
    ! ====================================================================================
    !  Purpose: 1. create logging mortalities: 
-   !           (a)logging mortality (cohort level)
-   !           (b)collateral mortality (cohort level)
-   !           (c)infrastructure mortality (cohort level)
+   !           (a) direct logging mortality (cohort level)
+   !           (b) collateral mortality (cohort level)
+   !           (c) infrastructure mortality (cohort level)
    !           2. move the logged trunk fluxes from live into product pool 
    !           3. move logging-associated mortality fluxes from live to CWD
    !           4. keep carbon balance (in ed_total_balance_check)
    !
-   !  Yi Xu
-   !  Date: 2017
+   !  Yi Xu & M.Huang
+   !  Date: 09/2017
+   !  Last updated: 10/2017
    ! ====================================================================================
 
    use FatesConstantsMod , only : r8 => fates_r8
@@ -29,7 +30,7 @@ module EDLoggingMortalityMod
    use EDParamsMod       , only : logging_collateral_frac 
    use EDParamsMod       , only : logging_direct_frac
    use EDParamsMod       , only : logging_mechanical_frac 
-   use EDParamsMod       , only : ED_val_understorey_death
+   use EDParamsMod       , only : logging_coll_under_frac 
    use FatesInterfaceMod , only : hlm_current_year
    use FatesInterfaceMod , only : hlm_current_month
    use FatesInterfaceMod , only : hlm_current_day
@@ -142,44 +143,49 @@ contains
 
    ! ======================================================================================
 
-   subroutine LoggingMortality_frac( pft_i, dbh, lmort_logging,lmort_collateral,lmort_infra )
+   subroutine LoggingMortality_frac( pft_i, dbh, lmort_direct,lmort_collateral,lmort_infra )
 
       ! Arguments
       integer,  intent(in)  :: pft_i            ! pft index 
       real(r8), intent(in)  :: dbh              ! diameter at breast height (cm)
-      real(r8), intent(out) :: lmort_logging    ! direct (harvestable) mortality fraction
+      real(r8), intent(out) :: lmort_direct     ! direct (harvestable) mortality fraction
       real(r8), intent(out) :: lmort_collateral ! collateral damage mortality fraction
       real(r8), intent(out) :: lmort_infra      ! infrastructure mortality fraction
 
       ! Parameters
       real(r8), parameter   :: adjustment = 1.0 ! adjustment for mortality rates
-
+      real(r8), parameter   :: logging_dbhmax_infra = 35 !(cm), based on Feldpaush et al. (2005) and Ferry et al. (2010)
+ 
       if (logging_time) then 
          if(EDPftvarcon_inst%woody(pft_i) == 1)then ! only set logging rates for trees
 
             ! Pass logging rates to cohort level 
 
             if (dbh >= logging_dbhmin ) then
-               lmort_logging = logging_direct_frac * adjustment
+               lmort_direct = logging_direct_frac * adjustment
                lmort_collateral = logging_collateral_frac * adjustment
             else
-               lmort_logging = 0.0_r8 
+               lmort_direct = 0.0_r8 
                lmort_collateral = 0.0_r8
             end if
            
-            lmort_infra      = logging_mechanical_frac * adjustment
+            if (dbh >= logging_dbhmax_infra) then
+               lmort_infra      = 0.0_r8
+            else
+               lmort_infra      = logging_mechanical_frac * adjustment
+            end if
             !damage rates for size class < & > threshold_size need to be specified seperately
 
             ! Collateral damage to smaller plants below the direct logging size threshold
             ! will be applied via "understory_death" via the disturbance algorithm
 
          else
-            lmort_logging    = 0.0_r8
+            lmort_direct    = 0.0_r8
             lmort_collateral = 0.0_r8
             lmort_infra      = 0.0_r8
          end if
       else 
-         lmort_logging    = 0.0_r8
+         lmort_direct    = 0.0_r8
          lmort_collateral = 0.0_r8
          lmort_infra      = 0.0_r8
       end if
@@ -269,14 +275,14 @@ contains
          
         
          if(currentCohort%canopy_layer == 1)then         
-            direct_dead   = currentCohort%n * currentCohort%lmort_logging
+            direct_dead   = currentCohort%n * currentCohort%lmort_direct
             indirect_dead = currentCohort%n * &
                   (currentCohort%lmort_collateral + currentCohort%lmort_infra)
 
          else
             if(EDPftvarcon_inst%woody(currentCohort%pft) == 1)then
                direct_dead   = 0.0_r8
-               indirect_dead = ED_val_understorey_death * currentCohort%n * &
+               indirect_dead = logging_coll_under_frac * currentCohort%n * &
                      (patch_site_areadis/currentPatch%area)  !kgC/site/day
             else
                ! If the cohort of interest is grass, it will not experience

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -75,9 +75,9 @@ contains
     ! be one disturbance type for each timestep.  
     ! all disturbance rates here are per daily timestep. 
     
-	! 2016-2017
-	! Modify to add logging disturbance
-	
+    ! 2016-2017
+    ! Modify to add logging disturbance
+
     ! !USES:
     use EDMortalityFunctionsMod , only : mortality_rates
     ! loging flux
@@ -97,7 +97,7 @@ contains
     real(r8) :: hmort
     real(r8) :: frmort
 
-    real(r8) :: lmort_logging
+    real(r8) :: lmort_direct
     real(r8) :: lmort_collateral
     real(r8) :: lmort_infra
 
@@ -128,9 +128,9 @@ contains
           currentCohort%fmort = 0.0_r8 ! Fire mortality is initialized as zero, but may be changed
 
           call LoggingMortality_frac(currentCohort%pft, currentCohort%dbh, &
-                lmort_logging,lmort_collateral,lmort_infra )
+                lmort_direct,lmort_collateral,lmort_infra )
          
-          currentCohort%lmort_logging    = lmort_logging
+          currentCohort%lmort_direct    = lmort_direct
           currentCohort%lmort_collateral = lmort_collateral
           currentCohort%lmort_infra      = lmort_infra
 
@@ -162,7 +162,7 @@ contains
 
              ! Logging Disturbance Rate
              currentPatch%disturbance_rates(dtype_ilog) = currentPatch%disturbance_rates(dtype_ilog) + &
-                   min(1.0_r8, currentCohort%lmort_logging +                         & 
+                   min(1.0_r8, currentCohort%lmort_direct +                         & 
                                currentCohort%lmort_collateral +                      &
                                currentCohort%lmort_infra ) *                         &
                                currentCohort%c_area/currentPatch%area
@@ -226,7 +226,7 @@ contains
                 currentCohort%bmort = currentCohort%bmort*(1.0_r8 - fates_mortality_disturbance_fraction)
                 currentCohort%dmort = currentCohort%dmort*(1.0_r8 - fates_mortality_disturbance_fraction)
                 currentCohort%frmort = currentCohort%frmort*(1.0_r8 - fates_mortality_disturbance_fraction)
-                currentCohort%lmort_logging    = 0.0_r8
+                currentCohort%lmort_direct    = 0.0_r8
                 currentCohort%lmort_collateral = 0.0_r8
                 currentCohort%lmort_infra      = 0.0_r8
              end if
@@ -249,7 +249,7 @@ contains
           currentCohort => currentPatch%shortest
           do while(associated(currentCohort))
              if(currentCohort%canopy_layer == 1)then
-                currentCohort%lmort_logging    = 0.0_r8
+                currentCohort%lmort_direct    = 0.0_r8
                 currentCohort%lmort_collateral = 0.0_r8
                 currentCohort%lmort_infra      = 0.0_r8
                 currentCohort%fmort            = 0.0_r8
@@ -284,7 +284,7 @@ contains
     !
     ! !USES:
     
-    use EDParamsMod         , only : ED_val_understorey_death
+    use EDParamsMod         , only : ED_val_understorey_death, logging_coll_under_frac
     use EDCohortDynamicsMod , only : zero_cohort, copy_cohort, terminate_cohorts 
 
     !
@@ -408,7 +408,7 @@ contains
                    nc%bmort = nan
                    nc%fmort = nan
                    nc%frmort = nan
-                   nc%lmort_logging    = nan
+                   nc%lmort_direct     = nan
                    nc%lmort_collateral = nan
                    nc%lmort_infra      = nan
 
@@ -452,7 +452,7 @@ contains
                       nc%bmort            = currentCohort%bmort
                       nc%frmort           = currentCohort%frmort
                       nc%dmort            = currentCohort%dmort
-                      nc%lmort_logging    = currentCohort%lmort_logging
+                      nc%lmort_direct     = currentCohort%lmort_direct
                       nc%lmort_collateral = currentCohort%lmort_collateral
                       nc%lmort_infra      = currentCohort%lmort_infra
 
@@ -477,7 +477,7 @@ contains
                       nc%bmort            = currentCohort%bmort
                       nc%frmort           = currentCohort%frmort
                       nc%dmort            = currentCohort%dmort
-                      nc%lmort_logging    = currentCohort%lmort_logging
+                      nc%lmort_direct    = currentCohort%lmort_direct
                       nc%lmort_collateral = currentCohort%lmort_collateral
                       nc%lmort_infra      = currentCohort%lmort_infra
                       
@@ -504,7 +504,7 @@ contains
                 nc%bmort            = currentCohort%bmort
                 nc%frmort           = currentCohort%frmort
                 nc%dmort            = currentCohort%dmort
-                nc%lmort_logging    = currentCohort%lmort_logging
+                nc%lmort_direct     = currentCohort%lmort_direct
                 nc%lmort_collateral = currentCohort%lmort_collateral
                 nc%lmort_infra      = currentCohort%lmort_infra
                 
@@ -519,7 +519,7 @@ contains
                    nc%n            = 0.0_r8 
 
                    ! Reduce counts in the existing/donor patch according to the logging rate
-                   currentCohort%n = currentCohort%n * (1.0_r8 - min(1.0_r8,(currentCohort%lmort_logging +    &
+                   currentCohort%n = currentCohort%n * (1.0_r8 - min(1.0_r8,(currentCohort%lmort_direct +    &
                                                                              currentCohort%lmort_collateral + &
                                                                              currentCohort%lmort_infra)))
 
@@ -529,7 +529,7 @@ contains
                    nc%bmort            = nan
                    nc%frmort           = nan
                    nc%fmort            = nan
-                   nc%lmort_logging    = nan
+                   nc%lmort_direct     = nan
                    nc%lmort_collateral = nan
                    nc%lmort_infra      = nan
 
@@ -553,30 +553,29 @@ contains
                       ! the number density.
                       currentSite%imort_rate(currentCohort%size_class, currentCohort%pft) = &
                            currentSite%imort_rate(currentCohort%size_class, currentCohort%pft) + &
-                           nc%n * ED_val_understorey_death / hlm_freq_day
+                           nc%n * logging_coll_under_frac / hlm_freq_day
                       currentSite%imort_carbonflux = currentSite%imort_carbonflux + &
-                           (nc%n * ED_val_understorey_death / hlm_freq_day ) * &
+                           (nc%n * logging_coll_under_frac/ hlm_freq_day ) * &
                            currentCohort%b * g_per_kg * days_per_sec * years_per_day * ha_per_m2
                       
                       ! Step 2:  Apply survivor ship function based on the understory death fraction
                      
                       ! remaining of understory plants of those that are knocked over by the overstorey trees dying...  
-                      ! CURRENTLY ASSUMING THAT LOGGING SURVIVORSHIP OF UNDERSTORY PLANTS IS SAME AS NATURAL
-                      ! TREEFALL (STILL BEING DISCUSSED)
-                      nc%n = nc%n * (1.0_r8 - ED_val_understorey_death)
+                      ! LOGGING SURVIVORSHIP OF UNDERSTORY PLANTS IS SET AS A NEW PARAMETER in the fatesparameter files 
+                      nc%n = nc%n * (1.0_r8 - logging_coll_under_frac)
 
                       ! Step 3: Reduce the number count of cohorts in the original/donor/non-disturbed patch 
                       !         to reflect the area change
                       currentCohort%n = currentCohort%n * (1._r8 -  patch_site_areadis/currentPatch%area)
 
 
-                      nc%fmort = 0.0_r8
+                      nc%fmort            = 0.0_r8
                       nc%cmort            = currentCohort%cmort
                       nc%hmort            = currentCohort%hmort
                       nc%bmort            = currentCohort%bmort
                       nc%frmort           = currentCohort%frmort
                       nc%dmort            = currentCohort%dmort
-                      nc%lmort_logging    = currentCohort%lmort_logging
+                      nc%lmort_direct     = currentCohort%lmort_direct
                       nc%lmort_collateral = currentCohort%lmort_collateral
                       nc%lmort_infra      = currentCohort%lmort_infra
 
@@ -596,7 +595,7 @@ contains
                       nc%bmort            = currentCohort%bmort
                       nc%frmort           = currentCohort%frmort
                       nc%dmort            = currentCohort%dmort
-                      nc%lmort_logging    = currentCohort%lmort_logging
+                      nc%lmort_direct    = currentCohort%lmort_direct
                       nc%lmort_collateral = currentCohort%lmort_collateral
                       nc%lmort_infra      = currentCohort%lmort_infra
                       

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -815,7 +815,7 @@ contains
     real(r8) :: hmort    ! hydraulic failure mortality rate (fraction per year)
     real(r8) :: frmort   ! freezing tolerance  mortality rate (fraction per year)
 
-    real(r8) :: lmort_logging     ! Mortality fraction associated with direct logging
+    real(r8) :: lmort_direct      ! Mortality fraction associated with direct logging
     real(r8) :: lmort_collateral  ! Mortality fraction associated with logging collateral damage
     real(r8) :: lmort_infra       ! Mortality fraction associated with logging infrastructure
     real(r8) :: dndt_logging      ! Mortality rate (per day) associated with the a logging event
@@ -846,18 +846,19 @@ contains
     ipft = currentCohort%pft
 
     ! Mortality for trees in the understorey. 
-    !if trees are in the canopy, then their death is 'disturbance'. This probably needs a different terminology
+    ! if trees are in the canopy, then their death is 'disturbance'. This probably needs a different terminology
 
     call mortality_rates(currentCohort,bc_in,cmort,hmort,bmort,frmort)
+
     call LoggingMortality_frac(ipft, currentCohort%dbh, &
-                               currentCohort%lmort_logging,                       &
-                               currentCohort%lmort_collateral,                    &
+                               currentCohort%lmort_direct,           &
+                               currentCohort%lmort_collateral,       &
                                currentCohort%lmort_infra )
 
     if (currentCohort%canopy_layer > 1)then 
        
        ! Include understory logging mortality rates not associated with disturbance
-       dndt_logging = (currentCohort%lmort_logging    + &
+       dndt_logging = (currentCohort%lmort_direct    + &
                        currentCohort%lmort_collateral + &
                        currentCohort%lmort_infra)/hlm_freq_day
 
@@ -1308,7 +1309,7 @@ contains
 
           ! Total number of dead understory from direct logging
           ! (it is possible that large harvestable trees are in the understory)
-          dead_n_dlogging = ( currentCohort%lmort_logging) * &
+          dead_n_dlogging = ( currentCohort%lmort_direct) * &
                 currentCohort%n/hlm_freq_day/currentPatch%area
           
           ! Total number of dead understory from indirect logging

--- a/main/EDParamsMod.F90
+++ b/main/EDParamsMod.F90
@@ -444,6 +444,7 @@ contains
         write(fates_log(),fmt0) 'hydr_psicap = ',hydr_psicap
         write(fates_log(),fmt0) 'logging_dbhmin = ',logging_dbhmin
         write(fates_log(),fmt0) 'logging_collateral_frac = ',logging_collateral_frac
+        write(fates_log(),fmt0) 'logging_coll_under_frac = ',logging_coll_under_frac
         write(fates_log(),fmt0) 'logging_direct_frac = ',logging_direct_frac
         write(fates_log(),fmt0) 'logging_mechanical_frac = ',logging_mechanical_frac
         write(fates_log(),fmt0) 'logging_event_code = ',logging_event_code

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -222,11 +222,10 @@ module EDTypesMod
      real(r8) ::  frmort                                 ! freezing mortality               n/year
 
       ! Logging Mortality Rate 
-	 ! Yi Xu
-     real(r8) ::  lmort_logging                          ! directly logging rate            %/per logging activity
+      ! Yi Xu & M. Huang
+     real(r8) ::  lmort_direct                           ! directly logging rate            %/per logging activity
      real(r8) ::  lmort_collateral                       ! collaterally damaged rate        %/per logging activity
      real(r8) ::  lmort_infra                            ! mechanically damaged rate        %/per logging activity
-	      
 
      ! NITROGEN POOLS      
      ! ----------------------------------------------------------------------------------

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -1492,9 +1492,8 @@ end subroutine flush_hvars
                        hio_m2_si_scpf(io_si,scpf) = hio_m2_si_scpf(io_si,scpf) + ccohort%hmort*ccohort%n
                        hio_m3_si_scpf(io_si,scpf) = hio_m3_si_scpf(io_si,scpf) + ccohort%cmort*ccohort%n
                        hio_m5_si_scpf(io_si,scpf) = hio_m5_si_scpf(io_si,scpf) + ccohort%fmort*ccohort%n
-
-		       hio_m7_si_scpf(io_si,scpf) = hio_m7_si_scpf(io_si,scpf) + &
-		       	    (ccohort%lmort_logging+ccohort%lmort_collateral+ccohort%lmort_infra) * ccohort%n
+                       hio_m7_si_scpf(io_si,scpf) = hio_m7_si_scpf(io_si,scpf) + &
+                            (ccohort%lmort_direct+ccohort%lmort_collateral+ccohort%lmort_infra) * ccohort%n
                        hio_m8_si_scpf(io_si,scpf) = hio_m8_si_scpf(io_si,scpf) + ccohort%frmort*ccohort%n
 
                        hio_m1_si_scls(io_si,scls) = hio_m1_si_scls(io_si,scls) + ccohort%bmort*ccohort%n
@@ -1502,7 +1501,7 @@ end subroutine flush_hvars
                        hio_m3_si_scls(io_si,scls) = hio_m3_si_scls(io_si,scls) + ccohort%cmort*ccohort%n
                        hio_m5_si_scls(io_si,scls) = hio_m5_si_scls(io_si,scls) + ccohort%fmort*ccohort%n
 		       hio_m7_si_scls(io_si,scls) = hio_m7_si_scls(io_si,scls) + &
-		       	    (ccohort%lmort_logging+ccohort%lmort_collateral+ccohort%lmort_infra) * ccohort%n
+                             (ccohort%lmort_direct+ccohort%lmort_collateral+ccohort%lmort_infra) * ccohort%n
                        hio_m8_si_scls(io_si,scls) = hio_m8_si_scls(io_si,scls) + &
                              + ccohort%frmort*ccohort%n
 
@@ -1553,9 +1552,8 @@ end subroutine flush_hvars
 
                        hio_mortality_canopy_si_scpf(io_si,scpf) = hio_mortality_canopy_si_scpf(io_si,scpf)+ &
                             (ccohort%bmort + ccohort%hmort + ccohort%cmort + ccohort%fmort + ccohort%frmort) * ccohort%n + &
-			    (ccohort%lmort_logging + ccohort%lmort_collateral + ccohort%lmort_infra) * &
+			    (ccohort%lmort_direct + ccohort%lmort_collateral + ccohort%lmort_infra) * &
                             ccohort%n * sec_per_day * days_per_year
-                        
 
                        hio_nplant_canopy_si_scpf(io_si,scpf) = hio_nplant_canopy_si_scpf(io_si,scpf) + ccohort%n
                        hio_nplant_canopy_si_scls(io_si,scls) = hio_nplant_canopy_si_scls(io_si,scls) + ccohort%n
@@ -1575,14 +1573,14 @@ end subroutine flush_hvars
 
                        ! sum of all mortality
                        hio_mortality_canopy_si_scls(io_si,scls) = hio_mortality_canopy_si_scls(io_si,scls) + &
-                             (ccohort%bmort + ccohort%hmort + ccohort%cmort  + ccohort%fmort + ccohort%frmort) * ccohort%n + &
-                             (ccohort%lmort_logging + ccohort%lmort_collateral + ccohort%lmort_infra) * &
+                             (ccohort%bmort + ccohort%hmort + ccohort%cmort  + ccohort%fmort + ccohort%frmort ) * ccohort%n + &
+                             (ccohort%lmort_direct + ccohort%lmort_collateral + ccohort%lmort_infra) * &
                              ccohort%n * sec_per_day * days_per_year
 
                        hio_canopy_mortality_carbonflux_si(io_si) = hio_canopy_mortality_carbonflux_si(io_si) + &
                             (ccohort%bmort + ccohort%hmort + ccohort%cmort + ccohort%fmort + ccohort%frmort) * &
                             ccohort%b * ccohort%n * g_per_kg * days_per_sec * years_per_day * ha_per_m2 + &
-                            (ccohort%lmort_logging + ccohort%lmort_collateral + ccohort%lmort_infra)* ccohort%b * &
+                            (ccohort%lmort_direct + ccohort%lmort_collateral + ccohort%lmort_infra)* ccohort%b * &
                             ccohort%n * g_per_kg * ha_per_m2
                        
                        hio_leaf_md_canopy_si_scls(io_si,scls) = hio_leaf_md_canopy_si_scls(io_si,scls) + &
@@ -1632,8 +1630,8 @@ end subroutine flush_hvars
                         !    (ccohort%bmort + ccohort%hmort + ccohort%cmort + ccohort%fmort + ccohort%frmort) * ccohort%n
 
                        hio_mortality_understory_si_scpf(io_si,scpf) = hio_mortality_understory_si_scpf(io_si,scpf)+ &
-                            (ccohort%bmort + ccohort%hmort + ccohort%cmort + ccohort%fmort + ccohort%frmort) * ccohort%n + &
-			    (ccohort%lmort_logging + ccohort%lmort_collateral + ccohort%lmort_infra) * &
+                            (ccohort%bmort + ccohort%hmort + ccohort%cmort + ccohort%fmort + ccohort%frmort ) * ccohort%n + &
+			    (ccohort%lmort_direct + ccohort%lmort_collateral + ccohort%lmort_infra) * &
                             ccohort%n * sec_per_day * days_per_year
 
                        hio_nplant_understory_si_scpf(io_si,scpf) = hio_nplant_understory_si_scpf(io_si,scpf) + ccohort%n
@@ -1655,14 +1653,14 @@ end subroutine flush_hvars
 
                        ! sum of all mortality
                        hio_mortality_understory_si_scls(io_si,scls) = hio_mortality_understory_si_scls(io_si,scls) + &
-                             (ccohort%bmort + ccohort%hmort + ccohort%cmort + ccohort%fmort + ccohort%frmort) * ccohort%n + &
-                             (ccohort%lmort_logging + ccohort%lmort_collateral + ccohort%lmort_infra) * &
+                             (ccohort%bmort + ccohort%hmort + ccohort%cmort + ccohort%fmort + ccohort%frmort ) * ccohort%n + &
+                             (ccohort%lmort_direct + ccohort%lmort_collateral + ccohort%lmort_infra) * &
                              ccohort%n * sec_per_day * days_per_year
                        
                        hio_understory_mortality_carbonflux_si(io_si) = hio_understory_mortality_carbonflux_si(io_si) + &
                              (ccohort%bmort + ccohort%hmort + ccohort%cmort + ccohort%fmort + ccohort%frmort) * &
                              ccohort%b * ccohort%n * g_per_kg * days_per_sec * years_per_day * ha_per_m2 + &
-                             (ccohort%lmort_logging + ccohort%lmort_collateral + ccohort%lmort_infra) * ccohort%b * &
+                             (ccohort%lmort_direct + ccohort%lmort_collateral + ccohort%lmort_infra) * ccohort%b * &
                              ccohort%n * g_per_kg * ha_per_m2
                        !
                        hio_leaf_md_understory_si_scls(io_si,scls) = hio_leaf_md_understory_si_scls(io_si,scls) + &

--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -102,7 +102,7 @@ module FatesRestartInterfaceMod
   integer, private :: ir_frmort_co
 
    !Logging
-  integer, private :: ir_lmort_logging_co
+  integer, private :: ir_lmort_direct_co
   integer, private :: ir_lmort_collateral_co
   integer, private :: ir_lmort_infra_co
 
@@ -749,10 +749,10 @@ contains
          units='/year', flushval = flushzero, &
          hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_frmort_co )
 
-    call this%set_restart_var(vname='fates_lmort_logging', vtype=cohort_r8, &
+    call this%set_restart_var(vname='fates_lmort_direct', vtype=cohort_r8, &
          long_name='ed cohort - directly logging mortality rate', &
          units='%/event', flushval = flushzero, &
-         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_lmort_logging_co )
+         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_lmort_direct_co )
 
     call this%set_restart_var(vname='fates_lmort_collateral', vtype=cohort_r8, &
          long_name='ed cohort - collateral mortality rate', &
@@ -1061,13 +1061,9 @@ contains
            rio_cmort_co                => this%rvars(ir_cmort_co)%r81d, &
            rio_fmort_co                => this%rvars(ir_fmort_co)%r81d, &
            rio_frmort_co               => this%rvars(ir_frmort_co)%r81d, &
-
-
-	   rio_lmort_logging_co                => this%rvars(ir_lmort_logging_co)%r81d, &
-	   rio_lmort_collateral_co              => this%rvars(ir_lmort_collateral_co)%r81d, &
-	   rio_lmort_infra_co                => this%rvars(ir_lmort_infra_co)%r81d, &
-
-
+           rio_lmort_direct_co         => this%rvars(ir_lmort_direct_co)%r81d, &
+           rio_lmort_collateral_co     => this%rvars(ir_lmort_collateral_co)%r81d, &
+           rio_lmort_infra_co          => this%rvars(ir_lmort_infra_co)%r81d, &
            rio_ddbhdt_co               => this%rvars(ir_ddbhdt_co)%r81d, &
            rio_dbalivedt_co            => this%rvars(ir_dbalivedt_co)%r81d, &
            rio_dbdeaddt_co             => this%rvars(ir_dbdeaddt_co)%r81d, &
@@ -1184,11 +1180,9 @@ contains
                 rio_frmort_co(io_idx_co)       = ccohort%frmort                
 
                 !Logging
-	        rio_lmort_logging_co(io_idx_co)        = ccohort%lmort_logging
-	        rio_lmort_collateral_co(io_idx_co)     = ccohort%lmort_collateral
-	        rio_lmort_infra_co(io_idx_co)        = ccohort%lmort_infra
-
-
+                rio_lmort_direct_co(io_idx_co)       = ccohort%lmort_direct
+                rio_lmort_collateral_co(io_idx_co)   = ccohort%lmort_collateral
+                rio_lmort_infra_co(io_idx_co)        = ccohort%lmort_infra
 
                 rio_ddbhdt_co(io_idx_co)       = ccohort%ddbhdt
                 rio_dbalivedt_co(io_idx_co)    = ccohort%dbalivedt
@@ -1644,11 +1638,9 @@ contains
           rio_fmort_co                => this%rvars(ir_fmort_co)%r81d, &
           rio_frmort_co               => this%rvars(ir_frmort_co)%r81d, &
 
-	  rio_lmort_logging_co                => this%rvars(ir_lmort_logging_co)%r81d, &
-	  rio_lmort_collateral_co                => this%rvars(ir_lmort_collateral_co)%r81d, &
-	  rio_lmort_infra_co                => this%rvars(ir_lmort_infra_co)%r81d, &
-
-
+          rio_lmort_direct_co         => this%rvars(ir_lmort_direct_co)%r81d, &
+          rio_lmort_collateral_co     => this%rvars(ir_lmort_collateral_co)%r81d, &
+          rio_lmort_infra_co          => this%rvars(ir_lmort_infra_co)%r81d, &
 
           rio_ddbhdt_co               => this%rvars(ir_ddbhdt_co)%r81d, &
           rio_dbalivedt_co            => this%rvars(ir_dbalivedt_co)%r81d, &
@@ -1749,12 +1741,10 @@ contains
                 ccohort%fmort        = rio_fmort_co(io_idx_co)
                 ccohort%frmort        = rio_frmort_co(io_idx_co)
 
-		!Logging
-		ccohort%lmort_logging        = rio_lmort_logging_co(io_idx_co)
-		ccohort%lmort_collateral     = rio_lmort_collateral_co(io_idx_co)
-		ccohort%lmort_infra        = rio_lmort_infra_co(io_idx_co)
-
-
+                !Logging
+                ccohort%lmort_direct       = rio_lmort_direct_co(io_idx_co)
+                ccohort%lmort_collateral   = rio_lmort_collateral_co(io_idx_co)
+                ccohort%lmort_infra        = rio_lmort_infra_co(io_idx_co)
 
                 ccohort%ddbhdt       = rio_ddbhdt_co(io_idx_co)
                 ccohort%dbalivedt    = rio_dbalivedt_co(io_idx_co)

--- a/tools/modify_fates_paramfile.py
+++ b/tools/modify_fates_paramfile.py
@@ -19,6 +19,8 @@ import os
 from scipy.io import netcdf as nc
 import argparse
 import shutil
+import tempfile
+
 
 # ========================================================================================
 # ========================================================================================
@@ -38,60 +40,74 @@ def main():
     parser.add_argument('--silent', '--s', dest='silent', help="prevent writing of output.", action="store_true")
     #
     args = parser.parse_args()
-    # print(args.varname, args.pftnum, args.inputfname, args.outputfname, args.val, args.overwrite)
     #
-    # check to see if output file exists
-    if os.path.isfile(args.outputfname):
-        if args.overwrite:
+    # work with the file in some random temprary place so that if something goes wrong nothing happens to original file and it doesn't make an output file
+    tempdir = tempfile.mkdtemp()
+    tempfilename = os.path.join(tempdir, 'temp_fates_param_file.nc')
+    #
+    try:
+        shutil.copyfile(args.inputfname, tempfilename)
+        #
+        ncfile = nc.netcdf_file(tempfilename, 'a')
+        #
+        var = ncfile.variables[args.varname]
+        #
+        ### check to make sure that, if a PFT is specified, the variable has a PFT dimension, and if not, then it doesn't. and also that shape is reasonable.
+        ndim_file = len(var.dimensions)
+        ispftvar = False
+        # for purposes of current stat eof this script, assume 1D 
+        if ndim_file > 1:
+            raise ValueError('variable dimensionality is too high for this script')
+        if ndim_file < 1:
+            raise ValueError('variable dimensionality is too low for this script. FATES assumes even scalars have a 1-length dimension')
+        for i in range(ndim_file):
+            if var.dimensions[i] == 'fates_pft':
+                ispftvar = True
+                npft_file = var.shape[i]
+                pftdim = 0
+            elif var.dimensions[i] == 'fates_scalar':
+                npft_file = None
+                pftdim = None
+            else:
+                raise ValueError('variable is not on either the PFT or scalar dimension')
+        if args.pftnum == None and ispftvar:
+            raise ValueError('pft value is missing but variable has pft dimension.')
+        if args.pftnum != None and not ispftvar:
+            raise ValueError('pft value is present but variable does not have pft dimension.')
+        if args.pftnum != None and ispftvar:
+            if args.pftnum > npft_file:
+                raise ValueError('PFT specified ('+str(args.pftnum)+') is larger than the number of PFTs in the file ('+str(npft_file)+').')
+            if pftdim == 0:
+                if not args.silent:
+                    print('replacing prior value of variable '+args.varname+', for PFT '+str(args.pftnum)+', which was '+str(var[args.pftnum-1])+', with new value of '+str(args.val))
+                var[args.pftnum-1] = args.val
+        elif args.pftnum == None and not ispftvar:
             if not args.silent:
-                print('replacing file: '+args.outputfname)
-            os.remove(args.outputfname)
+                print('replacing prior value of variable '+args.varname+', which was '+str(var[:])+', with new value of '+str(args.val))
+            var[:] = args.val
         else:
-            raise ValueError('Output file already exists and overwrite flag not specified for filename: '+args.outputfname)
-    #
-    shutil.copyfile(args.inputfname, args.outputfname)
-    #
-    ncfile = nc.netcdf_file(args.outputfname, 'a')
-    #
-    var = ncfile.variables[args.varname]
-    #
-    ### check to make sure that, if a PFT is specified, the variable has a PFT dimension, and if not, then it doesn't. and also that shape is reasonable.
-    ndim_file = len(var.dimensions)
-    ispftvar = False
-    for i in range(ndim_file):
-        if var.dimensions[i] == 'fates_pft':
-            ispftvar = True
-            npft_file = var.shape[i]
-            pftdim = 0
-        else:
-            npft_file = None
-            pftdim = None
-    if args.pftnum == None and ispftvar:
-        raise ValueError('pft value is missing but variable has pft dimension.')
-    if args.pftnum != None and not ispftvar:
-        raise ValueError('pft value is present but variable does not have pft dimension.')
-    if ndim_file > 1:
-        raise ValueError('variable dimensionality is too high for this script')
-    if ndim_file == 1 and not ispftvar:
-        raise ValueError('variable dimensionality is too high for this script')
-    if args.pftnum != None and ispftvar:
-        if args.pftnum > npft_file:
-            raise ValueError('PFT specified ('+str(args.pftnum)+') is larger than the number of PFTs in the file ('+str(npft_file)+').')
-        if pftdim == 0:
-            if not args.silent:
-                print('replacing prior value of variable '+args.varname+', for PFT '+str(args.pftnum)+', which was '+str(var[args.pftnum-1])+', with new value of '+str(args.val))
-            var[args.pftnum-1] = args.val
-    elif args.pftnum == None and not ispftvar:
-        if not args.silent:
-            print('replacing prior value of variable '+args.varname+', which was '+str(var[:])+', with new value of '+str(args.val))
-        var[:] = args.val
-    else:
-        raise ValueError('Nothing happened somehow.')
-    #
-    #
-    ncfile.close()
-
-
+            raise ValueError('Nothing happened somehow.')
+        #
+        #
+        ncfile.close()
+        #
+        #
+        # now move file from temprary location to final location
+        #
+        # check to see if output file exists
+        if os.path.isfile(args.outputfname):
+            if args.overwrite:
+                if not args.silent:
+                    print('replacing file: '+args.outputfname)
+                os.remove(args.outputfname)
+            else:
+                raise ValueError('Output file already exists and overwrite flag not specified for filename: '+args.outputfname)
+        #
+        shutil.move(tempfilename, args.outputfname)
+        shutil.rmtree(tempdir, ignore_errors=True)
+    except:
+        shutil.rmtree(tempdir, ignore_errors=True)
+        raise
 
 
 # =======================================================================================


### PR DESCRIPTION
### Description:
Basic functionality for a "cold stress induced mortality", based on PFT freezing tolerances. This includes a freezing induced mortality that is based on average daily temperature, a 5 degree temperature buffer, and a PFT specific freezing tolerance threshold (which also requires updates to the FATES parameter file). This does not include the physiological processes of cold hardening. 

@rgknox : These changes also include a fix to the calculation of AGB in litter fluxes during patch dynamics.  Previously we were using a mean AGB fraction from all pfts, and now we use a pft specific fraction for each litter flux (better).  This also should change answers.

### Collaborators:
@rgknox, @rosiealice 

### Expectation of Answer Changes:
Better representation of global PFT distributions.
This will change the total mortality rates. An additional mortality value (frmort) is now calculated and outputted as "M8", but this "M" naming convention will change based new updates. 
The default FATES parameter file has fates_freezetol set at a very high value, such that freezing tolerance will never occur. To complement this pull request an update to the parameter file is needed. 
The PFT specific freezing tolerance were based on ED2 values (below reference), expert knowledge from M. Dietze. 
Albani, M.; D. Medvigy; G. C. Hurtt; P. R. Moorcroft, 2006: The contributions of land-use change, CO2 fertilization, and climate variability to the Eastern US carbon sink. Glob. Change Biol., 12, 2370-2390, doi: 10.1111/j.1365-2486.2006.01254.x 

### Checklist:
- [X ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation AND wiki accordingly.
- [ X] I have read the [**CONTRIBUTING**](https://github.com/rgknox/fates/blob/rgknox-new-PR-template/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ X] If answers were expected to change, evaluation was performed and provided


### Test Results:
Manually tested and did not use testing suite. 
Tested on Lawrencium, runs compiled and successfully ran. 
./create_newcase -case ICLM45ED_ACME-testing_cold_test -res f45_f45 -mach lawrencium-lr3 -project ac_acme -compiler intel -compset ICLM45ED

Note - But these might be incorrect, I'm not all the way sure I have the correct hash-tag.

FATES-CLM (or) HLM test hash-tag: ELM = 6660c71

FATES-CLM (or) HLM baseline hash-tag: ELM = 9446f00

FATES baseline hash-tag: a00482e Merge pull request #292 from ckoven/fates_ppm_cbalancefixes

Regression Tests (updated RGK):

FATES-CLM: 2cb7194
FATES: F93f2aef


```
  FAIL ERP_Ld9.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesAllVars COMPARE_base_rest
  FAIL ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesPPhys COMPARE_base_rest
```
Note: Since these changes impacted the restart files, I had to generate new finidat files for some of our tests.  I did not generate the 100 year files, instead I made 20 year files.  All expected tests passed, and some that didn't pass before, pass now.  But I suspect that the new passes are just artifacts of a different initial condition.



Test Output:

![image](https://user-images.githubusercontent.com/8737688/35709762-ddfe8332-0768-11e8-9d32-a9e04711aa94.png)

![image](https://user-images.githubusercontent.com/8737688/35709765-e4ed2a18-0768-11e8-9c4f-9f0bca5a14f6.png)




<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 