### PR TITLE
Recruitment into size classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,11 @@ For more information on the FATES model, see our wiki:  https://github.com/NGEET
 
 **Most users should not need to directly clone this repository.  FATES needs to be run through a host model, and all supported host-models are in charge of cloning and loading the fates software.**
 
-FATES has support to be run via the Accelerated Climate Model for Energy (ACME) and the Community Earth System Model (CESM).
+FATES has support to be run via the Accelerated Climate Model for Energy (ACME) and the Community Terrestrial Systems Model (CTSM).
 
 https://climatemodeling.science.energy.gov/projects/accelerated-climate-modeling-energy
 
-http://www.cesm.ucar.edu/
+https://github.com/ESCOMP/ctsm
 
-The NGEE-T project maintains a mirror of CLM.  That software system will automatically pull in the FATES software, and is where most users should go to clone the code:
-
-https://github.com/NGEET/fates-clm
 
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ For more information on the FATES model, see our wiki:  https://github.com/NGEET
 
 **Most users should not need to directly clone this repository.  FATES needs to be run through a host model, and all supported host-models are in charge of cloning and loading the fates software.**
 
-FATES has support to be run via the Accelerated Climate Model for Energy (ACME) and the Community Terrestrial Systems Model (CTSM).
+FATES has support to be run via the Energy Exascale Earth System Model (E3SM) and the Community Terrestrial Systems Model (CTSM).
 
-https://climatemodeling.science.energy.gov/projects/accelerated-climate-modeling-energy
+https://e3sm.org/
 
 https://github.com/ESCOMP/ctsm
 

--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -241,6 +241,7 @@ contains
     currentCohort%NV                 = fates_unset_int  ! Number of leaf layers: -
     currentCohort%status_coh         = fates_unset_int  ! growth status of plant  (2 = leaves on , 1 = leaves off)
     currentCohort%size_class         = fates_unset_int  ! size class index
+    currentCohort%size_class_lasttimestep = nan  ! size class index (represented as float to accomodate fusion)
     currentCohort%size_by_pft_class  = fates_unset_int  ! size by pft classification index
 
     currentCohort%n                  = nan ! number of individuals in cohort per 'area' (10000m2 default)     
@@ -391,7 +392,8 @@ contains
     currentCohort%npp_dead = 0._r8
     currentCohort%npp_seed = 0._r8
     currentCohort%npp_stor = 0._r8
-    
+    currentCohort%size_class = 1
+    currentCohort%size_class_lasttimestep = 0._r8
   end subroutine zero_cohort
 
   !-------------------------------------------------------------------------------------!
@@ -732,6 +734,10 @@ contains
                                 currentCohort%canopy_layer_yesterday  = (currentCohort%n*currentCohort%canopy_layer_yesterday  + &
                                       nextc%n*nextc%canopy_layer_yesterday)/newn
                                 
+                                ! size class the prior timestep, tracked as a real to accomodate fusion
+                                currentCohort%size_class_lasttimestep = (currentCohort%n*currentCohort%size_class_lasttimestep + &
+                                     nextc%n*nextc%size_class_lasttimestep)/newn
+
                                 ! Flux and biophysics variables have not been calculated for recruits we just default to 
                                 ! their initization values, which should be the same for eahc
                                 
@@ -1137,6 +1143,7 @@ contains
     n%excl_weight     = o%excl_weight               
     n%prom_weight     = o%prom_weight               
     n%size_class      = o%size_class
+    n%size_class_lasttimestep      = o%size_class_lasttimestep
     n%size_by_pft_class = o%size_by_pft_class
 
     ! CARBON FLUXES
@@ -1230,6 +1237,7 @@ contains
 
     ! indices for binning
     n%size_class      = o%size_class
+    n%size_class_lasttimestep      = o%size_class_lasttimestep
     n%size_by_pft_class   = o%size_by_pft_class
 
     !Pointers

--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -345,55 +345,6 @@ contains
 
     currentCohort => cc_p
 
-<<<<<<< HEAD
-    currentCohort%NV                 = 0    
-    currentCohort%status_coh         = 0    
-    currentCohort%rdark              = 0._r8
-    currentCohort%resp_m             = 0._r8 
-    currentCohort%resp_g             = 0._r8
-    currentCohort%livestem_mr        = 0._r8
-    currentCohort%livecroot_mr       = 0._r8
-    currentCohort%froot_mr           = 0._r8
-    currentCohort%fire_mort          = 0._r8 
-    currentcohort%npp_acc            = 0._r8
-    currentcohort%gpp_acc            = 0._r8
-    currentcohort%resp_acc           = 0._r8
-    currentcohort%npp_tstep          = 0._r8
-    currentcohort%gpp_tstep          = 0._r8
-    currentcohort%resp_tstep         = 0._r8
-    currentcohort%resp_acc_hold      = 0._r8
-    currentcohort%leaf_litter        = 0._r8
-    currentcohort%year_net_uptake(:) = 999._r8 ! this needs to be 999, or trimming of new cohorts will break. 
-    currentcohort%ts_net_uptake(:)   = 0._r8
-    currentcohort%seed_prod          = 0._r8
-    currentcohort%cfa                = 0._r8 
-    currentcohort%md                 = 0._r8
-    currentcohort%root_md            = 0._r8
-    currentcohort%leaf_md            = 0._r8
-    currentcohort%bstore_md          = 0._r8
-    currentcohort%bsw_md             = 0._r8
-    currentcohort%bdead_md           = 0._r8
-    currentcohort%npp_acc_hold       = 0._r8 
-    currentcohort%gpp_acc_hold       = 0._r8  
-    currentcohort%dmort              = 0._r8 
-    currentcohort%g_sb_laweight      = 0._r8 
-    currentcohort%treesai            = 0._r8  
-    currentCohort%lmort_direct       = 0._r8
-    currentCohort%lmort_infra        = 0._r8
-    currentCohort%lmort_collateral   = 0._r8
-    currentCohort%leaf_cost          = 0._r8
-    currentcohort%excl_weight        = 0._r8
-    currentcohort%prom_weight        = 0._r8
-    currentcohort%crownfire_mort     = 0._r8
-    currentcohort%cambial_mort       = 0._r8
-    currentCohort%npp_leaf = 0._r8
-    currentCohort%npp_fnrt = 0._r8
-    currentCohort%npp_sapw = 0._r8
-    currentCohort%npp_dead = 0._r8
-    currentCohort%npp_seed = 0._r8
-    currentCohort%npp_stor = 0._r8
-    currentCohort%size_class = 1
-    currentCohort%size_class_lasttimestep = 0
     currentCohort%NV                    = 0    
     currentCohort%status_coh            = 0    
     currentCohort%rdark                 = 0._r8
@@ -440,6 +391,8 @@ contains
     currentCohort%npp_dead              = 0._r8
     currentCohort%npp_seed              = 0._r8
     currentCohort%npp_stor              = 0._r8
+    currentCohort%size_class            = 1
+    currentCohort%size_class_lasttimestep = 0
     
   end subroutine zero_cohort
 

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -72,6 +72,7 @@ contains
     allocate(site_in%demotion_rate(1:nlevsclass))
     allocate(site_in%promotion_rate(1:nlevsclass))
     allocate(site_in%imort_rate(1:nlevsclass,1:numpft))
+    allocate(site_in%growthflux_fusion(1:nlevsclass,1:numpft))
     !
     end subroutine init_site_vars
 
@@ -125,6 +126,9 @@ contains
     site_in%recruitment_rate(:) = 0._r8
     site_in%imort_rate(:,:) = 0._r8
     site_in%imort_carbonflux = 0._r8
+
+    ! fusoin-induced growth flux of individuals
+    site_in%growthflux_fusion(:,:) = 0._r8
 
     ! demotion/promotion info
     site_in%demotion_rate(:) = 0._r8

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -170,6 +170,9 @@ module EDTypesMod
                                                          ! type classification. We also maintain this in the main cohort memory
                                                          ! because we don't want to continually re-calculate the cohort's position when
                                                          ! performing size diagnostics at high-frequency calls
+     real(r8) ::  size_class_lasttimestep                ! size class of the cohort at the end of the previous timestep (used for calculating growth flux)
+                                                         ! represented as a real so as to accomodate the case where merging leads to a cohort that was 
+                                                         ! fractionally in one size class and fractionally in the other
 
 
      ! CARBON FLUXES 

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -170,9 +170,7 @@ module EDTypesMod
                                                          ! type classification. We also maintain this in the main cohort memory
                                                          ! because we don't want to continually re-calculate the cohort's position when
                                                          ! performing size diagnostics at high-frequency calls
-     real(r8) ::  size_class_lasttimestep                ! size class of the cohort at the end of the previous timestep (used for calculating growth flux)
-                                                         ! represented as a real so as to accomodate the case where merging leads to a cohort that was 
-                                                         ! fractionally in one size class and fractionally in the other
+     integer ::  size_class_lasttimestep                 ! size class of the cohort at the end of the previous timestep (used for calculating growth flux)
 
 
      ! CARBON FLUXES 
@@ -599,6 +597,7 @@ module EDTypesMod
      real(r8) :: promotion_carbonflux                          ! biomass of promoted individuals from understory to canopy [kgC/ha/day]
      real(r8), allocatable :: imort_rate(:,:)                    ! rate of individuals killed due to impact mortality per year.  on size x pft array
      real(r8) :: imort_carbonflux                                ! biomass of individuals killed due to impact mortality per year. [kgC/ha/day]
+     real(r8), allocatable :: growthflux_fusion(:,:)             ! rate of individuals moving into a given size class bin due to fusion in a given day. on size x pft array 
 
      ! some diagnostic-only (i.e. not resolved by ODE solver) flux of carbon to CWD and litter pools from termination and canopy mortality
      real(r8) :: CWD_AG_diagnostic_input_carbonflux(1:ncwd)       ! diagnostic flux to AG CWD [kg C / m2 / yr]

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -176,6 +176,7 @@ module FatesHistoryInterfaceMod
 
   integer, private :: ih_ddbh_si_scpf
   integer, private :: ih_growthflux_si_scpf
+  integer, private :: ih_growthflux_fusion_si_scpf
   integer, private :: ih_ba_si_scpf
   integer, private :: ih_m1_si_scpf
   integer, private :: ih_m2_si_scpf
@@ -1392,6 +1393,7 @@ end subroutine flush_hvars
                hio_ar_understory_si_scpf     => this%hvars(ih_ar_understory_si_scpf)%r82d, &
                hio_ddbh_si_scpf        => this%hvars(ih_ddbh_si_scpf)%r82d, &
                hio_growthflux_si_scpf        => this%hvars(ih_growthflux_si_scpf)%r82d, &
+               hio_growthflux_fusion_si_scpf        => this%hvars(ih_growthflux_fusion_si_scpf)%r82d, &
                hio_ba_si_scpf          => this%hvars(ih_ba_si_scpf)%r82d, &
                hio_nplant_si_scpf      => this%hvars(ih_nplant_si_scpf)%r82d, &
 
@@ -1984,23 +1986,23 @@ end subroutine flush_hvars
                     ccohort%canopy_layer_yesterday = real(ccohort%canopy_layer, r8)
                     !
                     ! growth flux of individuals into a given bin
-                    if ( real(scls, r8) .gt. ccohort%size_class_lasttimestep ) then  ! increment the size class counter of this size class bin
-                       hio_growthflux_si_scpf(io_si,scpf) = hio_growthflux_si_scpf(io_si,scpf) + &
-                            (real(scls, r8) - ccohort%size_class_lasttimestep) * ccohort%n * days_per_year
-                       ccohort%size_class_lasttimestep = real(scls, r8)
-                    else if ( real(scls, r8) .lt. ccohort%size_class_lasttimestep ) then  ! decrement the counter of the larger size class bin
-                       hio_growthflux_si_scpf(io_si,scpf+1) = hio_growthflux_si_scpf(io_si,scpf+1) + &
-                            (real(scls, r8) - ccohort%size_class_lasttimestep) * ccohort%n * days_per_year
-                       ccohort%size_class_lasttimestep = real(scls, r8)
-                    endif
-                    
+                    ! track the actual growth here, the virtual growth from fusion lower down
+                    if ( (scls - ccohort%size_class_lasttimestep ) .gt. 0) then
+                       do i_scls = ccohort%size_class_lasttimestep + 1, scls
+                          i_scpf = (ccohort%pft-1)*nlevsclass+i_scls
+                          hio_growthflux_si_scpf(io_si,i_scpf) = hio_growthflux_si_scpf(io_si,i_scpf) + &
+                               ccohort%n * days_per_year
+                       end do
+                    end if
+                    ccohort%size_class_lasttimestep = scls
+                    !
                   end associate
                else  ! i.e. cohort%isnew
                   !
                   ! if cohort is new, track its growth flux into the first size bin
                   i_scpf = (ccohort%pft-1)*nlevsclass+1
                   hio_growthflux_si_scpf(io_si,i_scpf) = hio_growthflux_si_scpf(io_si,i_scpf) + ccohort%n * days_per_year
-                  ccohort%size_class_lasttimestep = 1._r8
+                  ccohort%size_class_lasttimestep = 1
                   !
                end if
 
@@ -2134,6 +2136,10 @@ end subroutine flush_hvars
                iscag = i_scls ! since imort is by definition something that only happens in newly disturbed patches, treat as such
                hio_mortality_understory_si_scag(io_si,iscag) = hio_mortality_understory_si_scag(io_si,iscag) + &
                     sites(s)%imort_rate(i_scls, i_pft)
+               !
+               ! while in this loop, pass the fusion-induced growth rate flux to history
+               hio_growthflux_fusion_si_scpf(io_si,i_scpf) = hio_growthflux_fusion_si_scpf(io_si,i_scpf) + &
+                    sites(s)%growthflux_fusion(i_scls, i_pft) * days_per_year
             end do
          end do
          !
@@ -2144,6 +2150,8 @@ end subroutine flush_hvars
          sites(s)%terminated_nindivs(:,:,:) = 0._r8
          sites(s)%imort_carbonflux = 0._r8
          sites(s)%imort_rate(:,:) = 0._r8
+         !
+         sites(s)%growthflux_fusion(:,:) = 0._r8
 
          ! pass the recruitment rate as a flux to the history, and then reset the recruitment buffer
          do i_pft = 1, numpft
@@ -3774,6 +3782,11 @@ end subroutine flush_hvars
           long='flux of individuals into a given size class bin via growth and recruitment',use_default='inactive',          &
           avgflag='A', vtype=site_size_pft_r8, hlms='CLM:ALM', flushval=0.0_r8,   &
           upfreq=1, ivar=ivar, initialize=initialize_variables, index = ih_growthflux_si_scpf )
+
+    call this%set_history_var(vname='GROWTHFLUX_FUSION_SCPF', units = 'n/yr/ha',         &
+          long='flux of individuals into a given size class bin via fusion',use_default='inactive',          &
+          avgflag='A', vtype=site_size_pft_r8, hlms='CLM:ALM', flushval=0.0_r8,   &
+          upfreq=1, ivar=ivar, initialize=initialize_variables, index = ih_growthflux_fusion_si_scpf )
 
     call this%set_history_var(vname='DDBH_CANOPY_SCPF', units = 'cm/yr/ha',         &
           long='diameter growth increment by pft/size',use_default='inactive', &


### PR DESCRIPTION
A thing that's been bugging me for a while is our inability to compare prognostic recruitment rates with census data of that, because we don't track the flux of trees into a given size class, only the recruitment into the smallest size class.  I had thought that this could be calculated during postprocessing by continuity, since we have mortality rates from each size class, the change in the population in each size class, and the recruitment into the smallest size class.  Unfortunately, doing that doesn't seem to work in general, I think because there are errors in population conservation within a given size class due to cohort fusion, which are sufficiently large that they mess up the calculation.

So this PR adds a couple variables to actually track this quantity.  I've added two new variables, both on a size-class x PFT dimension, which track the recruitment rates into a given size class, due to (a) normal growth, and (b) cohort fusion.  The real growth-based recruitment flux is positive definite. The virtual recruitment due to fusion can be either positive or negative depending on whether the trees are getting moved into a size bin or out of a size bin when they are fused.


### Collaborators:
Some discussion on this with @rgknox 

### Expectation of Answer Changes:
Expectation is that these quantities are purely diagnostic and should not change answers of existing variables

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ x I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [x] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
Not yet tested

CTSM (or) E3SM (specify which) test hash-tag:

27f7fa

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

cheyenne, intel, fates test suite, alll PASS  
