### PR TITLE
Increase maxlayer to 3, reduce max cohorts to 40

### DIFF
--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -603,7 +603,7 @@ contains
             endif
          endif
 
-         ! In the third canopy layer
+         ! Outside the maximum canopy layer
          if (currentCohort%canopy_layer > nclmax ) then 
            terminate = 1
            if ( debug ) then

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -16,13 +16,13 @@ module EDTypesMod
   save
 
   integer, parameter :: maxPatchesPerSite  = 10   ! maximum number of patches to live on a site
-  integer, parameter :: maxCohortsPerPatch = 80  ! maximum number of cohorts per patch
+  integer, parameter :: maxCohortsPerPatch = 100  ! maximum number of cohorts per patch
   
   integer, parameter :: nclmax = 3                ! Maximum number of canopy layers
   integer, parameter :: ican_upper = 1            ! Nominal index for the upper canopy
   integer, parameter :: ican_ustory = 2           ! Nominal index for understory in two-canopy system
 
-  integer, parameter :: nlevleaf = 40             ! number of leaf layers in canopy layer
+  integer, parameter :: nlevleaf = 20             ! number of leaf layers in canopy layer
   integer, parameter :: maxpft = 15               ! maximum number of PFTs allowed
                                                   ! the parameter file may determine that fewer
                                                   ! are used, but this helps allocate scratch

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -16,9 +16,9 @@ module EDTypesMod
   save
 
   integer, parameter :: maxPatchesPerSite  = 10   ! maximum number of patches to live on a site
-  integer, parameter :: maxCohortsPerPatch = 160  ! maximum number of cohorts per patch
+  integer, parameter :: maxCohortsPerPatch = 40  ! maximum number of cohorts per patch
   
-  integer, parameter :: nclmax = 2                ! Maximum number of canopy layers
+  integer, parameter :: nclmax = 3                ! Maximum number of canopy layers
   integer, parameter :: ican_upper = 1            ! Nominal index for the upper canopy
   integer, parameter :: ican_ustory = 2           ! Nominal index for understory in two-canopy system
 

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -16,7 +16,7 @@ module EDTypesMod
   save
 
   integer, parameter :: maxPatchesPerSite  = 10   ! maximum number of patches to live on a site
-  integer, parameter :: maxCohortsPerPatch = 40  ! maximum number of cohorts per patch
+  integer, parameter :: maxCohortsPerPatch = 80  ! maximum number of cohorts per patch
   
   integer, parameter :: nclmax = 3                ! Maximum number of canopy layers
   integer, parameter :: ican_upper = 1            ! Nominal index for the upper canopy

--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -677,8 +677,8 @@ contains
     ! 1D cohort Variables
     ! -----------------------------------------------------------------------------------
 
-    call this%set_restart_var(vname='fates_canopy_layer', vtype=cohort_r8, &
-         long_name='ed cohort - canopy_layer', units='unitless', flushval = flushzero, &
+    call this%set_restart_var(vname='fates_canopy_layer', vtype=cohort_int, &
+         long_name='ed cohort - canopy_layer', units='unitless', flushval = flushinvalid, &
          hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_canopy_layer_co )
 
     call this%set_restart_var(vname='fates_canopy_layer_yesterday', vtype=cohort_r8, &
@@ -1448,7 +1448,7 @@ contains
            rio_ncohort_pa              => this%rvars(ir_ncohort_pa)%int1d, &
            rio_solar_zenith_flag_pa    => this%rvars(ir_solar_zenith_flag_pa)%int1d, &
            rio_solar_zenith_angle_pa   => this%rvars(ir_solar_zenith_angle_pa)%r81d, &
-           rio_canopy_layer_co         => this%rvars(ir_canopy_layer_co)%r81d, &
+           rio_canopy_layer_co         => this%rvars(ir_canopy_layer_co)%int1d, &
            rio_canopy_layer_yesterday_co    => this%rvars(ir_canopy_layer_yesterday_co)%r81d, &
            rio_canopy_trim_co          => this%rvars(ir_canopy_trim_co)%r81d, &
            rio_size_class_lasttimestep => this%rvars(ir_size_class_lasttimestep_co)%int1d, &
@@ -2144,7 +2144,7 @@ contains
           rio_ncohort_pa              => this%rvars(ir_ncohort_pa)%int1d, &
           rio_solar_zenith_flag_pa    => this%rvars(ir_solar_zenith_flag_pa)%int1d, &
           rio_solar_zenith_angle_pa   => this%rvars(ir_solar_zenith_angle_pa)%r81d, &
-          rio_canopy_layer_co         => this%rvars(ir_canopy_layer_co)%r81d, &
+          rio_canopy_layer_co         => this%rvars(ir_canopy_layer_co)%int1d, &
           rio_canopy_layer_yesterday_co         => this%rvars(ir_canopy_layer_yesterday_co)%r81d, &
           rio_canopy_trim_co          => this%rvars(ir_canopy_trim_co)%r81d, &
           rio_size_class_lasttimestep => this%rvars(ir_size_class_lasttimestep_co)%int1d, &

--- a/parameter_files/fates_params_14pfts.cdl
+++ b/parameter_files/fates_params_14pfts.cdl
@@ -616,7 +616,7 @@ data:
 
  fates_canopy_closure_thresh = 0.8 ;
 
- fates_cohort_fusion_tol = 0.05 ;
+ fates_cohort_fusion_tol = 0.08 ;
 
  fates_comp_excln = 3 ;
 

--- a/parameter_files/fates_params_coastal_veg.cdl
+++ b/parameter_files/fates_params_coastal_veg.cdl
@@ -880,7 +880,7 @@ data:
 
  fates_canopy_closure_thresh = 0.8 ;
 
- fates_cohort_fusion_tol = 0.05 ;
+ fates_cohort_fusion_tol = 0.08 ;
 
  fates_comp_excln = 3 ;
 

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -999,7 +999,7 @@ data:
 
  fates_canopy_closure_thresh = 0.8 ;
 
- fates_cohort_fusion_tol = 0.05 ;
+ fates_cohort_fusion_tol = 0.08 ;
 
  fates_comp_excln = 3 ;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

This is a simple set of changes that changes to constants in the code. 

 By increasing the maximum number of canopy layers (nclmax) allowed to 3, FATES will allow a multi-layer canopy instead of artificially culling understory plants that exceed the second layer.  Thus far, dynamic simulations have not had a viable 3rd story in any known context, so this has not been much of an issue. However, inventory initialized simulations such as those at BCI will generate a 3rd story, so this change will enable them to be conducted correctly, particularly when running in static stand structure mode.

The maximum number of cohorts per patch has been a very large number as a default (~150). This number is somewhat of a legacy, in that in the past we set this number very high as it was necessary for memory allocation purposes in restart files.  Since this is not true anymore, the maximum number of cohorts can be reduced.  The ED2 model for instance, very often uses less than 50 cohorts per patch, and typically lower than that.  

A sensitivity analysis of going from 2 to 3 maximum number of canopy layers, and 150 to 40 maximum number of cohorts, at BCI was conducted and is provided in discussion below. The results showed a very small sensitivity to the changes.  I will follow up with timing information.



### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

Yes, answers should not be B4B, but they should also not be different with significance.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [x] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

TBD

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

