### PR TITLE
Add a simple scheme of leaf age to improve the seasonal cycles of GPP

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ For more information on the FATES model, see our wiki:  https://github.com/NGEET
 
 **Most users should not need to directly clone this repository.  FATES needs to be run through a host model, and all supported host-models are in charge of cloning and loading the fates software.**
 
-FATES has support to be run via the Accelerated Climate Model for Energy (ACME) and the Community Terrestrial Systems Model (CTSM).
+FATES has support to be run via the Energy Exascale Earth System Model (E3SM) and the Community Terrestrial Systems Model (CTSM).
 
-https://climatemodeling.science.energy.gov/projects/accelerated-climate-modeling-energy
+https://e3sm.org/
 
 https://github.com/ESCOMP/ctsm
 

--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -188,10 +188,17 @@ contains
 	  new_cohort%fracOldLeaves = 0.0_r8
 	  new_cohort%fracSenLeaves = 0.0_r8
        else
+         if(status == 2) then !leaf on
           new_cohort%fracExpLeaves = 0.25_r8
 	  new_cohort%fracYoungLeaves = 0.25_r8
 	  new_cohort%fracOldLeaves = 0.25_r8
-	  new_cohort%fracSenLeaves = 0.25_r8       
+	  new_cohort%fracSenLeaves = 0.25_r8
+	 else
+          new_cohort%fracExpLeaves = 1.0_r8
+	  new_cohort%fracYoungLeaves = 0.0_r8
+	  new_cohort%fracOldLeaves = 0.0_r8
+	  new_cohort%fracSenLeaves = 0.0_r8	   
+	 endif       
        endif
     endif
 
@@ -726,14 +733,21 @@ contains
                                       + nextc%n*nextc%canopy_trim)/newn
 				      
 				if(use_leaf_age) then
-				  currentCohort%fracExpLeaves = (currentCohort%n*currentCohort%fracExpLeaves*currentCohort%bl &
-                                      + nextc%n*nextc%fracExpLeaves*nextc%bl)/newn
-				  currentCohort%fracYoungLeaves = (currentCohort%n*currentCohort%fracYoungLeaves*currentCohort%bl   &
-                                      + nextc%n*nextc%fracYoungLeaves*nextc%bl)/newn
-				  currentCohort%fracOldLeaves = (currentCohort%n*currentCohort%fracOldLeaves*currentCohort%bl   &
-                                      + nextc%n*nextc%fracOldLeaves*nextc%bl)/newn
-				  currentCohort%fracSenLeaves = 1.0_r8-currentCohort%fracExpLeaves-currentCohort%fracYoungLeaves -&
-				      currentCohort%fracOldLeaves   				      				      				      
+				  if(currentCohort%bl>0)then
+				    currentCohort%fracExpLeaves = (currentCohort%n*currentCohort%fracExpLeaves*currentCohort%bl &
+                                      + nextc%n*nextc%fracExpLeaves*nextc%bl)/(newn*currentCohort%bl)
+				    currentCohort%fracYoungLeaves = (currentCohort%n*currentCohort%fracYoungLeaves*currentCohort%bl   &
+                                      + nextc%n*nextc%fracYoungLeaves*nextc%bl)/(newn*currentCohort%bl)
+				    currentCohort%fracOldLeaves = (currentCohort%n*currentCohort%fracOldLeaves*currentCohort%bl   &
+                                      + nextc%n*nextc%fracOldLeaves*nextc%bl)/(newn*currentCohort%bl)
+				    currentCohort%fracSenLeaves = 1.0_r8-currentCohort%fracExpLeaves-currentCohort%fracYoungLeaves -&
+				      currentCohort%fracOldLeaves 
+	                          else
+				     currentCohort%fracExpLeaves = 1.0_r8
+	                             currentCohort%fracYoungLeaves = 0.0_r8
+	                             currentCohort%fracOldLeaves = 0.0_r8
+	                             currentCohort%fracSenLeaves = 0.0_r8			       
+				  endif 				      				      				      
 				endif
 
                                 ! -----------------------------------------------------------------
@@ -860,14 +874,21 @@ contains
 				   
 				   !leaf age
 				   if(use_leaf_age) then
-				    currentCohort%fracExpLeaves = (currentCohort%n*currentCohort%fracExpLeaves*currentCohort%bl &
-                                      + nextc%n*nextc%fracExpLeaves*nextc%bl)/newn
-				    currentCohort%fracYoungLeaves = (currentCohort%n*currentCohort%fracYoungLeaves*currentCohort%bl   &
-                                      + nextc%n*nextc%fracYoungLeaves*nextc%bl)/newn
-				    currentCohort%fracOldLeaves = (currentCohort%n*currentCohort%fracOldLeaves*currentCohort%bl   &
-                                      + nextc%n*nextc%fracOldLeaves*nextc%bl)/newn
-				    currentCohort%fracSenLeaves = 1.0_r8-currentCohort%fracExpLeaves-currentCohort%fracYoungLeaves -&
-				      currentCohort%fracOldLeaves				      				      				      
+				    if(currentCohort%bl>0)then
+				      currentCohort%fracExpLeaves = (currentCohort%n*currentCohort%fracExpLeaves*currentCohort%bl &
+                                       + nextc%n*nextc%fracExpLeaves*nextc%bl)/(newn*currentCohort%bl)
+				      currentCohort%fracYoungLeaves = (currentCohort%n*currentCohort%fracYoungLeaves*currentCohort%bl&
+                                       + nextc%n*nextc%fracYoungLeaves*nextc%bl)/(newn*currentCohort%bl)
+				      currentCohort%fracOldLeaves = (currentCohort%n*currentCohort%fracOldLeaves*currentCohort%bl   &
+                                       + nextc%n*nextc%fracOldLeaves*nextc%bl)/(newn*currentCohort%bl)
+				      currentCohort%fracSenLeaves = 1.0_r8-currentCohort%fracExpLeaves-currentCohort%fracYoungLeaves -&
+				       currentCohort%fracOldLeaves
+				    else
+				       currentCohort%fracExpLeaves = 1.0_r8  
+				       currentCohort%fracYoungLeaves = 0.0_r8
+				       currentCohort%fracOldLeaves = 0.0_r8
+				       currentCohort%fracSenLeaves = 0.0_r8
+				    endif 				      				      				      
 				   endif
                                      
                                 end if !(currentCohort%isnew)

--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -180,6 +180,20 @@ contains
        snull = 1
        patchptr%shortest => new_cohort 
     endif
+    
+    if(use_leaf_age==itrue) then
+       if(recruitstatus==1)then
+          new_cohort%fracExpLeaves = 1.0_r8
+	  new_cohort%fracYoungLeaves = 0.0_r8
+	  new_cohort%fracOldLeaves = 0.0_r8
+	  new_cohort%fracSenLeaves = 0.0_r8
+       else
+          new_cohort%fracExpLeaves = 0.25_r8
+	  new_cohort%fracYoungLeaves = 0.25_r8
+	  new_cohort%fracOldLeaves = 0.25_r8
+	  new_cohort%fracSenLeaves = 0.25_r8       
+       endif
+    endif
 
     ! Recuits do not have mortality rates, nor have they moved any
     ! carbon when they are created.  They will bias our statistics
@@ -718,8 +732,8 @@ contains
                                       + nextc%n*nextc%fracYoungLeaves*nextc%bl)/newn
 				  currentCohort%fracOldLeaves = (currentCohort%n*currentCohort%fracOldLeaves*currentCohort%bl   &
                                       + nextc%n*nextc%fracOldLeaves*nextc%bl)/newn
-				  currentCohort%fracSenLeaves = (currentCohort%n*currentCohort%fracSenLeaves*currentCohort%bl   &
-                                      + nextc%n*nextc%fracSenLeaves*nextc%bl)/newn				      				      				      
+				  currentCohort%fracSenLeaves = 1.0_r8-currentCohort%fracExpLeaves-currentCohort%fracYoungLeaves -&
+				      currentCohort%fracOldLeaves   				      				      				      
 				endif
 
                                 ! -----------------------------------------------------------------
@@ -852,8 +866,8 @@ contains
                                       + nextc%n*nextc%fracYoungLeaves*nextc%bl)/newn
 				    currentCohort%fracOldLeaves = (currentCohort%n*currentCohort%fracOldLeaves*currentCohort%bl   &
                                       + nextc%n*nextc%fracOldLeaves*nextc%bl)/newn
-				    currentCohort%fracSenLeaves = (currentCohort%n*currentCohort%fracSenLeaves*currentCohort%bl   &
-                                      + nextc%n*nextc%fracSenLeaves*nextc%bl)/newn				      				      				      
+				    currentCohort%fracSenLeaves = 1.0_r8-currentCohort%fracExpLeaves-currentCohort%fracYoungLeaves -&
+				      currentCohort%fracOldLeaves				      				      				      
 				   endif
                                      
                                 end if !(currentCohort%isnew)

--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -731,7 +731,7 @@ contains
                                 currentCohort%canopy_trim = (currentCohort%n*currentCohort%canopy_trim &
                                       + nextc%n*nextc%canopy_trim)/newn
 				      
-				if(use_leaf_age) then
+				if(use_leaf_age == itrue) then
 				  if(currentCohort%bl>0)then
 				    currentCohort%fracExpLeaves = (currentCohort%n*currentCohort%fracExpLeaves*currentCohort%bl &
                                       + nextc%n*nextc%fracExpLeaves*nextc%bl)/(newn*currentCohort%bl)
@@ -872,7 +872,7 @@ contains
                                    enddo
 				   
 				   !leaf age
-				   if(use_leaf_age) then
+				   if(use_leaf_age == itrue) then
 				    if(currentCohort%bl>0)then
 				      currentCohort%fracExpLeaves = (currentCohort%n*currentCohort%fracExpLeaves*currentCohort%bl &
                                        + nextc%n*nextc%fracExpLeaves*nextc%bl)/(newn*currentCohort%bl)

--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -21,6 +21,7 @@ module EDCohortDynamicsMod
   use EDTypesMod            , only : min_npm2, min_nppatch
   use EDTypesMod            , only : min_n_safemath
   use EDTypesMod            , only : nlevleaf
+  use EDTypesMod            , only : use_leaf_age
   use FatesInterfaceMod      , only : hlm_use_planthydro
   use FatesPlantHydraulicsMod, only : FuseCohortHydraulics
   use FatesPlantHydraulicsMod, only : CopyCohortHydraulics
@@ -709,6 +710,17 @@ contains
                                 
                                 currentCohort%canopy_trim = (currentCohort%n*currentCohort%canopy_trim &
                                       + nextc%n*nextc%canopy_trim)/newn
+				      
+				if(use_leaf_age) then
+				  currentCohort%fracExpLeaves = (currentCohort%n*currentCohort%fracExpLeaves*currentCohort%bl &
+                                      + nextc%n*nextc%fracExpLeaves*nextc%bl)/newn
+				  currentCohort%fracYoungLeaves = (currentCohort%n*currentCohort%fracYoungLeaves*currentCohort%bl   &
+                                      + nextc%n*nextc%fracYoungLeaves*nextc%bl)/newn
+				  currentCohort%fracOldLeaves = (currentCohort%n*currentCohort%fracOldLeaves*currentCohort%bl   &
+                                      + nextc%n*nextc%fracOldLeaves*nextc%bl)/newn
+				  currentCohort%fracSenLeaves = (currentCohort%n*currentCohort%fracSenLeaves*currentCohort%bl   &
+                                      + nextc%n*nextc%fracSenLeaves*nextc%bl)/newn				      				      				      
+				endif
 
                                 ! -----------------------------------------------------------------
                                 ! If fusion pushed structural biomass to be larger than
@@ -831,7 +843,19 @@ contains
                                                nextc%n*nextc%year_net_uptake(i))/newn                
                                       endif
                                    enddo
-                                   
+				   
+				   !leaf age
+				   if(use_leaf_age) then
+				    currentCohort%fracExpLeaves = (currentCohort%n*currentCohort%fracExpLeaves*currentCohort%bl &
+                                      + nextc%n*nextc%fracExpLeaves*nextc%bl)/newn
+				    currentCohort%fracYoungLeaves = (currentCohort%n*currentCohort%fracYoungLeaves*currentCohort%bl   &
+                                      + nextc%n*nextc%fracYoungLeaves*nextc%bl)/newn
+				    currentCohort%fracOldLeaves = (currentCohort%n*currentCohort%fracOldLeaves*currentCohort%bl   &
+                                      + nextc%n*nextc%fracOldLeaves*nextc%bl)/newn
+				    currentCohort%fracSenLeaves = (currentCohort%n*currentCohort%fracSenLeaves*currentCohort%bl   &
+                                      + nextc%n*nextc%fracSenLeaves*nextc%bl)/newn				      				      				      
+				   endif
+                                     
                                 end if !(currentCohort%isnew)
 
                                 currentCohort%n = newn     
@@ -1200,6 +1224,14 @@ contains
     n%lmort_direct=o%lmort_direct
     n%lmort_collateral =o%lmort_collateral
     n%lmort_infra =o%lmort_infra
+    
+    if(use_leaf_age==itrue) then
+          n%fracExpLeaves = o%fracExpLeaves
+	  n%fracYoungLeaves = o%fracYoungLeaves
+	  n%fracOldLeaves = o%fracOldLeaves
+	  n%fracSenLeaves = o%fracSenLeaves
+    endif
+
 
     ! Flags
     n%isnew = o%isnew

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -1115,8 +1115,13 @@ contains
     
     if (EDPftvarcon_inst%evergreen(ipft) == 1)then
        if(use_leaf_age==itrue)then
-          currentCohort%leaf_md = currentCohort%bl*currentCohort%fracSenLeaves&
-	        / EDPftvarcon_inst%senleaf_long(ipft) 	 
+          if(currentSite%dstatus==1)then
+            currentCohort%leaf_md = currentCohort%bl*currentCohort%fracSenLeaves &
+	        / (EDPftvarcon_inst%senleaf_long(ipft)* EDPftvarcon_inst%senleaf_long_fdrought(ipft))
+          else
+	    currentCohort%leaf_md = currentCohort%bl*currentCohort%fracSenLeaves&
+	        / EDPftvarcon_inst%senleaf_long(ipft)
+	  endif			 
        else
          currentCohort%leaf_md = currentCohort%bl / EDPftvarcon_inst%leaf_long(ipft)
        endif
@@ -1153,7 +1158,11 @@ contains
 	  dOldLeaves_dt=previous_bl *currentCohort%fracOldLeaves &
 	                 / EDPftvarcon_inst%oldleaf_long(ipft)*hlm_freq_day			 			 
 	  dSenLeaves_dt=previous_bl *currentCohort%fracSenLeaves &
-	                 / EDPftvarcon_inst%senleaf_long(ipft)*hlm_freq_day	
+	                 / EDPftvarcon_inst%senleaf_long(ipft)*hlm_freq_day
+	  if(currentSite%dstatus==1)  then !drought periods
+	       dSenLeaves_dt=previous_bl *currentCohort%fracSenLeaves &
+	       /(EDPftvarcon_inst%senleaf_long(ipft)*EDPftvarcon_inst%senleaf_long_fdrought(ipft))*hlm_freq_day	  
+	  endif	
 	  currentCohort%fracExpLeaves = (previous_bl *currentCohort%fracExpLeaves-dExpLeaves_dt)&
 	                /currentCohort%bl
 	  currentCohort%fracYoungLeaves = (previous_bl *currentCohort%fracYoungLeaves+dExpLeaves_dt- &
@@ -1485,7 +1494,7 @@ contains
           currentCohort%bl        = currentCohort%bl + bl_flux
           currentCohort%npp_leaf  = currentCohort%npp_leaf + bl_flux / hlm_freq_day
           if(use_leaf_age==itrue.and.currentCohort%bl>0.0_r8) then
-	     currentCohort%fracExpLeaves = (previous_bl *currentCohort%fracExpLeaves + bl_flux)&
+	     currentCohort%fracExpLeaves = (previous_bl *currentCohort%fracExpLeaves + bl_flux) &
 	                                   /currentCohort%bl
 	     currentCohort%fracYoungLeaves = (previous_bl *currentCohort%fracYoungLeaves)/currentCohort%bl
 	     currentCohort%fracOldLeaves = (previous_bl *currentCohort%fracOldLeaves)/currentCohort%bl

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -284,11 +284,11 @@ contains
                    ! Leaf cost at leaf level z accounting for sla profile
 		   if(use_leaf_age==itrue)then
                       currentCohort%leaf_cost = 1.0_r8/(sla_levleaf* &
-                        (currentCohort%fracExpLeaves*EDPftvarcon_inst%expleaf_long(ipft)+ &
-			 currentCohort%fracYoungLeaves*EDPftvarcon_inst%youngleaf_long(ipft) + &
-			 currentCohort%fracOldLeaves*EDPftvarcon_inst%oldleaf_long(ipft) + &
-			 currentCohort%fracSenLeaves*EDPftvarcon_inst%senleaf_long(ipft) ) & 
-			 *1000.0_r8) !convert from sla in m2g-1 to m2kg-1		   
+                        (currentCohort%fracExpLeaves*EDPftvarcon_inst%expleaf_flong(ipft)+ &
+			 currentCohort%fracYoungLeaves*EDPftvarcon_inst%youngleaf_flong(ipft) + &
+			 currentCohort%fracOldLeaves*EDPftvarcon_inst%oldleaf_flong(ipft) + &
+			 currentCohort%fracSenLeaves*EDPftvarcon_inst%senleaf_flong(ipft) ) & 
+			 *EDPftvarcon_inst%leaf_long(ipft)*1000.0_r8) !convert from sla in m2g-1 to m2kg-1		   
 		   else
                       currentCohort%leaf_cost = 1.0_r8/(sla_levleaf* &
                         EDPftvarcon_inst%leaf_long(ipft)*1000.0_r8) !convert from sla in m2g-1 to m2kg-1
@@ -1117,10 +1117,11 @@ contains
        if(use_leaf_age==itrue)then
           if(currentSite%dstatus==1)then
             currentCohort%leaf_md = currentCohort%bl*currentCohort%fracSenLeaves &
-	        / (EDPftvarcon_inst%senleaf_long(ipft)* EDPftvarcon_inst%senleaf_long_fdrought(ipft))
+	        / (EDPftvarcon_inst%senleaf_flong(ipft)*EDPftvarcon_inst%leaf_long(ipft) &
+		 * EDPftvarcon_inst%senleaf_long_fdrought(ipft))
           else
 	    currentCohort%leaf_md = currentCohort%bl*currentCohort%fracSenLeaves&
-	        / EDPftvarcon_inst%senleaf_long(ipft)
+	        / (EDPftvarcon_inst%leaf_long(ipft)* EDPftvarcon_inst%senleaf_flong(ipft))
 	  endif			 
        else
          currentCohort%leaf_md = currentCohort%bl / EDPftvarcon_inst%leaf_long(ipft)
@@ -1151,17 +1152,18 @@ contains
     
     if(use_leaf_age.and. currentCohort%bl>0.0_r8)then
     	  !advance the leaf ages	  
-	  dExpLeaves_dt=previous_bl *currentCohort%fracExpLeaves &
-	                 / EDPftvarcon_inst%expleaf_long(ipft)*hlm_freq_day
-	  dYoungLeaves_dt=previous_bl *currentCohort%fracYoungLeaves &
-	                 / EDPftvarcon_inst%youngleaf_long(ipft)*hlm_freq_day	
-	  dOldLeaves_dt=previous_bl *currentCohort%fracOldLeaves &
-	                 / EDPftvarcon_inst%oldleaf_long(ipft)*hlm_freq_day			 			 
-	  dSenLeaves_dt=previous_bl *currentCohort%fracSenLeaves &
-	                 / EDPftvarcon_inst%senleaf_long(ipft)*hlm_freq_day
+	  dExpLeaves_dt=previous_bl *currentCohort%fracExpLeaves/(EDPftvarcon_inst%leaf_long(ipft)&
+	                 *EDPftvarcon_inst%expleaf_flong(ipft))*hlm_freq_day
+	  dYoungLeaves_dt=previous_bl *currentCohort%fracYoungLeaves/(EDPftvarcon_inst%leaf_long(ipft) &
+	                 *EDPftvarcon_inst%youngleaf_flong(ipft))*hlm_freq_day	
+	  dOldLeaves_dt=previous_bl *currentCohort%fracOldLeaves /(EDPftvarcon_inst%leaf_long(ipft) &
+	                 * EDPftvarcon_inst%oldleaf_flong(ipft))*hlm_freq_day			 			 
+	  dSenLeaves_dt=previous_bl *currentCohort%fracSenLeaves / (EDPftvarcon_inst%leaf_long(ipft) &
+	                 * EDPftvarcon_inst%senleaf_flong(ipft))*hlm_freq_day
 	  if(currentSite%dstatus==1)  then !drought periods
 	       dSenLeaves_dt=previous_bl *currentCohort%fracSenLeaves &
-	       /(EDPftvarcon_inst%senleaf_long(ipft)*EDPftvarcon_inst%senleaf_long_fdrought(ipft))*hlm_freq_day	  
+	       /(EDPftvarcon_inst%senleaf_flong(ipft)*EDPftvarcon_inst%senleaf_long_fdrought(ipft) &
+	       * EDPftvarcon_inst%leaf_long(ipft))*hlm_freq_day	  
 	  endif	
 	  currentCohort%fracExpLeaves = (previous_bl *currentCohort%fracExpLeaves-dExpLeaves_dt)&
 	                /currentCohort%bl

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -964,8 +964,9 @@ contains
     real(r8) :: previous_bl      !previous time step bleaf
     real(r8) :: dExpLeaves_dt    !change of amount of expanding leavese due to aging
     real(r8) :: dYoungLeaves_dt  !change of amount of youngleavese due to aging
-    real(r8) :: dOldLeaves_dt  !change of amount of old leavese due to aging
-    real(r8) :: dSenLeaves_dt  !change of amount of senescent leavese due to aging
+    real(r8) :: dOldLeaves_dt    !change of amount of old leavese due to aging
+    real(r8) :: dSenLeaves_dt    !change of amount of senescent leavese due to aging
+    real(r8) :: sumAgeFrac       !sum of leaf age fractions
 
     ! Woody turnover timescale [years]
     real(r8), parameter :: cbal_prec = 1.0e-15_r8     ! Desired precision in carbon balance
@@ -1167,6 +1168,16 @@ contains
 	               dOldLeaves_dt)/currentCohort%bl
 	  currentCohort%fracSenLeaves = (previous_bl *currentCohort%fracSenLeaves+dOldLeaves_dt- &
 	               dSenLeaves_dt)/currentCohort%bl	
+          sumAgeFrac = currentCohort%fracExpLeaves + currentCohort%fracYoungLeaves + &
+	        currentCohort%fracOldLeaves + currentCohort%fracSenLeaves
+	  if(sumAgeFrac > 1.01_r8)then
+	     write(fates_log(),*) 'Warning: Sum of leaf age fraction become larger than 1.0, &
+	           sumAgeFrac= ',sumAgeFrac 
+	  endif
+	  if(sumAgeFrac < 0.99_r8)then
+	     write(fates_log(),*) 'Warning: Sum of leaf age fraction become less than 1.0, &
+	           sumAgeFrac= ',sumAgeFrac 	     
+	  endif	  
     endif
     ! -----------------------------------------------------------------------------------
     ! V.  Prioritize some amount of carbon to replace leaf/root turnover
@@ -1205,7 +1216,17 @@ contains
 	                /currentCohort%bl
 	  currentCohort%fracYoungLeaves = (previous_bl *currentCohort%fracYoungLeaves)/currentCohort%bl
 	  currentCohort%fracOldLeaves = (previous_bl *currentCohort%fracOldLeaves)/currentCohort%bl
-	  currentCohort%fracSenLeaves = (previous_bl *currentCohort%fracSenLeaves)/currentCohort%bl	       
+	  currentCohort%fracSenLeaves = (previous_bl *currentCohort%fracSenLeaves)/currentCohort%bl	 
+          sumAgeFrac = currentCohort%fracExpLeaves + currentCohort%fracYoungLeaves + &
+	        currentCohort%fracOldLeaves + currentCohort%fracSenLeaves	  
+	  if(sumAgeFrac > 1.01_r8)then
+	     write(fates_log(),*) 'Warning: Sum of leaf age fraction become larger than 1.0, &
+	           sumAgeFrac= ',sumAgeFrac 
+	  endif
+	  if(sumAgeFrac < 0.99_r8)then
+	     write(fates_log(),*) 'Warning: Sum of leaf age fraction become less than 1.0, &
+	           sumAgeFrac= ',sumAgeFrac 	     
+	  endif	        
        endif
 
     end if

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -282,17 +282,8 @@ contains
                          (EDPftvarcon_inst%grperc(ipft) + 1._r8)
                 else !evergreen costs
                    ! Leaf cost at leaf level z accounting for sla profile
-		   if(use_leaf_age==itrue)then
-                      currentCohort%leaf_cost = 1.0_r8/(sla_levleaf* &
-                        (currentCohort%fracExpLeaves*EDPftvarcon_inst%expleaf_flong(ipft)+ &
-			 currentCohort%fracYoungLeaves*EDPftvarcon_inst%youngleaf_flong(ipft) + &
-			 currentCohort%fracOldLeaves*EDPftvarcon_inst%oldleaf_flong(ipft) + &
-			 currentCohort%fracSenLeaves*EDPftvarcon_inst%senleaf_flong(ipft) ) & 
-			 *EDPftvarcon_inst%leaf_long(ipft)*1000.0_r8) !convert from sla in m2g-1 to m2kg-1		   
-		   else
-                      currentCohort%leaf_cost = 1.0_r8/(sla_levleaf* &
+                   currentCohort%leaf_cost = 1.0_r8/(sla_levleaf* &
                         EDPftvarcon_inst%leaf_long(ipft)*1000.0_r8) !convert from sla in m2g-1 to m2kg-1
-		   endif
                    if ( int(EDPftvarcon_inst%allom_fmode(ipft)) .eq. 1 ) then
                       ! if using trimmed leaf for fine root biomass allometry, add the cost of the root increment
                       ! to the leaf increment; otherwise do not.

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -633,7 +633,12 @@ contains
                       ! The tendency for this could be parameterized
                       currentCohort%bl = currentCohort%bstore * store_output
                    endif
-
+		   if(use_leaf_age==itrue)then
+	               currentCohort%fracExpLeaves = 1.0_r8
+	               currentCohort%fracYoungLeaves = 0.0_r8
+	               currentCohort%fracOldLeaves = 0.0_r8
+	               currentCohort%fracSenLeaves = 0.0_r8		     
+		   endif
 
                    if ( DEBUG ) write(fates_log(),*) 'EDPhysMod 1 ',currentCohort%bstore
 
@@ -657,7 +662,12 @@ contains
                    ! add lost carbon to litter
                    currentCohort%leaf_litter = currentCohort%bl 
                    currentCohort%bl          = 0.0_r8   
-               
+		   if(use_leaf_age==itrue)then
+	               currentCohort%fracExpLeaves = 0.0_r8
+	               currentCohort%fracYoungLeaves = 0.0_r8
+	               currentCohort%fracOldLeaves = 0.0_r8
+	               currentCohort%fracSenLeaves = 0.0_r8		     
+		   endif               
                 endif !leaf status
              endif !currentSite status
           endif  !season_decid
@@ -673,8 +683,13 @@ contains
 
                     !we can only put on as much carbon as there is in the store.
                     currentCohort%bl = currentCohort%bstore * store_output
-                    endif
-
+                   endif
+		   if(use_leaf_age==itrue)then
+	               currentCohort%fracExpLeaves = 1.0_r8
+	               currentCohort%fracYoungLeaves = 0.0_r8
+	               currentCohort%fracOldLeaves = 0.0_r8
+	               currentCohort%fracSenLeaves = 0.0_r8		     
+		   endif
                    if ( DEBUG ) write(fates_log(),*) 'EDPhysMod 3 ',currentCohort%bstore
 
                    currentCohort%bstore = currentCohort%bstore - currentCohort%bl ! empty store
@@ -696,7 +711,12 @@ contains
                    ! add falling leaves to litter pools . convert to KgC/m2                    
                    currentCohort%leaf_litter = currentCohort%bl  
                    currentCohort%bl          = 0.0_r8                                        
-
+		   if(use_leaf_age==itrue)then
+	               currentCohort%fracExpLeaves = 0.0_r8
+	               currentCohort%fracYoungLeaves = 0.0_r8
+	               currentCohort%fracOldLeaves = 0.0_r8
+	               currentCohort%fracSenLeaves = 0.0_r8		     
+		   endif
                 endif
              endif !status
           endif !drought dec.
@@ -1124,7 +1144,7 @@ contains
     currentCohort%bdead  = currentCohort%bdead - currentCohort%bdead_md*hlm_freq_day
     currentCohort%bstore = currentCohort%bstore - currentCohort%bstore_md*hlm_freq_day
     
-    if(use_leaf_age)then
+    if(use_leaf_age.and. currentCohort%bl>0.0_r8)then
     	  !advance the leaf ages	  
 	  dExpLeaves_dt=previous_bl *currentCohort%fracExpLeaves &
 	                 / EDPftvarcon_inst%expleaf_long(ipft)*hlm_freq_day
@@ -1240,7 +1260,7 @@ contains
        carbon_balance         = carbon_balance - br_flux
        currentCohort%br       = currentCohort%br +  br_flux
        currentCohort%npp_fnrt = currentCohort%npp_fnrt + br_flux / hlm_freq_day
-       if(use_leaf_age==itrue) then
+       if(use_leaf_age==itrue .and. currentCohort%bl>0.0_r8) then
 	  currentCohort%fracExpLeaves = (previous_bl *currentCohort%fracExpLeaves +  bl_flux)&
 	                /currentCohort%bl
 	  currentCohort%fracYoungLeaves = (previous_bl *currentCohort%fracYoungLeaves)/currentCohort%bl
@@ -1464,7 +1484,7 @@ contains
           carbon_balance          = carbon_balance - bl_flux
           currentCohort%bl        = currentCohort%bl + bl_flux
           currentCohort%npp_leaf  = currentCohort%npp_leaf + bl_flux / hlm_freq_day
-          if(use_leaf_age==itrue) then
+          if(use_leaf_age==itrue.and.currentCohort%bl>0.0_r8) then
 	     currentCohort%fracExpLeaves = (previous_bl *currentCohort%fracExpLeaves + bl_flux)&
 	                                   /currentCohort%bl
 	     currentCohort%fracYoungLeaves = (previous_bl *currentCohort%fracYoungLeaves)/currentCohort%bl

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -1153,7 +1153,7 @@ contains
     currentCohort%bdead  = currentCohort%bdead - currentCohort%bdead_md*hlm_freq_day
     currentCohort%bstore = currentCohort%bstore - currentCohort%bstore_md*hlm_freq_day
     
-    if(use_leaf_age.and. currentCohort%bl>0.0_r8)then
+    if(use_leaf_age==itrue.and. currentCohort%bl>0.0_r8)then
     	  !advance the leaf ages	  
 	  dExpLeaves_dt=previous_bl *currentCohort%fracExpLeaves/(EDPftvarcon_inst%leaf_long(ipft)&
 	                 *EDPftvarcon_inst%expleaf_flong(ipft))*hlm_freq_day

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -1195,7 +1195,7 @@ contains
        currentCohort%br            = currentCohort%br +  br_flux
        currentCohort%npp_fnrt      = currentCohort%npp_fnrt + br_flux / hlm_freq_day
        
-       if(use_leaf_age==itrue) then
+       if(use_leaf_age==itrue.and.currentCohort%bl > 0.0_r8) then
 	  currentCohort%fracExpLeaves = (previous_bl *currentCohort%fracExpLeaves +  bl_flux)&
 	                /currentCohort%bl
 	  currentCohort%fracYoungLeaves = (previous_bl *currentCohort%fracYoungLeaves)/currentCohort%bl
@@ -1318,7 +1318,7 @@ contains
        carbon_balance               = carbon_balance - bstore_flux
        currentCohort%bstore         = currentCohort%bstore +  bstore_flux
        currentCohort%npp_stor       = currentCohort%npp_stor + bstore_flux / hlm_freq_day
-       if(use_leaf_age==itrue) then
+       if(use_leaf_age==itrue .and. currentCohort%bl> 0.0_r8) then
 	  currentCohort%fracExpLeaves = (previous_bl *currentCohort%fracExpLeaves + bl_flux)/currentCohort%bl
 	  currentCohort%fracYoungLeaves = (previous_bl *currentCohort%fracYoungLeaves)/currentCohort%bl
 	  currentCohort%fracOldLeaves = (previous_bl *currentCohort%fracOldLeaves)/currentCohort%bl

--- a/biogeophys/FatesPlantHydraulicsMod.F90
+++ b/biogeophys/FatesPlantHydraulicsMod.F90
@@ -1689,7 +1689,6 @@ end subroutine updateSizeDepRhizHydStates
            ! ----------------------------------------------------------------------------
 
            patch_wgt = min(1.0_r8,cpatch%total_canopy_area/cpatch%area) * (cpatch%area/AREA)
-	   bc_out(s)%lwp_pa(ifp) = 0.0_r8
 	   total_lai = sum(cpatch%canopy_layer_tlai)
 
            ! Total volume transpired from this patch [mm H2O / m2 /s ] * [m2/patch] = [mm H2O / patch / s]
@@ -2252,11 +2251,6 @@ end subroutine updateSizeDepRhizHydStates
                                (ccohort_hydr%flc_aroot(j) - ccohort_hydr%flc_min_aroot(j))*exp(-refill_rate*dtime)
                       end if
                    end do
-                   !----------------------------------------------------------------------------------------------
-		   !calculate the leaf water potential at the patch level weighed by leaf area
-		   if(total_lai>0.0_r8)then
-		     bc_out(s)%lwp_pa(ifp) = bc_out(s)%lwp_pa(ifp) + ccohort_hydr%psi_ag(1)*ccohort%lai/total_lai
-		   endif
 		   
                    ccohort => ccohort%shorter
                 enddo !cohort 

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -8,7 +8,7 @@ module EDInitMod
   use FatesConstantsMod         , only : ifalse
   use FatesConstantsMod         , only : itrue
   use FatesGlobals              , only : endrun => fates_endrun
-  use EDTypesMod                , only : nclmax
+  use EDTypesMod                , only : nclmax,use_leaf_age
   use FatesGlobals              , only : fates_log
   use FatesInterfaceMod         , only : hlm_is_restart
   use EDPftvarcon               , only : EDPftvarcon_inst
@@ -375,6 +375,12 @@ contains
        call h2d_allom(temp_cohort%hite,pft,temp_cohort%dbh)
 
        temp_cohort%canopy_trim = 1.0_r8
+       if(use_leaf_age==itrue) then
+          temp_cohort%fracExpLeaves = 1.0_r8
+	  temp_cohort%fracYoungLeaves = 0.0_r8
+	  temp_cohort%fracOldLeaves = 0.0_r8
+	  temp_cohort%fracSenLeaves = 0.0_r8
+       endif
 
        ! Calculate total above-ground biomass from allometry
        call bagw_allom(temp_cohort%dbh,pft,b_agw)

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -58,6 +58,7 @@ module EDPftvarcon
      real(r8), allocatable :: youngleaf_long(:)
      real(r8), allocatable :: oldleaf_long(:)
      real(r8), allocatable :: senleaf_long(:)
+     real(r8), allocatable :: senleaf_long_fdrought(:)
      real(r8), allocatable :: roota_par(:)
      real(r8), allocatable :: rootb_par(:)
      real(r8), allocatable :: lf_flab(:)
@@ -393,7 +394,11 @@ contains
 	 	
     name = 'fates_senleaf_long'
     call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
-         dimension_names=dim_names, lower_bounds=dim_lower_bound)	 	
+         dimension_names=dim_names, lower_bounds=dim_lower_bound)
+
+    name = 'fates_senleaf_long_fdrought'
+    call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
+         dimension_names=dim_names, lower_bounds=dim_lower_bound)	 	 	
 	  
     name = 'fates_roota_par'
     call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
@@ -858,8 +863,12 @@ contains
 	 
     name = 'fates_senleaf_long'
     call fates_params%RetreiveParameterAllocate(name=name, &
-         data=this%senleaf_long)	 	 	 
+         data=this%senleaf_long)	 	 	 	 
 
+    name = 'fates_senleaf_long_fdrought'
+    call fates_params%RetreiveParameterAllocate(name=name, &
+         data=this%senleaf_long_fdrought)
+	 
     name = 'fates_roota_par'
     call fates_params%RetreiveParameterAllocate(name=name, &
          data=this%roota_par)
@@ -1584,6 +1593,7 @@ contains
 	write(fates_log(),fmt0) 'youngleaf_long = ',EDPftvarcon_inst%youngleaf_long
 	write(fates_log(),fmt0) 'oldleaf_long = ',EDPftvarcon_inst%oldleaf_long
 	write(fates_log(),fmt0) 'senleaf_long = ',EDPftvarcon_inst%senleaf_long
+	write(fates_log(),fmt0) 'senleaf_long_fdrought = ',EDPftvarcon_inst%senleaf_long_fdrought
         write(fates_log(),fmt0) 'roota_par = ',EDPftvarcon_inst%roota_par
         write(fates_log(),fmt0) 'rootb_par = ',EDPftvarcon_inst%rootb_par
         write(fates_log(),fmt0) 'lf_flab = ',EDPftvarcon_inst%lf_flab

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -54,10 +54,10 @@ module EDPftvarcon
      real(r8), allocatable :: slamax(:)
      real(r8), allocatable :: slatop(:)
      real(r8), allocatable :: leaf_long(:)
-     real(r8), allocatable :: expleaf_long(:)
-     real(r8), allocatable :: youngleaf_long(:)
-     real(r8), allocatable :: oldleaf_long(:)
-     real(r8), allocatable :: senleaf_long(:)
+     real(r8), allocatable :: expleaf_flong(:)
+     real(r8), allocatable :: youngleaf_flong(:)
+     real(r8), allocatable :: oldleaf_flong(:)
+     real(r8), allocatable :: senleaf_flong(:)
      real(r8), allocatable :: senleaf_long_fdrought(:)
      real(r8), allocatable :: roota_par(:)
      real(r8), allocatable :: rootb_par(:)
@@ -380,19 +380,19 @@ contains
     call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
          dimension_names=dim_names, lower_bounds=dim_lower_bound)
 	 
-    name = 'fates_expleaf_long'
+    name = 'fates_expleaf_flong'
     call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
          dimension_names=dim_names, lower_bounds=dim_lower_bound)
 	 	
-    name = 'fates_youngleaf_long'
+    name = 'fates_youngleaf_flong'
     call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
          dimension_names=dim_names, lower_bounds=dim_lower_bound)
 	 	
-    name = 'fates_oldleaf_long'
+    name = 'fates_oldleaf_flong'
     call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
          dimension_names=dim_names, lower_bounds=dim_lower_bound)
 	 	
-    name = 'fates_senleaf_long'
+    name = 'fates_senleaf_flong'
     call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
          dimension_names=dim_names, lower_bounds=dim_lower_bound)
 
@@ -849,21 +849,21 @@ contains
     call fates_params%RetreiveParameterAllocate(name=name, &
          data=this%leaf_long)
 	 
-    name = 'fates_expleaf_long'
+    name = 'fates_expleaf_flong'
     call fates_params%RetreiveParameterAllocate(name=name, &
-         data=this%expleaf_long)
+         data=this%expleaf_flong)
 	 
-    name = 'fates_youngleaf_long'
+    name = 'fates_youngleaf_flong'
     call fates_params%RetreiveParameterAllocate(name=name, &
-         data=this%youngleaf_long)
+         data=this%youngleaf_flong)
 	 
-    name = 'fates_oldleaf_long'
+    name = 'fates_oldleaf_flong'
     call fates_params%RetreiveParameterAllocate(name=name, &
-         data=this%oldleaf_long)
+         data=this%oldleaf_flong)
 	 
-    name = 'fates_senleaf_long'
+    name = 'fates_senleaf_flong'
     call fates_params%RetreiveParameterAllocate(name=name, &
-         data=this%senleaf_long)	 	 	 	 
+         data=this%senleaf_flong)	 	 	 	 
 
     name = 'fates_senleaf_long_fdrought'
     call fates_params%RetreiveParameterAllocate(name=name, &
@@ -1589,10 +1589,10 @@ contains
         write(fates_log(),fmt0) 'slamax = ',EDPftvarcon_inst%slamax
         write(fates_log(),fmt0) 'slatop = ',EDPftvarcon_inst%slatop        
         write(fates_log(),fmt0) 'leaf_long = ',EDPftvarcon_inst%leaf_long
-	write(fates_log(),fmt0) 'expleaf_long = ',EDPftvarcon_inst%expleaf_long
-	write(fates_log(),fmt0) 'youngleaf_long = ',EDPftvarcon_inst%youngleaf_long
-	write(fates_log(),fmt0) 'oldleaf_long = ',EDPftvarcon_inst%oldleaf_long
-	write(fates_log(),fmt0) 'senleaf_long = ',EDPftvarcon_inst%senleaf_long
+	write(fates_log(),fmt0) 'expleaf_flong = ',EDPftvarcon_inst%expleaf_flong
+	write(fates_log(),fmt0) 'youngleaf_flong = ',EDPftvarcon_inst%youngleaf_flong
+	write(fates_log(),fmt0) 'oldleaf_flong = ',EDPftvarcon_inst%oldleaf_flong
+	write(fates_log(),fmt0) 'senleaf_flong = ',EDPftvarcon_inst%senleaf_flong
 	write(fates_log(),fmt0) 'senleaf_long_fdrought = ',EDPftvarcon_inst%senleaf_long_fdrought
         write(fates_log(),fmt0) 'roota_par = ',EDPftvarcon_inst%roota_par
         write(fates_log(),fmt0) 'rootb_par = ',EDPftvarcon_inst%rootb_par
@@ -1709,6 +1709,8 @@ contains
      character(len=32),parameter :: fmt0 = '(a,100(F12.4,1X))'
 
      integer :: npft,ipft
+     
+     real(r8):: totalfraction !total fraction of leaf longevity at different ages
 
      npft = size(EDPftvarcon_inst%pft_used,1)
 
@@ -1830,6 +1832,15 @@ contains
            call endrun(msg=errMsg(sourcefile, __LINE__))
 
         end if
+	
+	!check fraction of leaf longevity for leaf age is equal to one
+	totalfraction = EDPftvarcon_inst%expleaf_flong(ipft)+EDPftvarcon_inst%youngleaf_flong(ipft) &
+	     +EDPftvarcon_inst%oldleaf_flong(ipft)+EDPftvarcon_inst%senleaf_flong(ipft) 
+	if(totalfraction < 0.999_r8.or.totalfraction>1.001_r8) then
+	     write(fates_log(),*) 'Error: total fraction longevity of different leaf ages is not add up to 1.0'
+	     call endrun(msg=errMsg(sourcefile, __LINE__))
+	 endif
+	
 
      end do
      

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -53,12 +53,12 @@ module EDPftvarcon
      real(r8), allocatable :: evergreen(:)
      real(r8), allocatable :: slamax(:)
      real(r8), allocatable :: slatop(:)
-     real(r8), allocatable :: leaf_long(:)
-     real(r8), allocatable :: expleaf_flong(:)
-     real(r8), allocatable :: youngleaf_flong(:)
-     real(r8), allocatable :: oldleaf_flong(:)
-     real(r8), allocatable :: senleaf_flong(:)
-     real(r8), allocatable :: senleaf_long_fdrought(:)
+     real(r8), allocatable :: leaf_long(:)  !Leaf longevity (ie turnover timescale)
+     real(r8), allocatable :: expleaf_flong(:) !Fraction of leaf longevity for expanding leaves(ie turnover timescale)
+     real(r8), allocatable :: youngleaf_flong(:) !Fraction of leaf longevity for young leaves(ie turnover timescale)
+     real(r8), allocatable :: oldleaf_flong(:) !Fraction of leaf longevity for old leaves(ie turnover timescale)
+     real(r8), allocatable :: senleaf_flong(:) !Fraction of leaf longevity for senescent leaves(ie turnover timescale)
+     real(r8), allocatable :: senleaf_long_fdrought(:) !Multiplication factor for leaf longevity of senescent leaves during drought(1.0 indicates no change) 
      real(r8), allocatable :: roota_par(:)
      real(r8), allocatable :: rootb_par(:)
      real(r8), allocatable :: lf_flab(:)
@@ -71,11 +71,11 @@ module EDPftvarcon
      real(r8), allocatable :: clumping_index(:) ! factor describing how much self-occlusion 
                                                 ! of leaf scattering elements decreases light interception
      real(r8), allocatable :: c3psn(:)          ! index defining the photosynthetic pathway C4 = 0,  C3 = 1
-     real(r8), allocatable :: vcmax25top(:)
-     real(r8), allocatable :: vcmax25top_fexp(:)
-     real(r8), allocatable :: vcmax25top_fyoung(:)
-     real(r8), allocatable :: vcmax25top_fold(:)
-     real(r8), allocatable :: vcmax25top_fsen(:)          
+     real(r8), allocatable :: vcmax25top(:)     !maximum carboxylation rate of Rub. at 25C, canopy top
+     real(r8), allocatable :: vcmax25top_fexp(:) !mutiplying factor of vcmax25 for expanding leaves
+     real(r8), allocatable :: vcmax25top_fyoung(:)!mutiplying factor of vcmax25 for young leaves
+     real(r8), allocatable :: vcmax25top_fold(:)  !mutiplying factor of vcmax25 for old leaves
+     real(r8), allocatable :: vcmax25top_fsen(:)  !mutiplying factor of vcmax25 for senescent leaves        
      real(r8), allocatable :: leafcn(:)
      real(r8), allocatable :: frootcn(:)
      real(r8), allocatable :: woodcn(:)

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -54,6 +54,10 @@ module EDPftvarcon
      real(r8), allocatable :: slamax(:)
      real(r8), allocatable :: slatop(:)
      real(r8), allocatable :: leaf_long(:)
+     real(r8), allocatable :: expleaf_long(:)
+     real(r8), allocatable :: youngleaf_long(:)
+     real(r8), allocatable :: oldleaf_long(:)
+     real(r8), allocatable :: senleaf_long(:)
      real(r8), allocatable :: roota_par(:)
      real(r8), allocatable :: rootb_par(:)
      real(r8), allocatable :: lf_flab(:)
@@ -67,6 +71,10 @@ module EDPftvarcon
                                                 ! of leaf scattering elements decreases light interception
      real(r8), allocatable :: c3psn(:)          ! index defining the photosynthetic pathway C4 = 0,  C3 = 1
      real(r8), allocatable :: vcmax25top(:)
+     real(r8), allocatable :: vcmax25top_fexp(:)
+     real(r8), allocatable :: vcmax25top_fyoung(:)
+     real(r8), allocatable :: vcmax25top_fold(:)
+     real(r8), allocatable :: vcmax25top_fsen(:)          
      real(r8), allocatable :: leafcn(:)
      real(r8), allocatable :: frootcn(:)
      real(r8), allocatable :: woodcn(:)
@@ -370,7 +378,23 @@ contains
     name = 'fates_leaf_long'
     call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
          dimension_names=dim_names, lower_bounds=dim_lower_bound)
-
+	 
+    name = 'fates_expleaf_long'
+    call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
+         dimension_names=dim_names, lower_bounds=dim_lower_bound)
+	 	
+    name = 'fates_youngleaf_long'
+    call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
+         dimension_names=dim_names, lower_bounds=dim_lower_bound)
+	 	
+    name = 'fates_oldleaf_long'
+    call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
+         dimension_names=dim_names, lower_bounds=dim_lower_bound)
+	 	
+    name = 'fates_senleaf_long'
+    call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
+         dimension_names=dim_names, lower_bounds=dim_lower_bound)	 	
+	  
     name = 'fates_roota_par'
     call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
          dimension_names=dim_names, lower_bounds=dim_lower_bound)
@@ -417,6 +441,22 @@ contains
          dimension_names=dim_names, lower_bounds=dim_lower_bound)
 
     name = 'fates_leaf_vcmax25top'
+    call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
+         dimension_names=dim_names, lower_bounds=dim_lower_bound)
+
+    name = 'fates_leaf_vcmax25top_fexp'
+    call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
+         dimension_names=dim_names, lower_bounds=dim_lower_bound)
+
+    name = 'fates_leaf_vcmax25top_fyoung'
+    call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
+         dimension_names=dim_names, lower_bounds=dim_lower_bound)
+
+    name = 'fates_leaf_vcmax25top_fold'
+    call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
+         dimension_names=dim_names, lower_bounds=dim_lower_bound)
+
+    name = 'fates_leaf_vcmax25top_fsen'
     call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
          dimension_names=dim_names, lower_bounds=dim_lower_bound)
 
@@ -803,6 +843,22 @@ contains
     name = 'fates_leaf_long'
     call fates_params%RetreiveParameterAllocate(name=name, &
          data=this%leaf_long)
+	 
+    name = 'fates_expleaf_long'
+    call fates_params%RetreiveParameterAllocate(name=name, &
+         data=this%expleaf_long)
+	 
+    name = 'fates_youngleaf_long'
+    call fates_params%RetreiveParameterAllocate(name=name, &
+         data=this%youngleaf_long)
+	 
+    name = 'fates_oldleaf_long'
+    call fates_params%RetreiveParameterAllocate(name=name, &
+         data=this%oldleaf_long)
+	 
+    name = 'fates_senleaf_long'
+    call fates_params%RetreiveParameterAllocate(name=name, &
+         data=this%senleaf_long)	 	 	 
 
     name = 'fates_roota_par'
     call fates_params%RetreiveParameterAllocate(name=name, &
@@ -851,6 +907,22 @@ contains
     name = 'fates_leaf_vcmax25top'
     call fates_params%RetreiveParameterAllocate(name=name, &
          data=this%vcmax25top)
+
+    name = 'fates_leaf_vcmax25top_fexp'
+    call fates_params%RetreiveParameterAllocate(name=name, &
+         data=this%vcmax25top_fexp)
+
+    name = 'fates_leaf_vcmax25top_fyoung'
+    call fates_params%RetreiveParameterAllocate(name=name, &
+         data=this%vcmax25top_fyoung)
+
+    name = 'fates_leaf_vcmax25top_fold'
+    call fates_params%RetreiveParameterAllocate(name=name, &
+         data=this%vcmax25top_fold)
+
+    name = 'fates_leaf_vcmax25top_fsen'
+    call fates_params%RetreiveParameterAllocate(name=name, &
+         data=this%vcmax25top_fsen)
 
     name = 'fates_leaf_cn_ratio'
     call fates_params%RetreiveParameterAllocate(name=name, &
@@ -1508,6 +1580,10 @@ contains
         write(fates_log(),fmt0) 'slamax = ',EDPftvarcon_inst%slamax
         write(fates_log(),fmt0) 'slatop = ',EDPftvarcon_inst%slatop        
         write(fates_log(),fmt0) 'leaf_long = ',EDPftvarcon_inst%leaf_long
+	write(fates_log(),fmt0) 'expleaf_long = ',EDPftvarcon_inst%expleaf_long
+	write(fates_log(),fmt0) 'youngleaf_long = ',EDPftvarcon_inst%youngleaf_long
+	write(fates_log(),fmt0) 'oldleaf_long = ',EDPftvarcon_inst%oldleaf_long
+	write(fates_log(),fmt0) 'senleaf_long = ',EDPftvarcon_inst%senleaf_long
         write(fates_log(),fmt0) 'roota_par = ',EDPftvarcon_inst%roota_par
         write(fates_log(),fmt0) 'rootb_par = ',EDPftvarcon_inst%rootb_par
         write(fates_log(),fmt0) 'lf_flab = ',EDPftvarcon_inst%lf_flab
@@ -1520,6 +1596,10 @@ contains
         write(fates_log(),fmt0) 'clumping_index = ',EDPftvarcon_inst%clumping_index
         write(fates_log(),fmt0) 'c3psn = ',EDPftvarcon_inst%c3psn
         write(fates_log(),fmt0) 'vcmax25top = ',EDPftvarcon_inst%vcmax25top
+        write(fates_log(),fmt0) 'vcmax25top_fexp = ',EDPftvarcon_inst%vcmax25top_fexp
+        write(fates_log(),fmt0) 'vcmax25top_fyoung = ',EDPftvarcon_inst%vcmax25top_fyoung
+        write(fates_log(),fmt0) 'vcmax25top_fold = ',EDPftvarcon_inst%vcmax25top_fold
+        write(fates_log(),fmt0) 'vcmax25top_fsen = ',EDPftvarcon_inst%vcmax25top_fsen	
         write(fates_log(),fmt0) 'leafcn = ',EDPftvarcon_inst%leafcn
         write(fates_log(),fmt0) 'frootcn = ',EDPftvarcon_inst%frootcn
         write(fates_log(),fmt0) 'woodcn = ',EDPftvarcon_inst%woodcn

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -123,6 +123,7 @@ module EDTypesMod
   ! special mode to cause PFTs to create seed mass of all currently-existing PFTs
   logical, parameter :: homogenize_seed_pfts  = .false.
 
+
   !************************************
   !** COHORT type structure          **
   !************************************

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -22,8 +22,6 @@ module EDTypesMod
                                                   ! are used, but this helps allocate scratch
                                                   ! space and output arrays.
   						  
-  integer, parameter :: use_leaf_age = 1          ! switch of using leaf age
-
   ! -------------------------------------------------------------------------------------
   ! Radiation parameters
   ! These should be part of the radiation module, but since we only have one option
@@ -71,6 +69,7 @@ module EDTypesMod
   ! WAS OUTSIDE THE SCOPE OF THE VERY LARGE CHANGESET WHERE THESE WERE FIRST
   ! INTRODUCED (RGK 03-2017)
   logical, parameter :: do_ed_phenology = .true.
+  integer, parameter :: use_leaf_age = 0          ! switch of using leaf age
 
 
   ! MODEL PARAMETERS

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -21,6 +21,8 @@ module EDTypesMod
                                                   ! the parameter file may determine that fewer
                                                   ! are used, but this helps allocate scratch
                                                   ! space and output arrays.
+  						  
+  integer, parameter :: use_leaf_age = 1          ! switch of using leaf age
 
   ! -------------------------------------------------------------------------------------
   ! Radiation parameters
@@ -269,6 +271,12 @@ module EDTypesMod
      real(r8) ::  cambial_mort                           ! probability that trees dies due to cambial char:-
      real(r8) ::  crownfire_mort                         ! probability of tree post-fire mortality due to crown scorch:-
      real(r8) ::  fire_mort                              ! post-fire mortality from cambial and crown damage assuming two are independent:-
+     
+     !leaf age
+     real(r8) ::  fracExpLeaves                          ! proportion of new expanding leaves
+     real(r8) ::  fracYoungLeaves                        ! proportion of young adult leaves
+     real(r8) ::  fracOldLeaves                          ! proportion of old adult leaves     
+     real(r8) ::  fracSenLeaves                          ! proportion of senescent leaves     
 
      ! Integration
      real(r8) :: ode_opt_step                            ! What is the current optimum step size

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -3378,12 +3378,12 @@ end subroutine flush_hvars
          avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
          ivar=ivar, initialize=initialize_variables, index = ih_total_exp_leaf_pa )
 	 
-    call this%set_history_var(vname='Toal_YoungLeaf', units='gC/m2',                   &
+    call this%set_history_var(vname='Total_YoungLeaf', units='gC/m2',                   &
          long='Total young leaf biomass',  use_default='inactive',                            &
          avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
          ivar=ivar, initialize=initialize_variables, index = ih_total_young_leaf_pa )
 	 
-    call this%set_history_var(vname='Toal_OldLeaf', units='gC/m2',                   &
+    call this%set_history_var(vname='Total_OldLeaf', units='gC/m2',                   &
          long='Total old leaf biomass',  use_default='inactive',                            &
          avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
          ivar=ivar, initialize=initialize_variables, index = ih_total_old_leaf_pa )

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -92,7 +92,7 @@ module FatesHistoryInterfaceMod
   integer, private :: ih_frac_exp_leaf_pa
   integer, private :: ih_frac_young_leaf_pa
   integer, private :: ih_frac_old_leaf_pa
-  integer, private :: ih_frac_sens_leaf_pa
+  integer, private :: ih_frac_sen_leaf_pa
 
   ! Indices to site by size-class by age variables
   integer, private :: ih_nplant_si_scag
@@ -1362,7 +1362,7 @@ end subroutine flush_hvars
 	       hio_frac_exp_leaf_pa   => this%hvars(ih_frac_exp_leaf_pa)%r81d, &
 	       hio_frac_young_leaf_pa   => this%hvars(ih_frac_young_leaf_pa)%r81d, &
 	       hio_frac_old_leaf_pa   => this%hvars(ih_frac_old_leaf_pa)%r81d, &
-	       hio_frac_sens_leaf_pa   => this%hvars(ih_frac_sens_leaf_pa)%r81d, &
+	       hio_frac_sen_leaf_pa   => this%hvars(ih_frac_sen_leaf_pa)%r81d, &
                hio_gpp_si_scpf         => this%hvars(ih_gpp_si_scpf)%r82d, &
                hio_npp_totl_si_scpf    => this%hvars(ih_npp_totl_si_scpf)%r82d, &
                hio_npp_leaf_si_scpf    => this%hvars(ih_npp_leaf_si_scpf)%r82d, &
@@ -1801,7 +1801,7 @@ end subroutine flush_hvars
 		                                         *ccohort%bl* g_per_kg
 		      hio_frac_old_leaf_pa(io_pa) = hio_frac_old_leaf_pa(io_pa) + n_density * ccohort%fracOldLeaves&
 		                                        *ccohort%bl* g_per_kg
-		      hio_frac_sens_leaf_pa(io_pa) = hio_frac_sens_leaf_pa(io_pa) + n_density * ccohort%fracSensLeaves &
+		      hio_frac_sen_leaf_pa(io_pa) = hio_frac_sen_leaf_pa(io_pa) + n_density * ccohort%fracSenLeaves &
 		                                       *ccohort%bl* g_per_kg	
 		    endif 
 
@@ -2082,7 +2082,7 @@ end subroutine flush_hvars
 	        hio_frac_exp_leaf_pa(io_pa) = hio_frac_exp_leaf_pa(io_pa)/ hio_bleaf_pa(io_pa)
                 hio_frac_young_leaf_pa(io_pa) = hio_frac_young_leaf_pa(io_pa)/hio_bleaf_pa(io_pa)
 	        hio_frac_old_leaf_pa(io_pa) = hio_frac_old_leaf_pa(io_pa) / hio_bleaf_pa(io_pa)
-	        hio_frac_sens_leaf_pa(io_pa) = hio_frac_sens_leaf_pa(io_pa)/hio_bleaf_pa(io_pa)
+	        hio_frac_sen_leaf_pa(io_pa) = hio_frac_sen_leaf_pa(io_pa)/hio_bleaf_pa(io_pa)
 	      endif
 	    endif
 
@@ -3358,10 +3358,10 @@ end subroutine flush_hvars
          avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
          ivar=ivar, initialize=initialize_variables, index = ih_frac_old_leaf_pa )
 
-    call this%set_history_var(vname='Frac_SensLeaf', units='fraction',                   &
-         long='Fraction of senscent leaf',  use_default='inactive',                            &
+    call this%set_history_var(vname='Frac_SenLeaf', units='fraction',                   &
+         long='Fraction of senescent leaf',  use_default='inactive',                            &
          avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
-         ivar=ivar, initialize=initialize_variables, index = ih_frac_sens_leaf_pa )	 	 
+         ivar=ivar, initialize=initialize_variables, index = ih_frac_sen_leaf_pa )	 	 
 	 	 
     ! Canopy Resistance 
 

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -19,6 +19,7 @@ module FatesHistoryInterfaceMod
   use EDParamsMod              , only : ED_val_comp_excln
   use FatesInterfaceMod        , only : nlevsclass, nlevage
   use FatesInterfaceMod        , only : nlevheight
+  use EDTypesMod               , only : use_leaf_age
 
   ! FIXME(bja, 2016-10) need to remove CLM dependancy 
   use EDPftvarcon              , only : EDPftvarcon_inst
@@ -88,6 +89,11 @@ module FatesHistoryInterfaceMod
   integer, private :: ih_canopy_biomass_pa
   integer, private :: ih_understory_biomass_pa
   
+  integer, private :: ih_frac_exp_leaf_pa
+  integer, private :: ih_frac_young_leaf_pa
+  integer, private :: ih_frac_old_leaf_pa
+  integer, private :: ih_frac_sens_leaf_pa
+
   ! Indices to site by size-class by age variables
   integer, private :: ih_nplant_si_scag
   integer, private :: ih_nplant_canopy_si_scag
@@ -1353,6 +1359,10 @@ end subroutine flush_hvars
                hio_agb_pa              => this%hvars(ih_agb_pa)%r81d, &
                hio_canopy_biomass_pa   => this%hvars(ih_canopy_biomass_pa)%r81d, &
                hio_understory_biomass_pa   => this%hvars(ih_understory_biomass_pa)%r81d, &
+	       hio_frac_exp_leaf_pa   => this%hvars(ih_frac_exp_leaf_pa)%r81d, &
+	       hio_frac_young_leaf_pa   => this%hvars(ih_frac_young_leaf_pa)%r81d, &
+	       hio_frac_old_leaf_pa   => this%hvars(ih_frac_old_leaf_pa)%r81d, &
+	       hio_frac_sens_leaf_pa   => this%hvars(ih_frac_sens_leaf_pa)%r81d, &
                hio_gpp_si_scpf         => this%hvars(ih_gpp_si_scpf)%r82d, &
                hio_npp_totl_si_scpf    => this%hvars(ih_npp_totl_si_scpf)%r82d, &
                hio_npp_leaf_si_scpf    => this%hvars(ih_npp_leaf_si_scpf)%r82d, &
@@ -1783,6 +1793,17 @@ end subroutine flush_hvars
 
                     hio_biomass_si_agepft(io_si,iagepft) = hio_biomass_si_agepft(io_si,iagepft) + &
                          ccohort%b_total() * ccohort%n * AREA_INV
+		    
+		    if(use_leaf_age==itrue)then	 
+		      hio_frac_exp_leaf_pa(io_pa) = hio_frac_exp_leaf_pa(io_pa) + n_density * ccohort%fracExpLeaves &
+		                                        *ccohort%bl* g_per_kg
+		      hio_frac_young_leaf_pa(io_pa) = hio_frac_young_leaf_pa(io_pa) + n_density * ccohort%fracYoungLeaves &
+		                                         *ccohort%bl* g_per_kg
+		      hio_frac_old_leaf_pa(io_pa) = hio_frac_old_leaf_pa(io_pa) + n_density * ccohort%fracOldLeaves&
+		                                        *ccohort%bl* g_per_kg
+		      hio_frac_sens_leaf_pa(io_pa) = hio_frac_sens_leaf_pa(io_pa) + n_density * ccohort%fracSensLeaves &
+		                                       *ccohort%bl* g_per_kg	
+		    endif 
 
                     ! update SCPF/SCLS- and canopy/subcanopy- partitioned quantities
                     if (ccohort%canopy_layer .eq. 1) then
@@ -2054,6 +2075,16 @@ end subroutine flush_hvars
                hio_cwd_bg_out_si_cwdsc(io_si, i_cwd) = hio_cwd_bg_out_si_cwdsc(io_si, i_cwd) + &
                     cpatch%CWD_BG_OUT(i_cwd)*cpatch%area * AREA_INV * g_per_kg
             end do
+	    
+	    !normalize leaf ages
+	    if(use_leaf_age==itrue)then
+	      if(hio_bleaf_pa(io_pa)>0.0_r8)then
+	        hio_frac_exp_leaf_pa(io_pa) = hio_frac_exp_leaf_pa(io_pa)/ hio_bleaf_pa(io_pa)
+                hio_frac_young_leaf_pa(io_pa) = hio_frac_young_leaf_pa(io_pa)/hio_bleaf_pa(io_pa)
+	        hio_frac_old_leaf_pa(io_pa) = hio_frac_old_leaf_pa(io_pa) / hio_bleaf_pa(io_pa)
+	        hio_frac_sens_leaf_pa(io_pa) = hio_frac_sens_leaf_pa(io_pa)/hio_bleaf_pa(io_pa)
+	      endif
+	    endif
 
             ipa = ipa + 1
             cpatch => cpatch%younger
@@ -3310,8 +3341,28 @@ end subroutine flush_hvars
     call this%set_history_var(vname='BIOMASS_UNDERSTORY', units='gC m-2',                   &
          long='Biomass of understory plants',  use_default='active',                            &
          avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
-         ivar=ivar, initialize=initialize_variables, index = ih_understory_biomass_pa )
+         ivar=ivar, initialize=initialize_variables, index = ih_understory_biomass_pa )	 
 
+    call this%set_history_var(vname='Frac_ExpLeaf', units='fraction',                   &
+         long='Fraction of Expanding leaf',  use_default='inactive',                            &
+         avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
+         ivar=ivar, initialize=initialize_variables, index = ih_frac_exp_leaf_pa )
+	 
+    call this%set_history_var(vname='Frac_YoungLeaf', units='fraction',                   &
+         long='Fraction of young leaf',  use_default='inactive',                            &
+         avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
+         ivar=ivar, initialize=initialize_variables, index = ih_frac_young_leaf_pa )
+	 
+    call this%set_history_var(vname='Frac_OldLeaf', units='fraction',                   &
+         long='Fraction of old leaf',  use_default='inactive',                            &
+         avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
+         ivar=ivar, initialize=initialize_variables, index = ih_frac_old_leaf_pa )
+
+    call this%set_history_var(vname='Frac_SensLeaf', units='fraction',                   &
+         long='Fraction of senscent leaf',  use_default='inactive',                            &
+         avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
+         ivar=ivar, initialize=initialize_variables, index = ih_frac_sens_leaf_pa )	 	 
+	 	 
     ! Canopy Resistance 
 
     call this%set_history_var(vname='C_STOMATA', units='umol m-2 s-1',                   &

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -466,6 +466,9 @@ module FatesInterfaceMod
       ! leaf maintenance respiration rate (umol CO2/m**2/s) 
       ! (NOT CURRENTLY USED, PLACE-HOLDER)
       !real(r8), allocatable :: lmrcanopy_pa(:)
+      
+      ! area weighted leaf water potential (MPa) 
+      real(r8), allocatable :: lwp_pa(:)
 
       ! Canopy Radiation Boundaries
       ! ---------------------------------------------------------------------------------
@@ -715,7 +718,7 @@ contains
       allocate(bc_out%active_suction_sl(nlevsoil_in))
       allocate(bc_out%rootr_pasl(maxPatchesPerSite,nlevsoil_in))
       allocate(bc_out%btran_pa(maxPatchesPerSite))
-      
+
       ! Photosynthesis
 
       allocate(bc_out%rssun_pa(maxPatchesPerSite))
@@ -753,6 +756,7 @@ contains
       ! Plant-Hydro BC's
       if (hlm_use_planthydro.eq.itrue) then
          allocate(bc_out%qflx_soil2root_sisl(nlevsoil_in))
+         allocate(bc_out%lwp_pa(maxPatchesPerSite))	 
       end if
 
       return
@@ -820,7 +824,7 @@ contains
       this%bc_out(s)%laisha_pa(:)    = 0.0_r8
       this%bc_out(s)%rootr_pasl(:,:) = 0.0_r8
       this%bc_out(s)%btran_pa(:)     = 0.0_r8
-
+      
       this%bc_out(s)%FATES_c_to_litr_lab_c_col(:) = 0.0_r8
       this%bc_out(s)%FATES_c_to_litr_cel_c_col(:) = 0.0_r8
       this%bc_out(s)%FATES_c_to_litr_lig_c_col(:) = 0.0_r8
@@ -851,6 +855,7 @@ contains
 
       if (hlm_use_planthydro.eq.itrue) then
          this%bc_out(s)%qflx_soil2root_sisl(:) = 0.0_r8
+	 this%bc_out(s)%lwp_pa(:)    = 0.0_r8
       end if
       this%bc_out(s)%plant_stored_h2o_si = 0.0_r8
 

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -467,8 +467,6 @@ module FatesInterfaceMod
       ! (NOT CURRENTLY USED, PLACE-HOLDER)
       !real(r8), allocatable :: lmrcanopy_pa(:)
       
-      ! area weighted leaf water potential (MPa) 
-      real(r8), allocatable :: lwp_pa(:)
 
       ! Canopy Radiation Boundaries
       ! ---------------------------------------------------------------------------------
@@ -756,7 +754,6 @@ contains
       ! Plant-Hydro BC's
       if (hlm_use_planthydro.eq.itrue) then
          allocate(bc_out%qflx_soil2root_sisl(nlevsoil_in))
-         allocate(bc_out%lwp_pa(maxPatchesPerSite))	 
       end if
 
       return
@@ -855,7 +852,6 @@ contains
 
       if (hlm_use_planthydro.eq.itrue) then
          this%bc_out(s)%qflx_soil2root_sisl(:) = 0.0_r8
-	 this%bc_out(s)%lwp_pa(:)    = 0.0_r8
       end if
       this%bc_out(s)%plant_stored_h2o_si = 0.0_r8
 

--- a/parameter_files/fates_params_14pfts.cdl
+++ b/parameter_files/fates_params_14pfts.cdl
@@ -322,9 +322,6 @@ variables:
 		fates_senleaf_flong:long_name = "Fraction of leaf longevity for senescent leaves(ie turnover timescale)" ;	
 	float fates_senleaf_long_fdrought(fates_pft) ;
 		fates_senleaf_long_fdrought:units = "unitless[0-1]" ;
-		fates_senleaf_long_fdrought:long_name = "multiplication factor for leaf longevity of senescent leaves during drought" ;
-	float fates_senleaf_long_fdrought(fates_pft) ;
-		fates_senleaf_long_fdrought:units = "unitless[0-1]" ;
 		fates_senleaf_long_fdrought:long_name = "multiplication factor for leaf longevity of senescent leaves during drought" ;				
 	float fates_leaf_slamax(fates_pft) ;
 		fates_leaf_slamax:units = "m^2/gC" ;

--- a/parameter_files/fates_params_14pfts.cdl
+++ b/parameter_files/fates_params_14pfts.cdl
@@ -308,6 +308,24 @@ variables:
 	float fates_leaf_long(fates_pft) ;
 		fates_leaf_long:units = "yr" ;
 		fates_leaf_long:long_name = "Leaf longevity (ie turnover timescale)" ;
+	float fates_expleaf_flong(fates_pft) ;
+		fates_expleaf_flong:units = "fraction" ;
+		fates_expleaf_flong:long_name = "Fraction of leaf longevity for expanding leaves(ie turnover timescale)" ;		
+	float fates_youngleaf_flong(fates_pft) ;
+		fates_youngleaf_flong:units = "fraction" ;
+		fates_youngleaf_flong:long_name = "Fraction of leaf longevity for young leaves(ie turnover timescale)" ;		
+	float fates_oldleaf_flong(fates_pft) ;
+		fates_oldleaf_flong:units = "fraction" ;
+		fates_oldleaf_flong:long_name = "Fraction of leaf longevity for old leaves(ie turnover timescale)" ;	
+	float fates_senleaf_flong(fates_pft) ;
+		fates_senleaf_flong:units = "fraction" ;
+		fates_senleaf_flong:long_name = "Fraction of leaf longevity for senescent leaves(ie turnover timescale)" ;	
+	float fates_senleaf_long_fdrought(fates_pft) ;
+		fates_senleaf_long_fdrought:units = "unitless[0-1]" ;
+		fates_senleaf_long_fdrought:long_name = "multiplication factor for leaf longevity of senescent leaves during drought" ;
+	float fates_senleaf_long_fdrought(fates_pft) ;
+		fates_senleaf_long_fdrought:units = "unitless[0-1]" ;
+		fates_senleaf_long_fdrought:long_name = "multiplication factor for leaf longevity of senescent leaves during drought" ;				
 	float fates_leaf_slamax(fates_pft) ;
 		fates_leaf_slamax:units = "m^2/gC" ;
 		fates_leaf_slamax:long_name = "Maximum Specific Leaf Area (SLA), even if under a dense canopy" ;
@@ -329,6 +347,18 @@ variables:
 	float fates_leaf_vcmax25top(fates_pft) ;
 		fates_leaf_vcmax25top:units = "umol CO2/m^2/s" ;
 		fates_leaf_vcmax25top:long_name = "maximum carboxylation rate of Rub. at 25C, canopy top" ;
+	float fates_leaf_vcmax25top_fexp(fates_pft) ;
+		fates_leaf_vcmax25top:units = "unitless" ;
+		fates_leaf_vcmax25top:long_name = "factor of vcmax25 for expanding leaves" ;			
+	float fates_leaf_vcmax25top_fyoung(fates_pft) ;
+		fates_leaf_vcmax25top:units = "unitless" ;
+		fates_leaf_vcmax25top:long_name = "factor of vcmax25 for young leaves" ;
+	float fates_leaf_vcmax25top_fold(fates_pft) ;
+		fates_leaf_vcmax25top:units = "unitless" ;
+		fates_leaf_vcmax25top:long_name = "factor of vcmax25 for old leaves" ;	
+	float fates_leaf_vcmax25top_fsen(fates_pft) ;
+		fates_leaf_vcmax25top:units = "unitless" ;
+		fates_leaf_vcmax25top:long_name = "factor of vcmax25 for senescentleaves" ;			
 	float fates_leaf_vcmaxha(fates_pft) ;
 		fates_leaf_vcmaxha:units = "J/mol" ;
 		fates_leaf_vcmaxha:long_name = "activation energy for vcmax" ;
@@ -873,6 +903,21 @@ data:
     495, 495, 495 ;
 
  fates_leaf_long = 1.5, 4, 6, 1, 1.5, 1, 1, 1, 1.5, 1, 1, 1, 1, 1 ;
+ 
+ fates_expleaf_flong = 0.041, 0.041, 0.041, 0.041, 0.041, 0.041, 0.041, 0.041,
+    0.041, 0.041, 0.041, 0.041, 0.041, 0.041;
+ 
+ fates_youngleaf_flong = 0.375, 0.375, 0.375, 0.375, 0.375, 0.375, 0.375, 0.375, 
+    0.375, 0.375, 0.375, 0.375, 0.375, 0.375 ;
+ 
+ fates_oldleaf_flong = 0.167, 0.167, 0.167, 0.167, 0.167, 0.167, 0.167, 0.167, 
+     0.167, 0.167, 0.167, 0.167, 0.167, 0.167 ;
+ 
+ fates_senleaf_flong = 0.417, 0.417, 0.417, 0.417, 0.417, 0.417, 0.417, 0.417,
+     0.417, 0.417, 0.417, 0.417, 0.417, 0.417 ;
+ 
+ fates_senleaf_long_fdrought = 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+     1.0, 1.0, 1.0, 1.0, 1.0 ;
 
  fates_leaf_slamax = 0.0954, 0.0954, 0.0954, 0.0954, 0.0954, 0.0954, 0.0954, 0.0954, 
     0.012, 0.03, 0.03, 0.03, 0.03, 0.03 ;
@@ -893,6 +938,18 @@ data:
     490, 490, 490 ;
 
  fates_leaf_vcmax25top = 50, 65, 63, 39, 62, 41, 58, 58, 62, 54, 54, 78, 78, 78 ;
+ 
+ fates_leaf_vcmax25top_fexp = 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 
+    1.0, 1.0, 1.0, 1.0;
+  
+ fates_leaf_vcmax25top_fyoung = 1.9, 1.9, 1.9, 1.9, 1.9, 1.9, 1.9, 1.9, 1.9, 1.9, 
+   1.9, 1.9, 1.9, 1.9;
+   
+ fates_leaf_vcmax25top_fold = 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0,
+   1.0, 1.0, 1.0, 1.0 ;
+    
+ fates_leaf_vcmax25top_fsen = 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3, 0.3,
+    0.3 , 0.3 , 0.3 , 0.3 , 0.3 ;
 
  fates_leaf_vcmaxha = 65330, 65330, 65330, 65330, 65330, 65330, 65330, 65330, 
     65330, 65330, 65330, 65330, 65330, 65330 ;

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -248,18 +248,18 @@ variables:
 	float fates_leaf_long(fates_pft) ;
 		fates_leaf_long:units = "yr" ;
 		fates_leaf_long:long_name = "Leaf longevity (ie turnover timescale)" ;
-	float fates_expleaf_long(fates_pft) ;
-		fates_leaf_long:units = "yr" ;
-		fates_leaf_long:long_name = "Leaf longevity for expanding leaves(ie turnover timescale)" ;		
-	float fates_youngleaf_long(fates_pft) ;
-		fates_leaf_long:units = "yr" ;
-		fates_leaf_long:long_name = "Leaf longevity for young leaves(ie turnover timescale)" ;		
-	float fates_oldleaf_long(fates_pft) ;
-		fates_leaf_long:units = "yr" ;
-		fates_leaf_long:long_name = "Leaf longevity for old leaves(ie turnover timescale)" ;	
-	float fates_senleaf_long(fates_pft) ;
-		fates_leaf_long:units = "yr" ;
-		fates_leaf_long:long_name = "Leaf longevity for senescent leaves(ie turnover timescale)" ;	
+	float fates_expleaf_flong(fates_pft) ;
+		fates_leaf_flong:units = "fraction" ;
+		fates_leaf_flong:long_name = "Fraction of leaf longevity for expanding leaves(ie turnover timescale)" ;		
+	float fates_youngleaf_flong(fates_pft) ;
+		fates_youngleaf_flong:units = "fraction" ;
+		fates_youngleaf_flong:long_name = "Fraction of leaf longevity for young leaves(ie turnover timescale)" ;		
+	float fates_oldleaf_flong(fates_pft) ;
+		fates_oldleaf_flong:units = "fraction" ;
+		fates_oldleaf_flong:long_name = "Fraction of leaf longevity for old leaves(ie turnover timescale)" ;	
+	float fates_senleaf_flong(fates_pft) ;
+		fates_senleaf_flong:units = "fraction" ;
+		fates_senleaf_flong:long_name = "Fraction of leaf longevity for senescent leaves(ie turnover timescale)" ;	
 	float fates_senleaf_long_fdrought(fates_pft) ;
 		fates_leaf_long:units = "yr" ;
 		fates_leaf_long:long_name = "multiplication factor for leaf longevity of senescent leaves during drought" ;					
@@ -788,13 +788,13 @@ data:
 
  fates_leaf_long = 1.5, 1.5 ;
  
- fates_expleaf_long = 0.1, 0.1 ;
+ fates_expleaf_flong = 0.041, 0.041 ;
  
- fates_youngleaf_long = 0.3, 0.3 ;
+ fates_youngleaf_flong = 0.375, 0.375 ;
  
- fates_oldleaf_long = 0.3, 0.3 ;
+ fates_oldleaf_flong = 0.167, 0.167 ;
  
- fates_senleaf_long = 0.2, 0.2 ;
+ fates_senleaf_flong = 0.417, 0.417 ;
  
  fates_senleaf_long_fdrought = 1.0, 1.0 ;
  

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -259,7 +259,10 @@ variables:
 		fates_leaf_long:long_name = "Leaf longevity for old leaves(ie turnover timescale)" ;	
 	float fates_senleaf_long(fates_pft) ;
 		fates_leaf_long:units = "yr" ;
-		fates_leaf_long:long_name = "Leaf longevity for senescent leaves(ie turnover timescale)" ;				
+		fates_leaf_long:long_name = "Leaf longevity for senescent leaves(ie turnover timescale)" ;	
+	float fates_senleaf_long_fdrought(fates_pft) ;
+		fates_leaf_long:units = "yr" ;
+		fates_leaf_long:long_name = "multiplication factor for leaf longevity of senescent leaves during drought" ;					
 	float fates_leaf_slamax(fates_pft) ;
 		fates_leaf_slamax:units = "m^2/gC" ;
 		fates_leaf_slamax:long_name = "Maximum Specific Leaf Area (SLA), even if under a dense canopy" ;
@@ -792,6 +795,8 @@ data:
  fates_oldleaf_long = 0.3, 0.3 ;
  
  fates_senleaf_long = 0.2, 0.2 ;
+ 
+ fates_senleaf_long_fdrought = 1.0, 1.0 ;
  
  fates_leaf_slamax = 0.0954, 0.0954 ;
 

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -249,8 +249,8 @@ variables:
 		fates_leaf_long:units = "yr" ;
 		fates_leaf_long:long_name = "Leaf longevity (ie turnover timescale)" ;
 	float fates_expleaf_flong(fates_pft) ;
-		fates_leaf_flong:units = "fraction" ;
-		fates_leaf_flong:long_name = "Fraction of leaf longevity for expanding leaves(ie turnover timescale)" ;		
+		fates_expleaf_flong:units = "fraction" ;
+		fates_expleaf_flong:long_name = "Fraction of leaf longevity for expanding leaves(ie turnover timescale)" ;		
 	float fates_youngleaf_flong(fates_pft) ;
 		fates_youngleaf_flong:units = "fraction" ;
 		fates_youngleaf_flong:long_name = "Fraction of leaf longevity for young leaves(ie turnover timescale)" ;		
@@ -261,8 +261,8 @@ variables:
 		fates_senleaf_flong:units = "fraction" ;
 		fates_senleaf_flong:long_name = "Fraction of leaf longevity for senescent leaves(ie turnover timescale)" ;	
 	float fates_senleaf_long_fdrought(fates_pft) ;
-		fates_leaf_long:units = "yr" ;
-		fates_leaf_long:long_name = "multiplication factor for leaf longevity of senescent leaves during drought" ;					
+		fates_senleaf_long_fdrought:units = "unitless[0-1]" ;
+		fates_senleaf_long_fdrought:long_name = "multiplication factor for leaf longevity of senescent leaves during drought" ;					
 	float fates_leaf_slamax(fates_pft) ;
 		fates_leaf_slamax:units = "m^2/gC" ;
 		fates_leaf_slamax:long_name = "Maximum Specific Leaf Area (SLA), even if under a dense canopy" ;

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -248,6 +248,18 @@ variables:
 	float fates_leaf_long(fates_pft) ;
 		fates_leaf_long:units = "yr" ;
 		fates_leaf_long:long_name = "Leaf longevity (ie turnover timescale)" ;
+	float fates_expleaf_long(fates_pft) ;
+		fates_leaf_long:units = "yr" ;
+		fates_leaf_long:long_name = "Leaf longevity for expanding leaves(ie turnover timescale)" ;		
+	float fates_youngleaf_long(fates_pft) ;
+		fates_leaf_long:units = "yr" ;
+		fates_leaf_long:long_name = "Leaf longevity for young leaves(ie turnover timescale)" ;		
+	float fates_oldleaf_long(fates_pft) ;
+		fates_leaf_long:units = "yr" ;
+		fates_leaf_long:long_name = "Leaf longevity for old leaves(ie turnover timescale)" ;	
+	float fates_senleaf_long(fates_pft) ;
+		fates_leaf_long:units = "yr" ;
+		fates_leaf_long:long_name = "Leaf longevity for senescent leaves(ie turnover timescale)" ;				
 	float fates_leaf_slamax(fates_pft) ;
 		fates_leaf_slamax:units = "m^2/gC" ;
 		fates_leaf_slamax:long_name = "Maximum Specific Leaf Area (SLA), even if under a dense canopy" ;
@@ -269,6 +281,18 @@ variables:
 	float fates_leaf_vcmax25top(fates_pft) ;
 		fates_leaf_vcmax25top:units = "umol CO2/m^2/s" ;
 		fates_leaf_vcmax25top:long_name = "maximum carboxylation rate of Rub. at 25C, canopy top" ;
+	float fates_leaf_vcmax25top_fexp(fates_pft) ;
+		fates_leaf_vcmax25top:units = "unitless" ;
+		fates_leaf_vcmax25top:long_name = "factor of vcmax25 for expanding leaves" ;			
+	float fates_leaf_vcmax25top_fyoung(fates_pft) ;
+		fates_leaf_vcmax25top:units = "unitless" ;
+		fates_leaf_vcmax25top:long_name = "factor of vcmax25 for young leaves" ;
+	float fates_leaf_vcmax25top_fold(fates_pft) ;
+		fates_leaf_vcmax25top:units = "unitless" ;
+		fates_leaf_vcmax25top:long_name = "factor of vcmax25 for old leaves" ;	
+	float fates_leaf_vcmax25top_fsen(fates_pft) ;
+		fates_leaf_vcmax25top:units = "unitless" ;
+		fates_leaf_vcmax25top:long_name = "factor of vcmax25 for senescentleaves" ;					
 	float fates_leaf_vcmaxha(fates_pft) ;
 		fates_leaf_vcmaxha:units = "J/mol" ;
 		fates_leaf_vcmaxha:long_name = "activation energy for vcmax" ;
@@ -620,11 +644,11 @@ data:
   -2.25, -2.25 ;
 
  fates_hydr_pinot_node =
-  -999, -999,
-  -999, -999,
-  -999, -999,
-  -999, -999 ;
-
+  -1.465984, -1.465984,
+  -1.228070, -1.228070,
+  -1.228070, -1.228070,
+  -1.043478, -1.043478 ;
+  
  fates_hydr_pitlp_node =
   -1.67, -1.67,
   -1.4, -1.4,
@@ -760,7 +784,15 @@ data:
  fates_leaf_jmaxse = 495, 495 ;
 
  fates_leaf_long = 1.5, 1.5 ;
-
+ 
+ fates_expleaf_long = 0.1, 0.1 ;
+ 
+ fates_youngleaf_long = 0.3, 0.3 ;
+ 
+ fates_oldleaf_long = 0.3, 0.3 ;
+ 
+ fates_senleaf_long = 0.2, 0.2 ;
+ 
  fates_leaf_slamax = 0.0954, 0.0954 ;
 
  fates_leaf_slatop = 0.012, 0.012 ;
@@ -774,7 +806,15 @@ data:
  fates_leaf_tpuse = 490, 490 ;
 
  fates_leaf_vcmax25top = 50, 50 ;
-
+ 
+ fates_leaf_vcmax25top_fexp = 1.0, 1.0;
+  
+ fates_leaf_vcmax25top_fyoung = 1.9, 1.9;
+   
+ fates_leaf_vcmax25top_fold = 1.0, 1.0 ;
+    
+ fates_leaf_vcmax25top_fsen = 0.3, 0.3 ;
+     
  fates_leaf_vcmaxha = 65330, 65330 ;
 
  fates_leaf_vcmaxhd = 149250, 149250 ;


### PR DESCRIPTION
### Description:
This pull request resolve the mismatch between simulated GPP and observed GPP in BCI, where the simulated GPP is too flat after the dry season. This new pull request added a simple scheme that tracks the fraction of emerging, young, old and senescent leaves in the cohorts. It 

### Collaborators:
@serbinsh , @everpassenger , @ckoven , @rosiealice , @rgknox 
### Expectation of Answer Changes:
The leaf age is turn off by default; however, if turned on, we expected the GPP to be higher right after dryseason and thus higher seasonal variability.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My change requires a change to the documentation.
- [X ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [X ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

