### PR TITLE
change cohort fusion to conserve crown area

### DIFF
--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -91,6 +91,12 @@ module EDCohortDynamicsMod
   character(len=*), parameter, private :: sourcefile = &
        __FILE__
 
+
+  integer, parameter, private :: conserve_crownarea_and_number_not_dbh = 1
+  integer, parameter, private :: conserve_dbh_and_number_not_crownarea = 2
+
+  integer, parameter, private :: cohort_fusion_conservation_method = conserve_crownarea_and_number_not_dbh
+  
   ! 10/30/09: Created by Rosie Fisher
   !-------------------------------------------------------------------------------------!
 
@@ -870,27 +876,77 @@ contains
                                 currentCohort%canopy_trim = (currentCohort%n*currentCohort%canopy_trim &
                                       + nextc%n*nextc%canopy_trim)/newn
 
-                                ! conserve total crown area during the fusion step, and then calculate 
-                                ! dbh of the fused cohort as that which conserves both crown area and 
-                                ! the dbh to crown area allometry.  dbh will be updated in the next 
-                                ! growth step in the (likely) event that dbh to structural iomass 
-                                ! allometry is exceeded. if using a capped crown area allometry and 
-                                ! above the cap, then calculate as the weighted average of fusing 
-                                ! cohorts' dbh
-
-                                currentCohort%c_area = currentCohort%c_area + nextc%c_area
-
-                                call carea_allom(dbh,newn,currentSite%spread,currentCohort%pft,&
-                                     currentCohort%c_area,inverse=.true.)
-                                
-                                if (abs(dbh-fates_unset_r8)<nearzero) then
-                                   currentCohort%dbh = (currentCohort%n*currentCohort%dbh         &
+                                select case(cohort_fusion_conservation_method)
+                                   !
+                                   ! -----------------------------------------------------------------
+                                   ! Because cohort fusion is an unavoidable but non-physical process,
+                                   ! and because of the various nonlinear allometric relationships,
+                                   ! it isn't possible to simultaneously conserve all of the allometric
+                                   ! relationships during cohort fusion.  We will always conserve carbon,
+                                   ! but there are choices to made about what else to conserve or not.
+                                   ! In particular, there is a choice to be made of conservation amongst
+                                   ! the number density, stem diameter, and crown area. Below,
+                                   ! some different conservation relationships can be chosen during fusion.
+                                   ! -----------------------------------------------------------------
+                                   !
+                                case(conserve_crownarea_and_number_not_dbh)
+                                   !
+                                   ! -----------------------------------------------------------------
+                                   ! conserve total crown area during the fusion step, and then calculate
+                                   ! dbh of the fused cohort as that which conserves both crown area and
+                                   ! the dbh to crown area allometry.  dbh will be updated in the next
+                                   ! growth step in the (likely) event that dbh to structural iomass
+                                   ! allometry is exceeded. if using a capped crown area allometry and
+                                   ! above the cap, then calculate as the weighted average of fusing
+                                   ! cohorts' dbh
+                                   ! -----------------------------------------------------------------
+                                   !
+                                   currentCohort%c_area = currentCohort%c_area + nextc%c_area
+                                   !
+                                   call carea_allom(dbh,newn,currentSite%spread,currentCohort%pft,&
+                                        currentCohort%c_area,inverse=.true.)
+                                   !
+                                   if (abs(dbh-fates_unset_r8)<nearzero) then
+                                      currentCohort%dbh = (currentCohort%n*currentCohort%dbh         &
+                                           + nextc%n*nextc%dbh)/newn
+                                   else
+                                      currentCohort%dbh = dbh
+                                   endif
+                                   !
+                                   call h_allom(currentCohort%dbh,currentCohort%pft,currentCohort%hite)
+                                   !
+                                case(conserve_dbh_and_number_not_crownarea)
+                                   !
+                                   ! -----------------------------------------------------------------
+                                   ! Here we conserve the mean stem diameter of the trees in the cohorts
+                                   ! rather than the crown area of the cohort
+                                   ! -----------------------------------------------------------------
+                                   !
+                                   currentCohort%dbh         = (currentCohort%n*currentCohort%dbh         &
                                         + nextc%n*nextc%dbh)/newn
-                                else
-                                   currentCohort%dbh = dbh
-                                endif
-
-                                call h_allom(currentCohort%dbh,currentCohort%pft,currentCohort%hite)
+                                   !
+                                   call h_allom(currentCohort%dbh,currentCohort%pft,currentCohort%hite)
+                                   !
+                                   ! -----------------------------------------------------------------
+                                   ! If fusion pushed structural biomass to be larger than
+                                   ! the allometric target value derived by diameter, we
+                                   ! then increase diameter and height until the allometric
+                                   ! target matches actual bdead. (if it is the other way around
+                                   ! we then just let the carbon pools grow to fill out allometry)
+                                   ! -----------------------------------------------------------------
+                                   !
+                                   if( EDPftvarcon_inst%woody(currentCohort%pft) == itrue ) then
+                                      call StructureResetOfDH( currentCohort%prt%GetState(struct_organ,all_carbon_elements), currentCohort%pft, &
+                                           currentCohort%canopy_trim, currentCohort%dbh, currentCohort%hite )
+                                   end if
+                                   !
+                                   call carea_allom(currentCohort%dbh,newn,currentSite%spread,currentCohort%pft,&
+                                        currentCohort%c_area,inverse=.false.)
+                                   !
+                                case(default)
+                                    write(fates_log(),*) 'FATES: Invalid choice for cohort_fusion_conservation_method'
+                                   call endrun(msg=errMsg(sourcefile, __LINE__))
+                                end select
 
                                 call sizetype_class_index(currentCohort%dbh,currentCohort%pft, &
                                       currentCohort%size_class,currentCohort%size_by_pft_class)

--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -11,6 +11,7 @@ module EDCohortDynamicsMod
   use FatesConstantsMod     , only : r8 => fates_r8
   use FatesConstantsMod     , only : fates_unset_int
   use FatesConstantsMod     , only : itrue,ifalse
+  use FatesConstantsMod     , only : fates_unset_r8
   use FatesInterfaceMod     , only : hlm_days_per_year
   use EDPftvarcon           , only : EDPftvarcon_inst
   use EDTypesMod            , only : ed_site_type, ed_patch_type, ed_cohort_type
@@ -729,6 +730,7 @@ contains
      real(r8) :: newn
      real(r8) :: diff
      real(r8) :: dynamic_fusion_tolerance
+     real(r8) :: dbh
 
      integer  :: largersc, smallersc, sc_i        ! indices for tracking the growth flux caused by fusion
      real(r8) :: larger_n, smaller_n
@@ -794,6 +796,7 @@ contains
                              if( currentCohort%isnew.eqv.nextc%isnew ) then
 
                                 newn = currentCohort%n + nextc%n
+
                                 fusion_took_place = 1         
 
                                 if ( fuse_debug .and. currentCohort%isnew ) then
@@ -822,26 +825,28 @@ contains
                                 currentCohort%laimemory   = (currentCohort%n*currentCohort%laimemory   &
                                       + nextc%n*nextc%laimemory)/newn
 
-                                currentCohort%dbh         = (currentCohort%n*currentCohort%dbh         &
-                                      + nextc%n*nextc%dbh)/newn
-
-                                call h_allom(currentCohort%dbh,currentCohort%pft,currentCohort%hite)
-                                
                                 currentCohort%canopy_trim = (currentCohort%n*currentCohort%canopy_trim &
                                       + nextc%n*nextc%canopy_trim)/newn
 
-                                ! -----------------------------------------------------------------
-                                ! If fusion pushed structural biomass to be larger than
-                                ! the allometric target value derived by diameter, we
-                                ! then increase diameter and height until the allometric 
-                                ! target matches actual bdead. (if it is the other way around
-                                ! we then just let the carbon pools grow to fill-out allometry)
-                                ! -----------------------------------------------------------------
+                                ! conserve total crown area during the fusion step, and then calculate dbh of the
+                                ! fused cohort as that which conserves both crown area and the dbh to crown area allometry.  
+                                ! dbh will be updated in the next growth step in the (likely) event that dbh to structural 
+                                ! biomass allometry is exceeded. if using a capped crown area allometry and above the cap, 
+                                ! then calculate as the weighted average of fusing cohorts' dbh
+
+                                currentCohort%c_area = currentCohort%c_area + nextc%c_area
+
+                                call carea_allom(dbh,newn,currentSite%spread,currentCohort%pft,&
+                                     currentCohort%c_area,inverse=.true.)
                                 
-                                if( EDPftvarcon_inst%woody(currentCohort%pft) == itrue ) then
-                                   call StructureResetOfDH( currentCohort%prt%GetState(struct_organ,all_carbon_elements), currentCohort%pft, &
-                                         currentCohort%canopy_trim, currentCohort%dbh, currentCohort%hite )
-                                end if
+                                if (dbh .eq. fates_unset_r8) then
+                                   currentCohort%dbh = (currentCohort%n*currentCohort%dbh         &
+                                        + nextc%n*nextc%dbh)/newn
+                                else
+                                   currentCohort%dbh = dbh
+                                endif
+
+                                call h_allom(currentCohort%dbh,currentCohort%pft,currentCohort%hite)
 
                                 call sizetype_class_index(currentCohort%dbh,currentCohort%pft, &
                                       currentCohort%size_class,currentCohort%size_by_pft_class)

--- a/biogeochem/FatesAllometryMod.F90
+++ b/biogeochem/FatesAllometryMod.F90
@@ -90,6 +90,7 @@ module FatesAllometryMod
   use FatesConstantsMod, only : cm2_per_m2
   use FatesConstantsMod, only : kg_per_Megag
   use FatesConstantsMod, only : calloc_abs_error
+  use FatesConstantsMod, only : fates_unset_r8
   use shr_log_mod      , only : errMsg => shr_log_errMsg
   use FatesGlobals     , only : fates_log
   use FatesGlobals     , only : endrun => fates_endrun
@@ -448,15 +449,17 @@ contains
   ! Generic crown area allometry wrapper
   ! ============================================================================
   
-  subroutine carea_allom(d,nplant,site_spread,ipft,c_area)
+  subroutine carea_allom(d,nplant,site_spread,ipft,c_area,inverse)
      
-     real(r8),intent(in)    :: d           ! plant diameter [cm]
+     real(r8),intent(inout) :: d           ! plant diameter [cm]
      real(r8),intent(in)    :: site_spread ! site level spread factor (crowdedness)
      real(r8),intent(in)    :: nplant      ! number of plants [1/ha]
      integer(i4),intent(in) :: ipft        ! PFT index
-     real(r8),intent(out)   :: c_area      ! crown area per cohort (m2)
+     real(r8),intent(inout) :: c_area      ! crown area per cohort (m2)
+     logical,optional,intent(in) :: inverse! if true, calculate dbh from crown area instead of crown area from dbh
 
      real(r8)               :: d_eff     ! Effective diameter (cm)
+     logical                :: do_inverse, capped_allom
      
      associate( dbh_maxh    => EDPftvarcon_inst%allom_dbh_maxheight(ipft), &
                 allom_lmode => EDPftvarcon_inst%allom_lmode(ipft),  &
@@ -465,24 +468,45 @@ contains
                 d2ca_min    => EDPftvarcon_inst%allom_d2ca_coefficient_min(ipft), &
                 d2ca_max    => EDPftvarcon_inst%allom_d2ca_coefficient_max(ipft))
        
+       if( .not. present(inverse) ) then 
+          do_inverse = .false.
+       else
+          do_inverse = inverse
+       endif
+
+       if (do_inverse) then
+          c_area = c_area / nplant
+       endif
+
        select case(int(allom_lmode))
        case(1)
           d_eff = min(d,dbh_maxh)
-          call carea_2pwr(d_eff,site_spread,d2bl_p2,d2bl_ediff,d2ca_min,d2ca_max,c_area)
+          call carea_2pwr(d_eff,site_spread,d2bl_p2,d2bl_ediff,d2ca_min,d2ca_max,c_area,do_inverse)
+          capped_allom = .true.
        case(2)   ! "2par_pwr")
-          call carea_2pwr(d,site_spread,d2bl_p2,d2bl_ediff,d2ca_min,d2ca_max,c_area)
+          call carea_2pwr(d,site_spread,d2bl_p2,d2bl_ediff,d2ca_min,d2ca_max,c_area,do_inverse)
+          capped_allom = .false.
        case(3)
           d_eff = min(d,dbh_maxh)
-          call carea_2pwr(d_eff,site_spread,d2bl_p2,d2bl_ediff,d2ca_min,d2ca_max,c_area)
+          call carea_2pwr(d_eff,site_spread,d2bl_p2,d2bl_ediff,d2ca_min,d2ca_max,c_area,do_inverse)
+          capped_allom = .true.
        case DEFAULT
-         write(fates_log(),*) 'An undefined leaf allometry was specified: ', &
+          write(fates_log(),*) 'An undefined leaf allometry was specified: ', &
                allom_lmode
-         write(fates_log(),*) 'Aborting'
-         call endrun(msg=errMsg(sourcefile, __LINE__))
-      end select
+          write(fates_log(),*) 'Aborting'
+          call endrun(msg=errMsg(sourcefile, __LINE__))
+       end select
+       
 
-      c_area = c_area * nplant
+       if (capped_allom .and. do_inverse) then
+          if (d_eff .lt. dbh_maxh) then
+             d = d_eff
+          else
+             d = fates_unset_r8
+          endif
+       endif
 
+       c_area = c_area * nplant
 
     end associate
     return
@@ -1848,20 +1872,21 @@ contains
   ! =============================================================================
 
   
-  subroutine carea_2pwr(d,spread,d2bl_p2,d2bl_ediff,d2ca_min,d2ca_max,c_area)
+  subroutine carea_2pwr(d,spread,d2bl_p2,d2bl_ediff,d2ca_min,d2ca_max,c_area,inverse)
 
      ! ============================================================================
      ! Calculate area of ground covered by entire cohort. (m2)
      ! Function of DBH (cm) canopy spread (m/cm) and number of individuals. 
      ! ============================================================================
 
-     real(r8),intent(in) :: d           ! diameter [cm]
+     real(r8),intent(inout) :: d           ! diameter [cm]
      real(r8),intent(in) :: spread      ! site level relative spread score [0-1]
      real(r8),intent(in) :: d2bl_p2     ! parameter 2 in the diameter->bleaf allometry (exponent)
      real(r8),intent(in) :: d2bl_ediff  ! area difference factor in the diameter-bleaf allometry (exponent)
      real(r8),intent(in) :: d2ca_min    ! minimum diameter to crown area scaling factor
      real(r8),intent(in) :: d2ca_max    ! maximum diameter to crown area scaling factor
-     real(r8),intent(out) :: c_area     ! crown area for one plant [m2]
+     real(r8),intent(inout) :: c_area     ! crown area for one plant [m2]
+     logical,intent(in)  :: inverse     ! if true, calculate dbh from crown area rather than its reverse
      
      real(r8)            :: crown_area_to_dbh_exponent
      real(r8)            :: spreadterm  ! Effective 2bh to crown area scaling factor
@@ -1885,7 +1910,11 @@ contains
     
      spreadterm = spread * d2ca_max + (1._r8 - spread) * d2ca_min
      
-     c_area = spreadterm * d ** crown_area_to_dbh_exponent
+     if ( .not. inverse) then
+        c_area = spreadterm * d ** crown_area_to_dbh_exponent
+     else
+        d = (c_area / spreadterm) ** (1./crown_area_to_dbh_exponent)
+     endif
      
   end subroutine carea_2pwr
   

--- a/main/FatesConstantsMod.F90
+++ b/main/FatesConstantsMod.F90
@@ -17,7 +17,7 @@ module FatesConstantsMod
 
   ! Unset and various other 'special' values
   integer, parameter :: fates_unset_int = -9999
-
+  real(fates_r8), parameter :: fates_unset_r8 = -9999._fates_r8
   
   ! Integer equivalent of true  (in case some compilers dont auto convert)
   integer, parameter :: itrue = 1


### PR DESCRIPTION
This PR slightly revises the cohort fusion routine, so that it conserves crown area during the fusion timestep instead of conserving total stem diameter.

### Description:
Currently, when cohorts fuse, the resulting cohort tries to conserve total diameter of the two fusing cohorts.  I ran into an issue where, when cohorts get really big, the numerical errors in crown area conservation get big enough to crash things.  This got me thinking that the way we do cohort fusion might be leading to more numerical errors than needed, because of the lack of crown area conservation during cohort fusion, which is itself typically a part of canopy structuring.  What happens in a typical canopy structure loop is that we split the cohorts between the canopy and the understory, which in general this causes some cohort to get moved between strata.  But upon arrival in the new strata, the small cohort will typically find a similarly sized cohort already there, and will get fused.  But because we don't conserve crown are during fusion, the total post-fusion crown area has changed, and thus the canopy structure logic isn't what it thought it was.

So what this PR does is, when fusing cohorts, to calculate the DBH of the newly fused cohort as being that DBH which conserves total crown area and the dbh-crown area allometry.  further, in the event that dbh is to be incremented based on the biomass allometry to put it back on the biomass allometry, instead of immediately recalculating the dbh, it waits until the next growth step to do that.  that way, if the fusion happens during the canopy structure logic, it conserves crown area during that timestep, even if doing so causes it to be above its biomass allometry, and then resets the dbh to go back onto allometry at the start of the next growth timestep.

Fixes #442.

### Collaborators:
Discussions with @rgknox and @rosiealice 

### Expectation of Answer Changes:
This should be answer changing but at the level of noise, except for the weird edge cases that gave rise to #442.  Possibly by better conserving crown area during canopy structure it might reduce radiation numerical error.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [x] If answers were expected to change, evaluation was performed and provided


### Test Results:
Not formally tested yet.  hold until tests done.