### PR TITLE
sorting logic changed to better handle equal-sized cohorts and to sort based on height

### DIFF
--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -396,7 +396,7 @@ contains
 
                   if ( tied_size_with_neighbor ) then
                      ! now we need to go through and figure out how many equal-size cohorts there are.
-                     ! then we need to go through, add up the collective corwn areas of all equal-sized and equal-canopy-layer cohorts,
+                     ! then we need to go through, add up the collective crown areas of all equal-sized and equal-canopy-layer cohorts,
                      ! and then demote from each as if they were a single group
                      !
                      total_crownarea_of_tied_cohorts = currentCohort%c_area
@@ -454,7 +454,7 @@ contains
                     has_taller_equalsized_neighbor) then
                   sumweights_equalsizebuffer = sumweights_equalsizebuffer + currentCohort%excl_weight
                else if (ED_val_comp_excln .lt. 0.0_r8) .and. tied_size_with_neighbor) then
-                  sumweights = sumweights + sumweights_equalsizebuffer
+                  sumweights = sumweights + currentCohort%excl_weight + sumweights_equalsizebuffer
                   sumweights_equalsizebuffer = 0._r8
                else
                   sumweights = sumweights + currentCohort%excl_weight
@@ -837,8 +837,8 @@ contains
 
                      if ( tied_size_with_neighbor ) then
                         ! now we need to go through and figure out how many equal-size cohorts there are.
-                        ! then we need to go through, add up the collective corwn areas of all equal-sized and equal-canopy-layer cohorts,
-                        ! and then demote from each as if they were a single group
+                        ! then we need to go through, add up the collective crown areas of all equal-sized and equal-canopy-layer cohorts,
+                        ! and then promote from each as if they were a single group
                         !
                         total_crownarea_of_tied_cohorts = currentCohort%c_area
                         !
@@ -894,7 +894,7 @@ contains
                        has_shorter_equalsized_neighbor) then
                      sumweights_equalsizebuffer = sumweights_equalsizebuffer + currentCohort%prom_weight
                   else if (ED_val_comp_excln .lt. 0.0_r8) .and. tied_size_with_neighbor) then
-                     sumweights = sumweights + sumweights_equalsizebuffer
+                     sumweights = sumweights + currentCohort%prom_weight + sumweights_equalsizebuffer
                      sumweights_equalsizebuffer = 0._r8
                   else
                      sumweights = sumweights + currentCohort%prom_weight

--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -379,19 +379,19 @@ contains
                   ! normal (stochastic) case. weight cohort demotion by 
                   ! inverse size to a constant power
                   currentCohort%excl_weight = &
-                       currentCohort%n/(currentCohort%dbh**ED_val_comp_excln)  
+                       currentCohort%n/(currentCohort%hite**ED_val_comp_excln)
                else
                   ! Rank ordered deterministic method
 
                   ! check to make sure there are no cohorts of equal size
                   tied_size_with_neighbor = .false.
                   if (associated(currentCohort%shorter)) then
-                     if (currentCohort%shorter%dbh .eq. currentCohort%dbh ) then
+                     if (currentCohort%shorter%hite .eq. currentCohort%hite ) then
                         tied_size_with_neighbor = .true.
                      endif
                   endif
                   if (associated(currentCohort%taller)) then
-                     if (currentCohort%taller%dbh .eq. currentCohort%dbh ) then
+                     if (currentCohort%taller%hite .eq. currentCohort%hite ) then
                         tied_size_with_neighbor = .true.
                      endif
                   endif
@@ -414,7 +414,7 @@ contains
                         whileloop_counter = whileloop_counter + 1
                         if (associated(cohort_tosearch_relative_to%shorter)) then
                            cohort_tocompare_to => cohort_tosearch_relative_to%shorter
-                           if (cohort_tocompare_to%dbh .eq. currentCohort%dbh ) then
+                           if (cohort_tocompare_to%hite .eq. currentCohort%hite ) then
                               if (cohort_tocompare_to%canopy_layer .eq. currentCohort%canopy_layer ) then
                                  total_crownarea_of_tied_cohorts = total_crownarea_of_tied_cohorts + cohort_tocompare_to%c_area
                               endif
@@ -440,7 +440,7 @@ contains
                         whileloop_counter = whileloop_counter + 1
                         if (associated(cohort_tosearch_relative_to%taller)) then
                            cohort_tocompare_to => cohort_tosearch_relative_to%taller
-                           if (cohort_tocompare_to%dbh .eq. currentCohort%dbh ) then
+                           if (cohort_tocompare_to%hite .eq. currentCohort%hite ) then
                               if (cohort_tocompare_to%canopy_layer .eq. currentCohort%canopy_layer ) then
                                  total_crownarea_of_tied_cohorts = total_crownarea_of_tied_cohorts + cohort_tocompare_to%c_area
                                  has_taller_equalsized_neighbor = .true.
@@ -835,19 +835,19 @@ contains
                if(currentCohort%canopy_layer == i_lyr+1)then !look at the cohorts in the canopy layer below... 
                   if (ED_val_comp_excln .ge. 0.0_r8 ) then
                      ! normal (stochastic) case, as above.
-                     currentCohort%prom_weight = currentCohort%n*currentCohort%dbh**ED_val_comp_excln
+                     currentCohort%prom_weight = currentCohort%n*currentCohort%hite**ED_val_comp_excln
                   else
                      ! Rank ordered deterministic method
 
                      ! check to make sure there are no cohorts of equal size
                      tied_size_with_neighbor = .false.
                      if (associated(currentCohort%shorter)) then
-                        if (currentCohort%shorter%dbh .eq. currentCohort%dbh ) then
+                        if (currentCohort%shorter%hite .eq. currentCohort%hite ) then
                            tied_size_with_neighbor = .true.
                         endif
                      endif
                      if (associated(currentCohort%taller)) then
-                        if (currentCohort%taller%dbh .eq. currentCohort%dbh ) then
+                        if (currentCohort%taller%hite .eq. currentCohort%hite ) then
                            tied_size_with_neighbor = .true.
                         endif
                      endif
@@ -872,7 +872,7 @@ contains
                            whileloop_counter = whileloop_counter + 1
                            if (associated(cohort_tosearch_relative_to%shorter)) then
                               cohort_tocompare_to => cohort_tosearch_relative_to%shorter
-                              if (cohort_tocompare_to%dbh .eq. currentCohort%dbh ) then
+                              if (cohort_tocompare_to%hite .eq. currentCohort%hite ) then
                                  if (cohort_tocompare_to%canopy_layer .eq. currentCohort%canopy_layer ) then
                                     total_crownarea_of_tied_cohorts = total_crownarea_of_tied_cohorts + cohort_tocompare_to%c_area
                                     has_shorter_equalsized_neighbor = .true.
@@ -898,7 +898,7 @@ contains
                            whileloop_counter = whileloop_counter + 1
                            if (associated(cohort_tosearch_relative_to%taller)) then
                               cohort_tocompare_to => cohort_tosearch_relative_to%taller
-                              if (cohort_tocompare_to%dbh .eq. currentCohort%dbh ) then
+                              if (cohort_tocompare_to%hite .eq. currentCohort%hite ) then
                                  if (cohort_tocompare_to%canopy_layer .eq. currentCohort%canopy_layer ) then
                                     total_crownarea_of_tied_cohorts = total_crownarea_of_tied_cohorts + cohort_tocompare_to%c_area
                                  endif

--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -462,11 +462,14 @@ contains
                      currentCohort%excl_weight = &
                           max(min(currentCohort%c_area, (currentCohort%c_area/total_crownarea_of_tied_cohorts) * &
                           (demote_area - sumweights) ), 0._r8)
-                  else
+                  else !  i.e. tied_size_with_neighbor = .false.
                      currentCohort%excl_weight = &
                           max(min(currentCohort%c_area, demote_area - sumweights ), 0._r8)
                   endif
                endif
+               !
+               ! when two or more cohorts have the same size, we need to keep track of their cumulative demoted crown area
+               ! in a separate buffer and add it once we reach the last of the equal-sized cohorts
                if ((ED_val_comp_excln .lt. 0.0_r8) .and. tied_size_with_neighbor .and. &
                     has_taller_equalsized_neighbor) then
                   sumweights_equalsizebuffer = sumweights_equalsizebuffer + currentCohort%excl_weight
@@ -918,11 +921,14 @@ contains
                         ! now we know the total crown area of all equal-sized, equal-canopy-layer cohorts
                         currentCohort%prom_weight = max(min(currentCohort%c_area, &
                              (currentCohort%c_area/total_crownarea_of_tied_cohorts) * (promote_area - sumweights) ), 0._r8)
-                     else
+                     else !  i.e. tied_size_with_neighbor = .false.
                         currentCohort%prom_weight = max(min(currentCohort%c_area, &
                              promote_area - sumweights ), 0._r8)
                      endif
                   endif
+                  !
+                  ! when two or more cohorts have the same size, we need to keep track of their cumulative demoted crown area
+                  ! in a separate buffer and add it once we reach the last of the equal-sized cohorts
                   if ((ED_val_comp_excln .lt. 0.0_r8) .and. tied_size_with_neighbor .and. &
                        has_shorter_equalsized_neighbor) then
                      sumweights_equalsizebuffer = sumweights_equalsizebuffer + currentCohort%prom_weight

--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -1146,7 +1146,7 @@ contains
     icohort => pcc ! assign address to icohort local name  
     !place in the correct place in the linked list of heights 
     !begin by finding cohort that is just taller than the new cohort 
-    tsp = icohort%dbh
+    tsp = icohort%hite
 
     current => pshortest
     exitloop = 0
@@ -1154,7 +1154,7 @@ contains
     !taller than tree being considered and return its pointer 
     if (associated(current)) then
        do while (associated(current).and.exitloop == 0)
-          if (current%dbh < tsp) then
+          if (current%hite < tsp) then
              current => current%taller   
           else
              exitloop = 1 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
This PR changes the sorting so that: 

- if using the deterministic PPA sorting algorithm, handle the special condition where two cohorts of different PFTs but the same size get demoted/promoted in proportion to their area rather than based on sorting order.
- sorting is switched to be a function of height rather than DBH.

This PR is meant to solve #438 and #302.

### Expectation of Answer Changes:
This should change answers in a few ways:

1. if 2 identical PFTs starting from bare ground are run using the strict PPA sorting algorithm, they should remain equal over time, rather than diverging.
2. if 2 non-identical PFTs are initialized to identical initial conditions using the inventory initialization, then they should actually start with the same structure rather than having some PFT-order effect thrown in.
3. if 2 PFTs with non-identical height-to-dbh allometry are competing, then their competitive dynamics will be different (and hopefully more correct)
4. in all cases when using stochastic PPA sorting algorithm, the answers should change because the promotion term is now height ** comp_excln parameter rather than dbh ** comp_excln.  To go back to the same behavior as before, it ought to work to change the comp_excln parameter by the exponent used in the height-to-dbh allometry.

### Collaborators:
discussed with @rgknox and @rosiealice.  also pinging @jenniferholm as this will effect her simulations due to point 3 above

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
not yet tested.  hold until both formal and more informal tests have been done.

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
