### PR TITLE
Fix to net assimilation tracker used for trimming

### DIFF
--- a/biogeophys/FatesPlantRespPhotosynthMod.F90
+++ b/biogeophys/FatesPlantRespPhotosynthMod.F90
@@ -938,7 +938,7 @@ contains
      
      if ( parsun_lsl <= 0._r8 ) then  ! night time
 
-        anet_av_out = 0._r8
+        anet_av_out = -lmr
         psn_out     = 0._r8
         rstoma_out  = min(rsmax0, 1._r8/bbb * cf)
         


### PR DESCRIPTION
### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

See issue #457, it appears that during photosynthesis, the net assimilation diagnostic was not being updated correctly at night, this fixes that.

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->
@rosiealice @ckoven @walkeranthonyp 

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

Yes this should change answers, however long-term simulations at BCI showed a much lower sensitivity to this fix that was expected.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [x] FATES PASS/FAIL regression tests were run
- [x] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

all PASS:
/gpfs/fs1/scratch/rgknox/clmed-tests/fates.cheyenne.intel.lmr-fix-C5dc7f0a-Fb8df885

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

