### PR TITLE
Liang/d13c ready to merge

### DIFF
--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -434,6 +434,9 @@ contains
     currentCohort%resp_acc_hold      = nan ! RESP: kgC/indiv/year
     currentCohort%resp_tstep         = nan ! RESP: kgC/indiv/timestep
     currentCohort%resp_acc           = nan ! RESP: kGC/cohort/day
+    
+    currentCohort%c13disc_clm        = nan ! C13 discrimination, per mil at indiv/timestep
+    currentCohort%c13disc_acc        = nan ! C13 discrimination, per mil at indiv/timestep at indiv/daily at the end of a day
 
     !RESPIRATION
     currentCohort%rdark              = nan
@@ -524,6 +527,8 @@ contains
     currentcohort%prom_weight        = 0._r8
     currentcohort%crownfire_mort     = 0._r8
     currentcohort%cambial_mort       = 0._r8
+    currentCohort%c13disc_clm        = 0._r8 
+    currentCohort%c13disc_acc        = 0._r8
     
   end subroutine zero_cohort
 
@@ -869,6 +874,15 @@ contains
                                 
                                 currentCohort%canopy_trim = (currentCohort%n*currentCohort%canopy_trim &
                                       + nextc%n*nextc%canopy_trim)/newn
+				
+				! c13disc_acc calculation; weighted mean by GPP
+				if ((currentCohort%n * currentCohort%gpp_acc + nextc%n * nextc%gpp_acc) .eq. 0.0_r8) then
+				     currentCohort%c13disc_acc = 0.0_r8
+				else  
+				     currentCohort%c13disc_acc = (currentCohort%n * currentCohort%gpp_acc * currentCohort%c13disc_acc +   &
+				     	                          nextc%n * nextc%gpp_acc * nextc%c13disc_acc)/    &
+					                           (currentCohort%n * currentCohort%gpp_acc + nextc%n * nextc%gpp_acc)
+				endif				
 
                                 ! -----------------------------------------------------------------
                                 ! If fusion pushed structural biomass to be larger than
@@ -1334,6 +1348,10 @@ contains
     n%resp_acc_hold   = o%resp_acc_hold
     n%year_net_uptake = o%year_net_uptake
     n%ts_net_uptake   = o%ts_net_uptake
+
+    ! C13 discrimination
+    n%c13disc_clm   = o%c13disc_clm
+    n%c13disc_acc   = o%c13disc_acc
 
     !RESPIRATION
     n%rdark           = o%rdark

--- a/biogeophys/EDAccumulateFluxesMod.F90
+++ b/biogeophys/EDAccumulateFluxesMod.F90
@@ -83,6 +83,14 @@ contains
                 ccohort%npp_acc  = ccohort%npp_acc  + ccohort%npp_tstep 
                 ccohort%gpp_acc  = ccohort%gpp_acc  + ccohort%gpp_tstep 
                 ccohort%resp_acc = ccohort%resp_acc + ccohort%resp_tstep
+		
+		! weighted mean of D13C by gpp
+		if((ccohort%gpp_acc + ccohort%gpp_tstep) .eq. 0.0_r8) then
+                  ccohort%c13disc_acc = 0.0_r8
+                else
+                  ccohort%c13disc_acc  = ((ccohort%c13disc_acc * ccohort%gpp_acc) + (ccohort%c13disc_clm * ccohort%gpp_tstep)) / &
+                                          (ccohort%gpp_acc + ccohort%gpp_tstep)
+		endif
                 
                 !----- THE FOLLOWING IS ONLY IMPLEMENTED TEMPORARILY FOR B4B reproducibility
                 !----- ALSO, THERE IS NO REASON TO USE THE ISNEW FLAG HERE

--- a/biogeophys/FatesPlantRespPhotosynthMod.F90
+++ b/biogeophys/FatesPlantRespPhotosynthMod.F90
@@ -946,7 +946,7 @@ contains
         anet_av_out = -lmr
         psn_out     = 0._r8
         rstoma_out  = min(rsmax0, 1._r8/bbb * cf)
-	c13disc_z = 1.0_r8                !carbon 13 discrimination in night time carbon flux, value from CLM
+	c13disc_z = 0.0_r8    !carbon 13 discrimination in night time carbon flux, note value of 1.0 is used in CLM
         
      else ! day time (a little bit more complicated ...)
         

--- a/biogeophys/FatesPlantRespPhotosynthMod.F90
+++ b/biogeophys/FatesPlantRespPhotosynthMod.F90
@@ -1263,10 +1263,11 @@ contains
        ! Dark respiration
        ! [umolC/m2leaf/s] * [m2 leaf]    (This is the cohort group sum)
        rdark = rdark + lmr_llz(il) * cohort_layer_eleaf_area
-       
+
     end do
     
     
+
      if (nv > 1) then     
       ! cohort%c13disc_clm as weighted mean of d13c flux at all related leave layers
       sum_weight = sum(psn_llz(1:nv-1) * elai_llz(1:nv-1))
@@ -1277,6 +1278,7 @@ contains
 	 end if   
 
      end if
+
 
     ! -----------------------------------------------------------------------------------
     ! We DO NOT normalize g_sb_laweight.

--- a/biogeophys/FatesPlantRespPhotosynthMod.F90
+++ b/biogeophys/FatesPlantRespPhotosynthMod.F90
@@ -948,7 +948,7 @@ contains
         anet_av_out = -lmr
         psn_out     = 0._r8
         rstoma_out  = min(rsmax0, 1._r8/bbb * cf)
-	c13disc_z = 1.0_r8                !carbon 13 discrimination in night time carbon flux, value from CLM
+	c13disc_z = 0.0_r8    !carbon 13 discrimination in night time carbon flux, note value of 1.0 is used in CLM
         
      else ! day time (a little bit more complicated ...)
         

--- a/biogeophys/FatesPlantRespPhotosynthMod.F90
+++ b/biogeophys/FatesPlantRespPhotosynthMod.F90
@@ -1166,6 +1166,7 @@ contains
            ! (leaves are off, or have reduced to 0)
            psn_out = 0._r8
            rstoma_out = min(rsmax0, 1._r8/bbb * cf)
+	   
 	   c13disc_z = 0.0_r8
            
         end if !is there leaf area? 
@@ -1265,6 +1266,7 @@ contains
        
     end do
     
+
     
      if (nv > 1) then     
       ! cohort%c13disc_clm as weighted mean of d13c flux at all related leave layers

--- a/biogeophys/FatesPlantRespPhotosynthMod.F90
+++ b/biogeophys/FatesPlantRespPhotosynthMod.F90
@@ -556,6 +556,7 @@ contains
                                                         currentCohort%g_sb_laweight,           & !out
                                                         currentCohort%gpp_tstep,               & !out
                                                         currentCohort%rdark,                   & !out
+							currentCohort%c13disc_clm,             & !out
                                                         cohort_eleaf_area)                       !out
                         
                         ! Net Uptake does not need to be scaled, just transfer directly
@@ -820,8 +821,9 @@ contains
                                      lmr,               &  ! in
                                      psn_out,           &  ! out
                                      rstoma_out,        &  ! out
-                                     anet_av_out)          ! out
-
+                                     anet_av_out,       &  ! out
+				     c13disc_z)            ! out
+ 
     ! ------------------------------------------------------------------------------------
     ! This subroutine calculates photosynthesis and stomatal conductance within each leaf 
     ! sublayer.
@@ -1181,6 +1183,7 @@ contains
                                         lmr_llz,     & ! in   lmr_z(1:currentCohort%nv,ft,cl)
                                         rs_llz,      & ! in   rs_z(1:currentCohort%nv,ft,cl)
                                         elai_llz,    & ! in   %elai_profile(cl,ft,1:currentCohort%nv)
+					c13disc_llz, & ! in   c13disc_z(cl, ft, 1:currentCohort%nv)
                                         c_area,      & ! in   currentCohort%c_area
                                         nplant,      & ! in   currentCohort%n
                                         rb,          & ! in   bc_in(s)%rb_pa(ifp)
@@ -1188,6 +1191,7 @@ contains
                                         g_sb_laweight, & ! out  currentCohort%g_sb_laweight [m/s] [m2-leaf]
                                         gpp,         &   ! out  currentCohort%gpp_tstep
                                         rdark,       &   ! out  currentCohort%rdark
+					c13disc_clm, &   ! out currentCohort%c13disc_clm
                                         cohort_eleaf_area ) ! out [m2]
    
     ! ------------------------------------------------------------------------------------
@@ -1206,6 +1210,7 @@ contains
     real(r8), intent(in) :: lmr_llz(nv)      ! layer dark respiration rate [umolC/m2leaf/s]
     real(r8), intent(in) :: rs_llz(nv)       ! leaf layer stomatal resistance [s/m]
     real(r8), intent(in) :: elai_llz(nv)     ! exposed LAI per layer [m2 leaf/ m2 pft footprint]
+    real(r8), intent(in) :: c13disc_llz(nv)  ! leaf layer c13 discrimination, weighted mean
     real(r8), intent(in) :: c_area           ! crown area m2/m2
     real(r8), intent(in) :: nplant           ! indiv/m2
     real(r8), intent(in) :: rb               ! leaf boundary layer resistance (s/m)

--- a/biogeophys/FatesPlantRespPhotosynthMod.F90
+++ b/biogeophys/FatesPlantRespPhotosynthMod.F90
@@ -823,7 +823,7 @@ contains
                                      rstoma_out,        &  ! out
                                      anet_av_out,       &  ! out
 				     c13disc_z)            ! out
- 
+
     ! ------------------------------------------------------------------------------------
     ! This subroutine calculates photosynthesis and stomatal conductance within each leaf 
     ! sublayer.

--- a/biogeophys/FatesPlantRespPhotosynthMod.F90
+++ b/biogeophys/FatesPlantRespPhotosynthMod.F90
@@ -948,7 +948,7 @@ contains
         anet_av_out = -lmr
         psn_out     = 0._r8
         rstoma_out  = min(rsmax0, 1._r8/bbb * cf)
-	c13disc_z = 0.0_r8    !carbon 13 discrimination in night time carbon flux, note value of 1.0 is used in CLM
+	c13disc_z = 1.0_r8                !carbon 13 discrimination in night time carbon flux, value from CLM
         
      else ! day time (a little bit more complicated ...)
         
@@ -1166,7 +1166,7 @@ contains
            ! (leaves are off, or have reduced to 0)
            psn_out = 0._r8
            rstoma_out = min(rsmax0, 1._r8/bbb * cf)
-	   
+
 	   c13disc_z = 0.0_r8
            
         end if !is there leaf area? 
@@ -1266,7 +1266,6 @@ contains
        
     end do
     
-
     
      if (nv > 1) then     
       ! cohort%c13disc_clm as weighted mean of d13c flux at all related leave layers
@@ -1274,8 +1273,9 @@ contains
          if (sum_weight .eq. 0.0_r8) then
             c13disc_clm = 0.0
          else
-            c13disc_clm = sum(c13disc_llz(1:nv-1) * psn_llz(1:nv-1) * elai_llz(1:nv-1)) / sum_weight
-         end if
+     	    c13disc_clm = sum(c13disc_llz(1:nv-1) * psn_llz(1:nv-1) * elai_llz(1:nv-1)) / sum_weight 
+	 end if   
+
      end if
 
     ! -----------------------------------------------------------------------------------

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -237,6 +237,11 @@ module EDTypesMod
      real(r8) ::  resp_tstep         ! Autotrophic respiration (see above *)
      real(r8) ::  resp_acc
      real(r8) ::  resp_acc_hold
+     
+     ! carbon 13c discrimination
+     real(r8) ::  c13disc_clm         ! carbon 13 discrimination in new synthesized carbon: part-per-mil, at each indiv/timestep
+     real(r8) ::  c13disc_acc         ! carbon 13 discrimination in new synthesized carbon: part-per-mil, at each indiv/day, at the end of a day
+
 
      real(r8) ::  ts_net_uptake(nlevleaf)              ! Net uptake of leaf layers: kgC/m2/timestep
      real(r8) ::  year_net_uptake(nlevleaf)            ! Net uptake of leaf layers: kgC/m2/year

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -1449,8 +1449,8 @@ end subroutine flush_hvars
                hio_m6_si_scls          => this%hvars(ih_m6_si_scls)%r82d, &
                hio_m7_si_scls          => this%hvars(ih_m7_si_scls)%r82d, &
                hio_m8_si_scls          => this%hvars(ih_m8_si_scls)%r82d, &    
-	       
 	       hio_c13disc_si_scpf     => this%hvars(ih_c13disc_si_scpf)%r82d, &                    
+
 
                hio_ba_si_scls          => this%hvars(ih_ba_si_scls)%r82d, &
                hio_agb_si_scls          => this%hvars(ih_agb_si_scls)%r82d, &
@@ -1806,6 +1806,7 @@ end subroutine flush_hvars
 			     
 		       !C13 discrimination
                        if(gpp_cached + ccohort%gpp_acc_hold > 0.0_r8)then
+
                            hio_c13disc_si_scpf(io_si,scpf) = ((hio_c13disc_si_scpf(io_si,scpf) * gpp_cached) + &
 			     (ccohort%c13disc_acc * ccohort%gpp_acc_hold)) / (gpp_cached + ccohort%gpp_acc_hold)
 		       else

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -1450,7 +1450,7 @@ end subroutine flush_hvars
                hio_m7_si_scls          => this%hvars(ih_m7_si_scls)%r82d, &
                hio_m8_si_scls          => this%hvars(ih_m8_si_scls)%r82d, &    
 	       
-	       hio_c13disc_si_scpf => this%hvars(ih_c13disc_si_scpf)%r82d, &                    
+	       hio_c13disc_si_scpf     => this%hvars(ih_c13disc_si_scpf)%r82d, &                    
 
                hio_ba_si_scls          => this%hvars(ih_ba_si_scls)%r82d, &
                hio_agb_si_scls          => this%hvars(ih_agb_si_scls)%r82d, &
@@ -1758,6 +1758,8 @@ end subroutine flush_hvars
 
                   associate( scpf => ccohort%size_by_pft_class, &
                              scls => ccohort%size_class )
+			     
+		    gpp_cached = hio_gpp_si_scpf(io_si,scpf)
 
                     hio_gpp_si_scpf(io_si,scpf)      = hio_gpp_si_scpf(io_si,scpf)      + &
                                                        n_perm2*ccohort%gpp_acc_hold  ! [kgC/m2/yr]
@@ -1803,7 +1805,7 @@ end subroutine flush_hvars
                              ccohort%frmort*ccohort%n
 			     
 		       !C13 discrimination
-                       if(gpp_cached + ccohort%gpp_acc_hold>0._r8)then
+                       if(gpp_cached + ccohort%gpp_acc_hold > 0.0_r8)then
                            hio_c13disc_si_scpf(io_si,scpf) = ((hio_c13disc_si_scpf(io_si,scpf) * gpp_cached) + &
 			     (ccohort%c13disc_acc * ccohort%gpp_acc_hold)) / (gpp_cached + ccohort%gpp_acc_hold)
 		       else

--- a/parameter_files/fates_params_hydro_default.cdl
+++ b/parameter_files/fates_params_hydro_default.cdl
@@ -923,11 +923,11 @@ data:
 
  fates_pft_used = 1, 1 ;
 
- fates_phen_evergreen = 1, 1 ;
+ fates_phen_evergreen = 1, 0 ;
 
  fates_phen_season_decid = 0, 0 ;
 
- fates_phen_stress_decid = 0, 0 ;
+ fates_phen_stress_decid = 0, 1 ;
 
  fates_prescribed_mortality_canopy = 0.0194, 0.0194 ;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
A carbon stable isotopes component is added to FATES. The C stable isotopes component has been previously introduced to 3-PG model (Wei et al, 2014a&b; Wei et al, 2018), LPX-Bern model (Keller et al, 2017), and CLM4.5 (Raczka et al, 2016; Duarte et al, 2017; Keller et al, 2017).  

Carbon stable isotope of C3 plant is tightly related to plant gas exchanges (GPP and transpiration) and the carbon stable isotope can be reasonably simulated only when gas exchange were reasonably simulated in the model. Therefore, the C stable isotope component may serve as a test for models’ ability to simulate productivity and transpiration by revealing models' weakness and constraining their parameterization (Wei et al, 2014a; Duarte et al, 2017). In a NGEE-Tropics project, Wei et al at LANL also used this component as a new approach to simulate forest mortality as carbon stable isotopes can be an indicator of water stress and shading. Further testing and improving this new modules are needed. 

At this stage, the only output of the stable isotope component is the discrimination of C3 plant to heavier stable C isotope (c13disc; you may put 'C13disc_SCPF' in user_nl_clm) for the new assimilated carbon. There will be post-photosynthetic discriminations after assimilated C is allocated to different plant tissues (e.g. Badeck et al, 2005; Cernusak et al, 2009; Wingate et al, 2010; Wei et al, 2014a), which may be incorporated the future model development. 


***
The key calculation is based on the simple model of Ubierna and Farquhar, 2014 in FatesPlantRespPhotosynthMod.F90 as:
         
! The simple model is used: $\Delta ^{13} C = \alpha_s + (b - \alpha_s) \cdot \frac{C_i}{C_a}$
! just hard code b and \alpha_s for now, might move to parameter set in the future
! b = 27.0 alpha_s = 4.4
c13disc_z = 4.4_r8 + (27.0_r8 - 4.4_r8) * min (can_co2_ppress, max (co2_inter_c, 0._r8)) / can_co2_ppress 

There are also more complete and hence more complicated models for the calculation (see review in Ubierna and Farquhar, 2014). However such models is difficult to parameterize at current stage mainly due to the limit knowledge of mesophyll conductance. 

***
Stable isotope ratio (δ13C) can be calculated as:
d13c = (d13c_background-c13disc)/(1+c13disc/1000)
or, approximately  d13c_background - c13disc
where d13c_background is the d13C of the atmosphere.  

δ13C is the relative 13C composition relative to a standard that we measure from plant tissues. 

We do not include the calculation of δ13C in the current version because 1) the d13c_background is changing fast; it is becoming more and more negative due to the burning of fossil fuel, which is C13 depleted; 2) it is not difficult to calculate d13C from c13disc as described above. Therefore, we believe it is a good idea to let users realizing this issue and calculate δ13C offline from c13disc, instead of obtaining a δ13C values without thinking the changing d13c_background.

! If we do want to estimate d13c directly from the model, one may use a function (Feng 1998) to estimate d13c_background for past years

 use clm_time_manager , only : get_curr_date 
 !! ...
real(r8) :: d13c_background = 0.0_r8
!! ...
  call get_curr_date(yr, mon, day, tod)
                if (yr < 1740) then
                  d13c_background = -6.429_r8
                else if (yr > 2019) then                       !calculated values change in an exponential fashion,                                         
                  d13c_background = -9.000_r8    !this is arbitrary, this equation should not be used after certain years
                else
                  d13c_background = -6.429_r8 - 0.0060_r8 * exp(0.0217_r8 * (yr - 1740))
endif

***
References:
•	Badeck, F.-W., Tcherkez, G., Nogués, S., Piel, C. and Ghashghaie, J., 2005. Post-photosynthetic fractionation of stable carbon isotopes between plant organs—a widespread phenomenon. Rapid Communications in Mass Spectrometry, 19(11): 1381-1391.
•	Cernusak, L.A. et al., 2009. Why are non-photosynthetic tissues generally 13C enriched compared with leaves in C3 plants? Review and synthesis of current hypotheses. Functional Plant Biology, 36(3): 199-213.
•	Duarte, H.F. et al., 2017. Evaluating the Community Land Model (CLM4.5) at a coniferous forest site in northwestern United States using flux and carbon-isotope measurements. Biogeosciences, 14(18): 4315-4340.
•	Feng, X., 1998. Long-term ci/ ca response of trees in western North America to atmospheric CO2 concentration derived from carbon isotope chronologies. Oecologia, 117(1): 19-25.
•	Keller, K.M. et al., 2017. 20th century changes in carbon isotopes and water-use efficiency: tree-ring-based evaluation of the CLM4.5 and LPX-Bern models. Biogeosciences, 14(10): 2641-2673.
•	Raczka, B. et al., 2017. Does vapor pressure deficit drive the seasonality of δ13C of the net land‐atmosphere CO2 exchange across the United States? Journal of Geophysical Research: Biogeosciences, 122(8): 1969-1987.
•	Ubierna, N. and Farquhar, G.D., 2014. Advances in measurements and models of photosynthetic carbon isotope discrimination in C3 plants. Plant, Cell & Environment, 37(7): 1494-1498.
•	Wei, L. et al., 2014a. Constraining 3-PG with a new δ13C submodel: a test using the δ13C of tree rings. Plant, Cell & Environment, 37(1): 82-100.
•	Wei, L., Marshall, J.D., Zhang, J., Zhou, H. and Powers, R.F., 2014b. 3-PG simulations of young ponderosa pine plantations under varied management intensity: Why do they grow so differently? Forest Ecology and Management, 313(0): 69-82.
•	Wei, L. et al., 2018. Forest productivity varies with soil moisture more than temperature in a small montane watershed. Agricultural and Forest Meteorology, 259: 211-221.
•	Wingate, L. et al., 2010. Photosynthetic carbon isotope discrimination and its relationship to the carbon isotope signals of stem, soil and ecosystem respiration. New Phytologist, 188(2): 576-589.


### Collaborators:
 @xuchongang, @ joeyzhou1984,  with help from many others

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

