### PR TITLE
Fire leaf flux update

### DIFF
--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -314,12 +314,12 @@ contains
     currentCohort%dbstoredt          = nan ! time derivative of stored biomass 
 
     ! FIRE
-    currentCohort%cfa                = nan ! proportion of crown affected by fire
-    currentCohort%cambial_mort       = nan ! probability that trees dies due to cambial char P&R (1986)
-    currentCohort%crownfire_mort     = nan ! probability of tree post-fire mortality due to crown scorch
-    currentCohort%fire_mort          = nan ! post-fire mortality from cambial and crown damage assuming two are independent
+    currentCohort%fraction_crown_burned = nan ! proportion of crown affected by fire
+    currentCohort%cambial_mort          = nan ! probability that trees dies due to cambial char P&R (1986)
+    currentCohort%crownfire_mort        = nan ! probability of tree post-fire mortality due to crown scorch
+    currentCohort%fire_mort             = nan ! post-fire mortality from cambial and crown damage assuming two are independent
 
-    currentCohort%ode_opt_step       = nan ! integrator step size
+    currentCohort%ode_opt_step          = nan ! integrator step size
 
   end subroutine nan_cohort
 
@@ -341,52 +341,52 @@ contains
 
     currentCohort => cc_p
 
-    currentCohort%NV                 = 0    
-    currentCohort%status_coh         = 0    
-    currentCohort%rdark              = 0._r8
-    currentCohort%resp_m             = 0._r8 
-    currentCohort%resp_g             = 0._r8
-    currentCohort%livestem_mr        = 0._r8
-    currentCohort%livecroot_mr       = 0._r8
-    currentCohort%froot_mr           = 0._r8
-    currentCohort%fire_mort          = 0._r8 
-    currentcohort%npp_acc            = 0._r8
-    currentcohort%gpp_acc            = 0._r8
-    currentcohort%resp_acc           = 0._r8
-    currentcohort%npp_tstep          = 0._r8
-    currentcohort%gpp_tstep          = 0._r8
-    currentcohort%resp_tstep         = 0._r8
-    currentcohort%resp_acc_hold      = 0._r8
-    currentcohort%leaf_litter        = 0._r8
-    currentcohort%year_net_uptake(:) = 999._r8 ! this needs to be 999, or trimming of new cohorts will break. 
-    currentcohort%ts_net_uptake(:)   = 0._r8
-    currentcohort%seed_prod          = 0._r8
-    currentcohort%cfa                = 0._r8 
-    currentcohort%md                 = 0._r8
-    currentcohort%root_md            = 0._r8
-    currentcohort%leaf_md            = 0._r8
-    currentcohort%bstore_md          = 0._r8
-    currentcohort%bsw_md             = 0._r8
-    currentcohort%bdead_md           = 0._r8
-    currentcohort%npp_acc_hold       = 0._r8 
-    currentcohort%gpp_acc_hold       = 0._r8  
-    currentcohort%dmort              = 0._r8 
-    currentcohort%g_sb_laweight      = 0._r8 
-    currentcohort%treesai            = 0._r8  
-    currentCohort%lmort_direct       = 0._r8
-    currentCohort%lmort_infra        = 0._r8
-    currentCohort%lmort_collateral   = 0._r8
-    currentCohort%leaf_cost          = 0._r8
-    currentcohort%excl_weight        = 0._r8
-    currentcohort%prom_weight        = 0._r8
-    currentcohort%crownfire_mort     = 0._r8
-    currentcohort%cambial_mort       = 0._r8
-    currentCohort%npp_leaf = 0._r8
-    currentCohort%npp_fnrt = 0._r8
-    currentCohort%npp_sapw = 0._r8
-    currentCohort%npp_dead = 0._r8
-    currentCohort%npp_seed = 0._r8
-    currentCohort%npp_stor = 0._r8
+    currentCohort%NV                    = 0    
+    currentCohort%status_coh            = 0    
+    currentCohort%rdark                 = 0._r8
+    currentCohort%resp_m                = 0._r8 
+    currentCohort%resp_g                = 0._r8
+    currentCohort%livestem_mr           = 0._r8
+    currentCohort%livecroot_mr          = 0._r8
+    currentCohort%froot_mr              = 0._r8
+    currentCohort%fire_mort             = 0._r8 
+    currentcohort%npp_acc               = 0._r8
+    currentcohort%gpp_acc               = 0._r8
+    currentcohort%resp_acc              = 0._r8
+    currentcohort%npp_tstep             = 0._r8
+    currentcohort%gpp_tstep             = 0._r8
+    currentcohort%resp_tstep            = 0._r8
+    currentcohort%resp_acc_hold         = 0._r8
+    currentcohort%leaf_litter           = 0._r8
+    currentcohort%year_net_uptake(:)    = 999._r8 ! this needs to be 999, or trimming of new cohorts will break. 
+    currentcohort%ts_net_uptake(:)      = 0._r8
+    currentcohort%seed_prod             = 0._r8
+    currentcohort%fraction_crown_burned = 0._r8 
+    currentcohort%md                    = 0._r8
+    currentcohort%root_md               = 0._r8
+    currentcohort%leaf_md               = 0._r8
+    currentcohort%bstore_md             = 0._r8
+    currentcohort%bsw_md                = 0._r8
+    currentcohort%bdead_md              = 0._r8
+    currentcohort%npp_acc_hold          = 0._r8 
+    currentcohort%gpp_acc_hold          = 0._r8  
+    currentcohort%dmort                 = 0._r8 
+    currentcohort%g_sb_laweight         = 0._r8 
+    currentcohort%treesai               = 0._r8  
+    currentCohort%lmort_direct          = 0._r8
+    currentCohort%lmort_infra           = 0._r8
+    currentCohort%lmort_collateral      = 0._r8
+    currentCohort%leaf_cost             = 0._r8
+    currentcohort%excl_weight           = 0._r8
+    currentcohort%prom_weight           = 0._r8
+    currentcohort%crownfire_mort        = 0._r8
+    currentcohort%cambial_mort          = 0._r8
+    currentCohort%npp_leaf              = 0._r8
+    currentCohort%npp_fnrt              = 0._r8
+    currentCohort%npp_sapw              = 0._r8
+    currentCohort%npp_dead              = 0._r8
+    currentCohort%npp_seed              = 0._r8
+    currentCohort%npp_stor              = 0._r8
     
   end subroutine zero_cohort
 
@@ -1213,10 +1213,10 @@ contains
     if ( DEBUG ) write(fates_log(),*) 'EDCohortDyn dpstoredt ',o%dbstoredt
 
     ! FIRE 
-    n%cfa             = o%cfa
-    n%fire_mort       = o%fire_mort
-    n%crownfire_mort  = o%crownfire_mort
-    n%cambial_mort    = o%cambial_mort
+    n%fraction_crown_burned = o%fraction_crown_burned
+    n%fire_mort             = o%fire_mort
+    n%crownfire_mort        = o%crownfire_mort
+    n%cambial_mort          = o%cambial_mort
 
     ! Plant Hydraulics
     

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -987,6 +987,7 @@ contains
 
        !************************************/     
        ! PART 3) Burn parts of trees that did *not* die in the fire.
+       !         currently we only remove leaves. branch and assocaited sapwood consumption coming soon.
        ! PART 4) Burn parts of grass that are consumed by the fire. 
        ! grasses are not killed directly by fire. They die by losing all of their leaves and starving. 
        !************************************/ 
@@ -995,9 +996,9 @@ contains
 
           call carea_allom(currentCohort%dbh,currentCohort%n,currentSite%spread,currentCohort%pft,currentCohort%c_area)
           if(EDPftvarcon_inst%woody(currentCohort%pft) == 1)then
-             burned_leaves = min(currentCohort%bl, (currentCohort%bl+currentCohort%bsw) * currentCohort%cfa)
+             burned_leaves = currentCohort%bl * currentCohort%cfa)
           else
-             burned_leaves = min(currentCohort%bl, (currentCohort%bl+currentCohort%bsw) * currentPatch%burnt_frac_litter(6))
+             burned_leaves = currentCohort%bl * currentPatch%burnt_frac_litter(6))
           endif
           if (burned_leaves > 0.0_r8) then
 

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -996,9 +996,9 @@ contains
 
           call carea_allom(currentCohort%dbh,currentCohort%n,currentSite%spread,currentCohort%pft,currentCohort%c_area)
           if(EDPftvarcon_inst%woody(currentCohort%pft) == 1)then
-             burned_leaves = currentCohort%bl * currentCohort%cfa)
+             burned_leaves = currentCohort%bl * currentCohort%cfa
           else
-             burned_leaves = currentCohort%bl * currentPatch%burnt_frac_litter(6))
+             burned_leaves = currentCohort%bl * currentPatch%burnt_frac_litter(6)
           endif
           if (burned_leaves > 0.0_r8) then
 

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -904,20 +904,20 @@ contains
              ! Unburned leaves and roots    
              
              new_patch%leaf_litter(p) = new_patch%leaf_litter(p) + dead_tree_density * (currentCohort%bl) &
-             * (1.0_r8-currentCohort%cfa)
+             * (1.0_r8-currentCohort%fraction_crown_burned)
              new_patch%root_litter(p) = new_patch%root_litter(p) + dead_tree_density * (currentCohort%br+currentCohort%bstore)
              currentPatch%leaf_litter(p) = currentPatch%leaf_litter(p) + dead_tree_density * &
-                  (currentCohort%bl) * (1.0_r8-currentCohort%cfa)
+                  (currentCohort%bl) * (1.0_r8-currentCohort%fraction_crown_burned)
              currentPatch%root_litter(p) = currentPatch%root_litter(p) + dead_tree_density * &
                   (currentCohort%br+currentCohort%bstore)
 
              ! track as diagnostic fluxes
              currentSite%leaf_litter_diagnostic_input_carbonflux(p) = currentSite%leaf_litter_diagnostic_input_carbonflux(p) + &
-                  (currentCohort%bl) * (1.0_r8-currentCohort%cfa) * currentCohort%fire_mort * currentCohort%n * &
-                  hlm_days_per_year / AREA
-             currentSite%root_litter_diagnostic_input_carbonflux(p) = currentSite%root_litter_diagnostic_input_carbonflux(p) + &
-                  (currentCohort%br+currentCohort%bstore) * (1.0_r8-currentCohort%cfa) * currentCohort%fire_mort * &
+                  (currentCohort%bl) * (1.0_r8-currentCohort%fraction_crown_burned) * currentCohort%fire_mort * & 
                   currentCohort%n * hlm_days_per_year / AREA
+             currentSite%root_litter_diagnostic_input_carbonflux(p) = currentSite%root_litter_diagnostic_input_carbonflux(p) + &
+                  (currentCohort%br+currentCohort%bstore) * (1.0_r8-currentCohort%fraction_crown_burned) &
+                   * currentCohort%fire_mort * currentCohort%n * hlm_days_per_year / AREA
       
              ! below ground coarse woody debris from burned trees
              do c = 1,ncwd
@@ -933,14 +933,14 @@ contains
              ! above ground coarse woody debris from unburned twigs and small branches
              do c = 1,2
                 new_patch%cwd_ag(c) = new_patch%cwd_ag(c) + dead_tree_density * SF_val_CWD_frac(c) * bstem &
-                * (1.0_r8-currentCohort%cfa)
+                * (1.0_r8-currentCohort%fraction_crown_burned)
                 currentPatch%cwd_ag(c) = currentPatch%cwd_ag(c) + dead_tree_density * SF_val_CWD_frac(c) * &
-                     bstem * (1.0_r8-currentCohort%cfa)
+                     bstem * (1.0_r8-currentCohort%fraction_crown_burned)
 
                 ! track as diagnostic fluxes
                 currentSite%CWD_AG_diagnostic_input_carbonflux(c) = currentSite%CWD_AG_diagnostic_input_carbonflux(c) + &
-                     SF_val_CWD_frac(c) * bstem * (1.0_r8-currentCohort%cfa) * currentCohort%fire_mort * currentCohort%n * &
-                     hlm_days_per_year / AREA
+                     SF_val_CWD_frac(c) * bstem * (1.0_r8-currentCohort%fraction_crown_burned) * currentCohort%fire_mort &
+                     * currentCohort%n * hlm_days_per_year / AREA
              enddo
              
              ! above ground coarse woody debris from large branches and stems: these do not burn in crown fires. 
@@ -959,11 +959,11 @@ contains
              do c = 1,2
 
                 currentSite%cwd_ag_burned(c) = currentSite%cwd_ag_burned(c) + dead_tree_density * &
-                     SF_val_CWD_frac(c) * bstem * currentCohort%cfa
+                     SF_val_CWD_frac(c) * bstem * currentCohort%fraction_crown_burned
                 currentSite%flux_out  = currentSite%flux_out + dead_tree_density * &
-                     AREA * SF_val_CWD_frac(c) * bstem * currentCohort%cfa
+                     AREA * SF_val_CWD_frac(c) * bstem * currentCohort%fraction_crown_burned
                 currentSite%total_burn_flux_to_atm  = currentSite%total_burn_flux_to_atm + dead_tree_density * &
-                     AREA * SF_val_CWD_frac(c) * bstem * currentCohort%cfa
+                     AREA * SF_val_CWD_frac(c) * bstem * currentCohort%fraction_crown_burned
 
              enddo
              
@@ -971,11 +971,11 @@ contains
              do p = 1,numpft                  
 
                 currentSite%leaf_litter_burned(p) = currentSite%leaf_litter_burned(p) + &
-                     dead_tree_density * currentCohort%bl * currentCohort%cfa
+                     dead_tree_density * currentCohort%bl * currentCohort%fraction_crown_burned
                 currentSite%flux_out  = currentSite%flux_out + &
-                     dead_tree_density * AREA * currentCohort%bl * currentCohort%cfa
+                     dead_tree_density * AREA * currentCohort%bl * currentCohort%fraction_crown_burned
                 currentSite%total_burn_flux_to_atm  = currentSite%total_burn_flux_to_atm + &
-                     dead_tree_density * AREA * currentCohort%bl * currentCohort%cfa
+                     dead_tree_density * AREA * currentCohort%bl * currentCohort%fraction_crown_burned
 
              enddo
 
@@ -996,7 +996,7 @@ contains
 
           call carea_allom(currentCohort%dbh,currentCohort%n,currentSite%spread,currentCohort%pft,currentCohort%c_area)
           if(EDPftvarcon_inst%woody(currentCohort%pft) == 1)then
-             burned_leaves = currentCohort%bl * currentCohort%cfa
+             burned_leaves = currentCohort%bl * currentCohort%fraction_crown_burned
           else
              burned_leaves = currentCohort%bl * currentPatch%burnt_frac_litter(6)
           endif
@@ -1011,7 +1011,7 @@ contains
                   patch_site_areadis/currentPatch%area * AREA 
 
           endif
-          currentCohort%cfa = 0.0_r8        
+          currentCohort%fraction_crown_burned = 0.0_r8        
 
           currentCohort => currentCohort%taller
 

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -366,7 +366,7 @@ contains
 
     !if there is a cover of more than one, then the grasses are under the trees
     grass_fraction = min(grass_fraction,1.0_r8-tree_fraction) 
-    bare_fraction = 1.0 - tree_fraction - grass_fraction
+    bare_fraction = 1.0_r8 - tree_fraction - grass_fraction
     if(write_sf == itrue)then
        if ( hlm_masterproc == itrue ) write(fates_log(),*) 'grass, trees, bare', &
             grass_fraction, tree_fraction, bare_fraction
@@ -377,7 +377,7 @@ contains
     do while(associated(currentPatch))       
        currentPatch%total_tree_area = min(currentPatch%total_tree_area,currentPatch%area)
        ! effect_wspeed in units m/min      
-       currentPatch%effect_wspeed = currentSite%wind * (tree_fraction*0.4+(grass_fraction+bare_fraction)*0.6)
+       currentPatch%effect_wspeed = currentSite%wind * (tree_fraction*0.4_r8+(grass_fraction+bare_fraction)*0.6_r8)
       
        currentPatch => currentPatch%younger
     enddo !end patch loop
@@ -488,7 +488,7 @@ contains
           if (debug_windspeed) write(fates_log(),*) 'month and day', hlm_current_month, hlm_current_day             
        else
           !max condition 225 ft/min (FIREMIP Rabin table A10 JSBACH-Spitfire) convert to 68.577 m/min 
-          wind_elev_fire = max(0.0_r8,(68.577-0.5*currentPatch%effect_wspeed))
+          wind_elev_fire = max(0.0_r8,(68.577_r8-0.5_r8*currentPatch%effect_wspeed))
           phi_wind = c * ((3.281_r8*wind_elev_fire)**b)*(beta_ratio**(-e))
           if (debug_windspeed) write(fates_log(),*) 'SF wind GREATER max ', currentPatch%effect_wspeed
           if (debug_windspeed) write(fates_log(),*) 'month and day', hlm_current_month, hlm_current_day 
@@ -503,7 +503,7 @@ contains
        ! ---reaction intensity----
        ! Equation in table A1 Thonicke et al. 2010. 
        a = 8.9033_r8 * (currentPatch%fuel_sav**(-0.7913_r8))
-       a_beta = exp(a*(1-beta_ratio))  !dummy variable for reaction_v_opt equation
+       a_beta = exp(a*(1.0_r8-beta_ratio))  !dummy variable for reaction_v_opt equation
   
        ! Equation in table A1 Thonicke et al. 2010.
        ! reaction_v_max and reaction_v_opt = reaction velocity in units of per min
@@ -674,7 +674,7 @@ contains
           ! Equation 14 in Thonicke et al. 2010
           ! fire duration in minutes
 
-          currentPatch%FD = (SF_val_max_durat+1) / (1.0_r8 + SF_val_max_durat * &
+          currentPatch%FD = (SF_val_max_durat+1.0_r8) / (1.0_r8 + SF_val_max_durat * &
                             exp(SF_val_durat_slope*currentSite%FDI))
 
           if(write_SF == itrue)then
@@ -778,9 +778,9 @@ contains
                 if ( hlm_masterproc == itrue ) write(fates_log(),*) 'frac_burnt',currentPatch%frac_burnt
              endif
 
-             if (currentPatch%frac_burnt > 1 ) then !all of patch burnt. 
+             if (currentPatch%frac_burnt > 1.0_r8 ) then !all of patch burnt. 
                 
-                currentPatch%frac_burnt = 1.0 ! capping at 1 same as %AB/patch_area_in_m2 
+                currentPatch%frac_burnt = 1.0_r8 ! capping at 1 same as %AB/patch_area_in_m2 
 
                 if ( hlm_masterproc == itrue ) write(fates_log(),*) 'burnt all of patch',currentPatch%patchno
                 if ( hlm_masterproc == itrue ) write(fates_log(),*) 'ros',currentPatch%ROS_front,currentPatch%FD, &
@@ -891,7 +891,7 @@ contains
                    if ((currentCohort%hite > 0.0_r8).and.(currentPatch%SH >=  &
                         (currentCohort%hite-currentCohort%hite*EDPftvarcon_inst%crown(currentCohort%pft)))) then 
 
-                           currentCohort%fraction_crown_burned =  (currentPatch%SH-currentCohort%hite*(1- &
+                           currentCohort%fraction_crown_burned =  (currentPatch%SH-currentCohort%hite*(1.0_r8- &
                                 EDPftvarcon_inst%crown(currentCohort%pft)))/(currentCohort%hite* &
                                 EDPftvarcon_inst%crown(currentCohort%pft)) 
 

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -862,8 +862,8 @@ contains
   subroutine  crown_damage ( currentSite )
     !*****************************************************************
 
-    !returns the updated currentCohort%cfa value for each tree cohort within each patch.
-    !currentCohort%cfa  proportion of crown affected by fire
+    !returns the updated currentCohort%fraction_crown_burned for each tree cohort within each patch.
+    !currentCohort%fraction_crown_burned is the proportion of crown affected by fire
 
     type(ed_site_type), intent(in), target :: currentSite
 
@@ -878,12 +878,12 @@ contains
           currentCohort=>currentPatch%tallest
 
           do while(associated(currentCohort))  
-             currentCohort%cfa = 0.0_r8
+             currentCohort%fraction_crown_burned = 0.0_r8
              if (EDPftvarcon_inst%woody(currentCohort%pft) == 1) then !trees only
                 ! Flames lower than bottom of canopy. 
                 ! c%hite is height of cohort
                 if (currentPatch%SH < (currentCohort%hite-currentCohort%hite*EDPftvarcon_inst%crown(currentCohort%pft))) then 
-                   currentCohort%cfa = 0.0_r8
+                   currentCohort%fraction_crown_burned = 0.0_r8
                 else
                    ! Flames part of way up canopy. 
                    ! Equation 17 in Thonicke et al. 2010. 
@@ -891,21 +891,21 @@ contains
                    if ((currentCohort%hite > 0.0_r8).and.(currentPatch%SH >=  &
                         (currentCohort%hite-currentCohort%hite*EDPftvarcon_inst%crown(currentCohort%pft)))) then 
 
-                           currentCohort%cfa =  (currentPatch%SH-currentCohort%hite*(1- &
+                           currentCohort%fraction_crown_burned =  (currentPatch%SH-currentCohort%hite*(1- &
                                 EDPftvarcon_inst%crown(currentCohort%pft)))/(currentCohort%hite* &
                                 EDPftvarcon_inst%crown(currentCohort%pft)) 
 
                    else 
                       ! Flames over top of canopy. 
-                      currentCohort%cfa =  1.0_r8 
+                      currentCohort%fraction_crown_burned =  1.0_r8 
                    endif
 
                 endif
                 ! Check for strange values. 
-                currentCohort%cfa = min(1.0_r8, max(0.0_r8,currentCohort%cfa))              
+                currentCohort%fraction_crown_burned = min(1.0_r8, max(0.0_r8,currentCohort%fraction_crown_burned))              
              endif !trees only
              !shrink canopy to account for burnt section.     
-             !currentCohort%canopy_trim = min(currentCohort%canopy_trim,(1.0_r8-currentCohort%cfa)) 
+             !currentCohort%canopy_trim = min(currentCohort%canopy_trim,(1.0_r8-currentCohort%fraction_crown_burned)) 
 
              currentCohort => currentCohort%shorter;
 
@@ -973,7 +973,7 @@ contains
   !*****************************************************************
 
     !  returns the updated currentCohort%fire_mort value for each tree cohort within each patch.
-    !  currentCohort%cfa  proportion of crown affected by fire
+    !  currentCohort%fraction_crown_burned is proportion of crown affected by fire
     !  currentCohort%crownfire_mort  probability of tree post-fire mortality due to crown scorch
     !  currentCohort%cambial_mort  probability of tree post-fire mortality due to cambial char
     !  currentCohort%fire_mort  post-fire mortality from cambial and crown damage assuming two are independent.
@@ -994,7 +994,7 @@ contains
              currentCohort%crownfire_mort = 0.0_r8
              if (EDPftvarcon_inst%woody(currentCohort%pft) == 1) then
                 ! Equation 22 in Thonicke et al. 2010. 
-                currentCohort%crownfire_mort = EDPftvarcon_inst%crown_kill(currentCohort%pft)*currentCohort%cfa**3.0_r8
+                currentCohort%crownfire_mort = EDPftvarcon_inst%crown_kill(currentCohort%pft)*currentCohort%fraction_crown_burned**3.0_r8
                 ! Equation 18 in Thonicke et al. 2010. 
                 currentCohort%fire_mort = currentCohort%crownfire_mort+currentCohort%cambial_mort- &
                      (currentCohort%crownfire_mort*currentCohort%cambial_mort)  !joint prob.   

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -265,7 +265,7 @@ module EDTypesMod
      real(r8) ::  dbstoredt                              ! time derivative of stored biomass       : KgC/year
 
      ! FIRE
-     real(r8) ::  cfa                                    ! proportion of crown affected by fire:-
+     real(r8) ::  fraction_crown_burned                  ! proportion of crown affected by fire:-
      real(r8) ::  cambial_mort                           ! probability that trees dies due to cambial char:-
      real(r8) ::  crownfire_mort                         ! probability of tree post-fire mortality due to crown scorch:-
      real(r8) ::  fire_mort                              ! post-fire mortality from cambial and crown damage assuming two are independent:-
@@ -815,7 +815,7 @@ contains
      write(fates_log(),*) 'co%ddbhdt                 = ', ccohort%ddbhdt
      write(fates_log(),*) 'co%dbdeaddt               = ', ccohort%dbdeaddt
      write(fates_log(),*) 'co%dbstoredt              = ', ccohort%dbstoredt
-     write(fates_log(),*) 'co%cfa                    = ', ccohort%cfa
+     write(fates_log(),*) 'co%fraction_crown_burned  = ', ccohort%fraction_crown_burned
      write(fates_log(),*) 'co%fire_mort              = ', ccohort%fire_mort
      write(fates_log(),*) 'co%crownfire_mort         = ', ccohort%crownfire_mort
      write(fates_log(),*) 'co%cambial_mort           = ', ccohort%cambial_mort


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
'cfa' was updated to 'fraction_crown_burned' for readability.
The changes here address Issue 412 and inconsistencies within the fire flux routine for live plants. The fire flux for live plants was updated to remove leaves according to the fraction of the crown scorched by fire. Consumption of branches would burn sapwood and remove stemwood, and will be addressed in a separate issue with separate fluxes. 

The equation was also updated to remove the minimum evaluation, as the fraction_crown_burned term already has a check on it to confirm it is not greater than 1 within the fire routine.

### Collaborators:
Charlie Koven, Ryan Knox, Rosie Fisher

### Expectation of Answer Changes:
removal of the sapwood flux will generate answer changes.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ x] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:



CTSM (or) E3SM (specify which) baseline hash-tag:
CTSM commit e49b84fb4

FATES baseline hash-tag:
 FATES commit 91785e3

Test Output:
Compiles and runs on Hobart. Biomass accumulation through 5 year run with and without active fire for 2 PFTs (TropTree and Grass).


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

