### PR TITLE
Remove Lasslop wind effect on fire ROS

### DIFF
--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -408,8 +408,8 @@ contains
     use SFParamsMod, only  : SF_val_miner_total, &
                              SF_val_part_dens,   &
                              SF_val_miner_damp,  &
-                             SF_val_fuel_energy, &
-                             SF_val_wind_max
+                             SF_val_fuel_energy
+    
     use FatesInterfaceMod, only : hlm_current_day, hlm_current_month
 
     type(ed_site_type), intent(in), target :: currentSite

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -426,7 +426,6 @@ contains
     real(r8) beta_ratio           ! ratio of beta/beta_op
     real(r8) a_beta               ! dummy variable for product of a* beta_ratio for react_v_opt equation
     real(r8) a,b,c,e              ! function of fuel sav
-    real(r8) wind_elev_fire                  !wind speed (m/min) at elevevation relevant for fire
 
     logical,parameter :: debug_windspeed = .false. !for debugging
 
@@ -493,21 +492,9 @@ contains
 
        ! Equation A5 in Thonicke et al. 2010
        ! phi_wind (unitless)
-       ! convert wind_elev_fire from m/min to ft/min for Rothermel ROS eqn
-       ! wind max per Lasslop et al 2014 to linearly reduce ROS for high wind speeds
-       !OLD! phi_wind = c * ((3.281_r8*currentPatch%effect_wspeed)**b)*(beta_ratio**(-e))
-       if (currentPatch%effect_wspeed .le. SF_val_wind_max) then
-          wind_elev_fire = currentPatch%effect_wspeed
-          phi_wind = c * ((3.281_r8*wind_elev_fire)**b)*(beta_ratio**(-e))
-          if (debug_windspeed) write(fates_log(),*) 'SF wind LESS max ', currentPatch%effect_wspeed 
-          if (debug_windspeed) write(fates_log(),*) 'month and day', hlm_current_month, hlm_current_day             
-       else
-          !max condition 225 ft/min (FIREMIP Rabin table A10 JSBACH-Spitfire) convert to 68.577 m/min 
-          wind_elev_fire = max(0.0_r8,(68.577_r8-0.5_r8*currentPatch%effect_wspeed))
-          phi_wind = c * ((3.281_r8*wind_elev_fire)**b)*(beta_ratio**(-e))
-          if (debug_windspeed) write(fates_log(),*) 'SF wind GREATER max ', currentPatch%effect_wspeed
-          if (debug_windspeed) write(fates_log(),*) 'month and day', hlm_current_month, hlm_current_day 
-       endif 
+       ! convert current_wspeed (wind at elev relevant to fire) from m/min to ft/min for Rothermel ROS eqn
+       phi_wind = c * ((3.281_r8*currentPatch%effect_wspeed)**b)*(beta_ratio**(-e))
+
 
        ! ---propagating flux----
        ! Equation A2 in Thonicke et al.2010 and Eq. 42 Rothermal 1972

--- a/fire/SFParamsMod.F90
+++ b/fire/SFParamsMod.F90
@@ -23,7 +23,6 @@ module SFParamsMod
    real(r8),protected :: SF_val_miner_damp
    real(r8),protected :: SF_val_max_durat
    real(r8),protected :: SF_val_durat_slope
-   real(r8),protected :: SF_val_wind_max          ! Maximum wind speed expected by fire model (m/min)
    real(r8),protected :: SF_val_alpha_FMC(NFSC)
    real(r8),protected :: SF_val_CWD_frac(NCWD)
    real(r8),protected :: SF_val_max_decomp(NFSC)
@@ -56,7 +55,6 @@ module SFParamsMod
    character(len=param_string_length),parameter :: SF_name_low_moisture_Slope = "fates_low_moisture_Slope"
    character(len=param_string_length),parameter :: SF_name_mid_moisture_Coeff = "fates_mid_moisture_Coeff"
    character(len=param_string_length),parameter :: SF_name_mid_moisture_Slope = "fates_mid_moisture_Slope"
-   character(len=param_string_length),parameter :: SF_name_wind_max = "fates_fire_wind_max"
 
    public :: SpitFireRegisterParams
    public :: SpitFireReceiveParams
@@ -90,7 +88,6 @@ contains
     SF_val_miner_damp = nan
     SF_val_max_durat = nan
     SF_val_durat_slope = nan
-    SF_val_wind_max = nan
 
     SF_val_CWD_frac(:) = nan
 
@@ -150,9 +147,6 @@ contains
 
     character(len=param_string_length), parameter :: dim_names_scalar(1) = (/dimension_name_scalar/)
     
-    call fates_params%RegisterParameter(name=SF_name_wind_max, dimension_shape=dimension_shape_scalar, &
-          dimension_names=dim_names_scalar)
-
     call fates_params%RegisterParameter(name=SF_name_fdi_a, dimension_shape=dimension_shape_scalar, &
          dimension_names=dim_names_scalar)
 
@@ -190,9 +184,6 @@ contains
     implicit none
 
     class(fates_parameters_type), intent(inout) :: fates_params
-
-    call fates_params%RetreiveParameter(name=SF_name_wind_max, &
-          data=SF_val_wind_max)
 
     call fates_params%RetreiveParameter(name=SF_name_fdi_a, &
          data=SF_val_fdi_a)

--- a/parameter_files/fates_params_14pfts.cdl
+++ b/parameter_files/fates_params_14pfts.cdl
@@ -569,9 +569,6 @@ variables:
 	float fates_fdi_b ;
 		fates_fdi_b:units = "NA" ;
 		fates_fdi_b:long_name = "spitfire parameter (unknown) " ;
-	float fates_fire_wind_max ;
-		fates_fire_wind_max:units = "m/min" ;
-		fates_fire_wind_max:long_name = "maximum wind speed expected by the fire model" ;
 	float fates_fuel_energy ;
 		fates_fuel_energy:units = "kJ/kg" ;
 		fates_fuel_energy:long_name = "pitfire parameter, heat content of fuel" ;
@@ -1188,8 +1185,6 @@ data:
  fates_fdi_alpha = 0.00037 ;
 
  fates_fdi_b = 243.12 ;
-
- fates_fire_wind_max = 45.718 ;
 
  fates_fuel_energy = 18000 ;
 

--- a/parameter_files/fates_params_coastal_veg.cdl
+++ b/parameter_files/fates_params_coastal_veg.cdl
@@ -527,9 +527,6 @@ variables:
 	float fates_fdi_b ;
 		fates_fdi_b:units = "NA" ;
 		fates_fdi_b:long_name = "spitfire parameter (unknown) " ;
-	float fates_fire_wind_max ;
-		fates_fire_wind_max:units = "m/min" ;
-		fates_fire_wind_max:long_name = "maximum wind speed expected by the fire model" ;
 	float fates_fuel_energy ;
 		fates_fuel_energy:units = "kJ/kg" ;
 		fates_fuel_energy:long_name = "pitfire parameter, heat content of fuel" ;
@@ -946,8 +943,6 @@ data:
  fates_fdi_alpha = 0.00037 ;
 
  fates_fdi_b = 243.12 ;
-
- fates_fire_wind_max = 45.718 ;
 
  fates_fuel_energy = 18000 ;
 

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -569,9 +569,6 @@ variables:
 	float fates_fdi_b ;
 		fates_fdi_b:units = "NA" ;
 		fates_fdi_b:long_name = "spitfire parameter (unknown) " ;
-	float fates_fire_wind_max ;
-		fates_fire_wind_max:units = "m/min" ;
-		fates_fire_wind_max:long_name = "maximum wind speed expected by the fire model" ;
 	float fates_fuel_energy ;
 		fates_fuel_energy:units = "kJ/kg" ;
 		fates_fuel_energy:long_name = "pitfire parameter, heat content of fuel" ;
@@ -1065,8 +1062,6 @@ data:
  fates_fdi_alpha = 0.00037 ;
 
  fates_fdi_b = 243.12 ;
-
- fates_fire_wind_max = 45.718 ;
 
  fates_fuel_energy = 18000 ;
 


### PR DESCRIPTION
Remove reducing effect of high winds based on Lasslop et al 2014

### Description:
Within SFMain remove the conditional clause that reduces fire rate of spread for high wind speeds. Within parameter files removed the parameter for fire_wind_max that triggers the conditional.
This showed an improvement in mode simulated fire behavior in past work (Lasslop et al 2014), but current research demonstrates there is not a clear link between high winds and a reducing effect on rate of spread. Andela et al 2018 ESSDD https://doi.org/10.5194/essd-2018-89 
This PR acts to remove this Lasslop et al (2014) reducing effect, and revert back to original Thonicke ROS wind effect.

### Collaborators:
JKShuman, RKnox

### Expectation of Answer Changes:
Fire behavior rate of spread will be higher at high winds within simulation, dependent on previous fire_wind_max parameter and forcing data.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided

### Test Results:
Code compiles and runs on Hobart.


