### PR TITLE
memory leak fix

### DIFF
--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -415,7 +415,7 @@ contains
     !----------------------------------------------------------------------
 
 
-    currentCohort => currentPatch%shortest  
+    currentCohort => currentPatch%shortest
     do while (associated(currentCohort))
 
        terminate = 0 
@@ -525,30 +525,30 @@ contains
                   currentSite%root_litter_diagnostic_input_carbonflux(currentCohort%pft) + &
                   currentCohort%n * (currentCohort%br+currentCohort%bstore) * hlm_days_per_year  / AREA
 
-
-             ! Set pointers and remove the current cohort from the list
-             
-             shorterCohort => currentCohort%shorter
-             
-             if (.not. associated(tallerCohort)) then
-                currentPatch%tallest => shorterCohort
-                if(associated(shorterCohort)) shorterCohort%taller => null()
-             else 
-                tallerCohort%shorter => shorterCohort
-             endif
-
-             if (.not. associated(shorterCohort)) then
-                currentPatch%shortest => tallerCohort
-                if(associated(tallerCohort)) tallerCohort%shorter => null()
-             else 
-                shorterCohort%taller => tallerCohort
-             endif
-             
-             ! At this point, nothing should be pointing to current Cohort
-             if (hlm_use_planthydro.eq.itrue) call DeallocateHydrCohort(currentCohort)
-             deallocate(currentCohort)
-
+          end if
+          
+          ! Set pointers and remove the current cohort from the list
+          shorterCohort => currentCohort%shorter
+          
+          if (.not. associated(tallerCohort)) then
+             currentPatch%tallest => shorterCohort
+             if(associated(shorterCohort)) shorterCohort%taller => null()
+          else 
+             tallerCohort%shorter => shorterCohort
           endif
+          
+          if (.not. associated(shorterCohort)) then
+             currentPatch%shortest => tallerCohort
+             if(associated(tallerCohort)) tallerCohort%shorter => null()
+          else 
+             shorterCohort%taller => tallerCohort
+          endif
+          
+          ! At this point, nothing should be pointing to current Cohort
+          if (hlm_use_planthydro.eq.itrue) call DeallocateHydrCohort(currentCohort)
+          deallocate(currentCohort)
+          nullify(currentCohort)
+          
        endif
        currentCohort => tallerCohort
     enddo
@@ -624,7 +624,7 @@ contains
               nextc => currentPatch%tallest
 
               do while (associated(nextc))
-                 nextnextc => nextc%shorter                      
+                 nextnextc => nextc%shorter
                  diff = abs((currentCohort%dbh - nextc%dbh)/(0.5*(currentCohort%dbh + nextc%dbh)))  
 
                  !Criteria used to divide up the height continuum into different cohorts.
@@ -843,7 +843,7 @@ contains
                                 ! At this point, nothing should be pointing to current Cohort
                                 if (hlm_use_planthydro.eq.itrue) call DeallocateHydrCohort(nextc)
                                 deallocate(nextc)
-
+                                nullify(nextc)
 
                              endif ! if( currentCohort%isnew.eqv.nextc%isnew ) then
                           endif !canopy layer


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

A memory leak was detected, see issue #370.  The physical memory usage was tracked in time, and with these fixes stabilizes without growing.  Some code cleaning and refactoring was performed as well, mostly removing redundant variables.  



### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->



### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the in-code documentation AND wiki accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/rgknox/fates/blob/rgknox-new-PR-template/CONTRIBUTING.md) document.
- [x] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

FATES-CLM (or) HLM test hash-tag:

FATES-CLM (or) HLM baseline hash-tag:

FATES baseline hash-tag:

Test Output:

All PASS, and B4B with #371.  Expected fails:

```
  FAIL ERP_Ld9.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesAllVars COMPARE_base_rest
  FAIL ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesFinif45 COMPARE_base_rest
  FAIL ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesLogging COMPARE_base_rest
  FAIL ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesPPhys COMPARE_base_rest
  FAIL ERS_Ld60.f45_f45.ICLM45ED.cheyenne_intel.clm-FatesST3 COMPARE_base_rest
```


<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 