### PR TITLE
Added new fields from the coastal veg PR to the 14 parameter cdl file

### DIFF
--- a/parameter_files/fates_params_14pfts.cdl
+++ b/parameter_files/fates_params_14pfts.cdl
@@ -126,6 +126,9 @@ variables:
 	float fates_alloc_storage_cushion(fates_pft) ;
 		fates_alloc_storage_cushion:units = "fraction" ;
 		fates_alloc_storage_cushion:long_name = "maximum size of storage C pool, relative to maximum size of leaf C pool" ;
+        float fates_allom_frbstor_repro(fates_pft) ;
+                fates_allom_frbstor_repro:units = "fraction" ;
+                fates_allom_frbstor_repro:long_name = "fraction of bstore goes to reproduction after plant dies" ;
 	float fates_allom_agb1(fates_pft) ;
 		fates_allom_agb1:units = "variable" ;
 		fates_allom_agb1:long_name = "Parameter 1 for agb allometry" ;
@@ -584,6 +587,9 @@ variables:
 	float fates_part_dens ;
 		fates_part_dens:units = "kg/m2" ;
 		fates_part_dens:long_name = "spitfire parameter, oven dry particle density, Table A1 Thonicke et al 2010" ;
+	float fates_soil_salinity(fates_scalar) ;
+                fates_soil_salinity:units = "ppt" ;
+                fates_soil_salinity:long_name = "soil salinity used for model when not coupled to dynamic soil salinity" ;
 
 // global attributes:
 		:history = "This file was made from FatesPFTIndexSwapper.py \n",
@@ -692,6 +698,8 @@ data:
   "storage                                          ",
   "reproduction                                     ", 
   "structure                                        ";
+
+ fates_allom_frbstor_repro = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
 
  fates_alloc_storage_cushion = 2, 1.2, 1.2, 1.2, 1.2, 1.2, 1.2, 1.2, 1.2, 
     1.2, 1.2, 1.2, 1.2, 1.2 ;
@@ -1192,4 +1200,6 @@ data:
  fates_miner_total = 0.055 ;
 
  fates_part_dens = 513 ;
+
+ fates_soil_salinity = 0.4;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

This PR is trivial, and fixes an omission from PR #435 where we did not add two parameters to the 14 pft parameter file.

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->
@xuchongang 

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

None, this file is not involved in any tests either.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

irrelevant

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->

These updates were necessary to invoke a multi-decade f45-f45 simulation using the 14pft set.  The parameters in the file recreate the default behavior.  Again, these parameters are not used in any tests.


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

