### PR TITLE
parameter file updates

### DIFF
--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -50,7 +50,8 @@ module EDPftvarcon
      real(r8), allocatable :: bark_scaler(:)         ! scaler from dbh to bark thickness. For fire model.
      real(r8), allocatable :: crown_kill(:)          ! scaler on fire death. For fire model. 
      real(r8), allocatable :: initd(:)               ! initial seedling density 
-     real(r8), allocatable :: seed_rain(:)           ! seeds that come from outside the gridbox.
+     real(r8), allocatable :: seed_rain(:)           ! Non-conserving, supplemental seed rain influx
+                                                     
      real(r8), allocatable :: BB_slope(:)            ! ball berry slope parameter
      
      real(r8), allocatable :: seed_alloc_mature(:)   ! fraction of carbon balance allocated to 

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -35,7 +35,6 @@ module EDPftvarcon
   !ED specific variables. 
   type, public ::  EDPftvarcon_type
 
-     real(r8), allocatable :: pft_used(:)            ! Switch to turn on and off PFTs
      real(r8), allocatable :: freezetol(:)           ! minimum temperature tolerance
      real(r8), allocatable :: wood_density(:)        ! wood density  g cm^-3  ...
      real(r8), allocatable :: hgt_min(:)             ! sapling height m
@@ -344,10 +343,6 @@ contains
     !X!    name = ''
     !X!    call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
     !X!         dimension_names=dim_names, lower_bounds=dim_lower_bound)
-
-    name = 'fates_pft_used'
-    call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
-         dimension_names=dim_names, lower_bounds=dim_lower_bound)
 
     name = 'fates_seed_dbh_repro_threshold'
     call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
@@ -780,10 +775,6 @@ contains
     !X!    name = ''
     !X!    call fates_params%RetreiveParameter(name=name, &
     !X!         data=this%)
-
-    name = 'fates_pft_used'
-    call fates_params%RetreiveParameterAllocate(name=name, &
-         data=this%pft_used)
 
     name = 'fates_seed_dbh_repro_threshold'
     call fates_params%RetreiveParameterAllocate(name=name, &
@@ -1705,7 +1696,7 @@ contains
 
      integer :: npft,ipft
      
-     npft = size(EDPftvarcon_inst%pft_used,1)
+     npft = size(EDPftvarcon_inst%wood_density,1)
      
      if(debug_report .and. is_master) then
         
@@ -1717,7 +1708,6 @@ contains
         end if
 
         write(fates_log(),*) '-----------  FATES PFT Parameters -----------------'
-        write(fates_log(),fmt0) 'pft_used = ',EDPftvarcon_inst%pft_used
         write(fates_log(),fmt0) 'dbh max height = ',EDPftvarcon_inst%allom_dbh_maxheight
         write(fates_log(),fmt0) 'dbh mature = ',EDPftvarcon_inst%dbh_repro_threshold
         write(fates_log(),fmt0) 'freezetol = ',EDPftvarcon_inst%freezetol
@@ -1875,7 +1865,7 @@ contains
      integer :: iage     ! leaf age class index
      integer :: norgans  ! size of the plant organ dimension
 
-     npft = size(EDPftvarcon_inst%pft_used,1)
+     npft = size(EDPftvarcon_inst%wood_density,1)
 
      ! Prior to performing checks copy grperc to the 
      ! organ dimensioned version

--- a/parameter_files/fates_params_14pfts.cdl
+++ b/parameter_files/fates_params_14pfts.cdl
@@ -420,9 +420,6 @@ variables:
 	float fates_mort_scalar_hydrfailure(fates_pft) ;
 		fates_mort_scalar_hydrfailure:units = "1/yr" ;
 		fates_mort_scalar_hydrfailure:long_name = "maximum mortality rate from hydraulic failure" ;
-	float fates_pft_used(fates_pft) ;
-		fates_pft_used:units = "0 = off (dont use), 1 = on (use)" ;
-		fates_pft_used:long_name = "Switch to turn on and off PFTs (also see fates_initd for cold-start)" ;
 	float fates_phen_evergreen(fates_pft) ;
 		fates_phen_evergreen:units = "logical flag" ;
 		fates_phen_evergreen:long_name = "Binary flag for evergreen leaf habit" ;
@@ -1064,8 +1061,6 @@ data:
 
  fates_mort_scalar_hydrfailure = 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 0.6, 
     0.6, 0.6, 0.6, 0.6, 0.6 ;
-
- fates_pft_used = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 ;
 
  fates_phen_evergreen    = 1, 1, 1, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0 ;
 

--- a/parameter_files/fates_params_14pfts.cdl
+++ b/parameter_files/fates_params_14pfts.cdl
@@ -492,9 +492,9 @@ variables:
 	float fates_seed_germination_timescale(fates_pft) ;
 		fates_seed_germination_timescale:units = "1/yr" ;
 		fates_seed_germination_timescale:long_name = "turnover time for seeds with respect to decay" ;
-	float fates_seed_rain(fates_pft) ;
-		fates_seed_rain:units = "KgC/m2/yr" ;
-		fates_seed_rain:long_name = "External seed rain from outside site (non-mass conserving)" ;
+	float fates_seed_suppl(fates_pft) ;
+		fates_seed_suppl:units = "KgC/m2/yr" ;
+		fates_seed_suppl:long_name = "Supplemental external seed rain source term (non-mass conserving)" ;
 	float fates_smpsc(fates_pft) ;
 		fates_smpsc:units = "mm" ;
 		fates_smpsc:long_name = "Soil water potential at full stomatal closure" ;
@@ -1131,7 +1131,7 @@ data:
  fates_seed_germination_timescale = 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 
     0.5, 0.5, 0.5, 0.5, 0.5, 0.5 ;
 
- fates_seed_rain = 0.28, 0.28, 0.28, 0.28, 0.28, 0.28, 0.28, 0.28, 0.28, 
+ fates_seed_suppl = 0.28, 0.28, 0.28, 0.28, 0.28, 0.28, 0.28, 0.28, 0.28, 
     0.28, 0.28, 0.28, 0.28, 0.28 ;
 
  fates_smpsc = -255000, -255000, -255000, -255000, -255000, -255000, -255000, 

--- a/parameter_files/fates_params_coastal_veg.cdl
+++ b/parameter_files/fates_params_coastal_veg.cdl
@@ -377,9 +377,9 @@ variables:
 	float fates_seed_germination_timescale(fates_pft) ;
 		fates_seed_germination_timescale:units = "1/yr" ;
 		fates_seed_germination_timescale:long_name = "turnover time for seeds with respect to decay" ;
-	float fates_seed_rain(fates_pft) ;
-		fates_seed_rain:units = "KgC/m2/yr" ;
-		fates_seed_rain:long_name = "External seed rain from outside site (non-mass conserving)" ;
+	float fates_seed_suppl(fates_pft) ;
+		fates_seed_suppl:units = "KgC/m2/yr" ;
+		fates_seed_suppl:long_name = "Supplemental external seed rain source term (non-mass conserving)" ;
 	float fates_smpsc(fates_pft) ;
 		fates_smpsc:units = "mm" ;
 		fates_smpsc:long_name = "Soil water potential at full stomatal closure" ;
@@ -841,7 +841,7 @@ data:
 
  fates_seed_germination_timescale = 0.5, 0.5 ;
 
- fates_seed_rain = 0.28, 0.28 ;
+ fates_seed_suppl = 0.28, 0.28 ;
 
  fates_smpsc = -255000, -255000 ;
 

--- a/parameter_files/fates_params_coastal_veg.cdl
+++ b/parameter_files/fates_params_coastal_veg.cdl
@@ -311,9 +311,6 @@ variables:
 	float fates_mort_scalar_hydrfailure(fates_pft) ;
 		fates_mort_scalar_hydrfailure:units = "1/yr" ;
 		fates_mort_scalar_hydrfailure:long_name = "maximum mortality rate from hydraulic failure" ;
-	float fates_pft_used(fates_pft) ;
-		fates_pft_used:units = "0 = off (dont use), 1 = on (use)" ;
-		fates_pft_used:long_name = "Switch to turn on and off PFTs (also see fates_initd for cold-start)" ;
 	float fates_phen_evergreen(fates_pft) ;
 		fates_phen_evergreen:units = "logical flag" ;
 		fates_phen_evergreen:long_name = "Binary flag for evergreen leaf habit" ;
@@ -799,8 +796,6 @@ data:
  fates_mort_scalar_cstarvation = 0.6, 0.6 ;
 
  fates_mort_scalar_hydrfailure = 0.6, 0.6 ;
-
- fates_pft_used = 1, 0 ;
 
  fates_phen_evergreen = 0, 0;
 

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -357,9 +357,6 @@ variables:
 	float fates_mort_scalar_hydrfailure(fates_pft) ;
 		fates_mort_scalar_hydrfailure:units = "1/yr" ;
 		fates_mort_scalar_hydrfailure:long_name = "maximum mortality rate from hydraulic failure" ;
-	float fates_pft_used(fates_pft) ;
-		fates_pft_used:units = "0 = off (dont use), 1 = on (use)" ;
-		fates_pft_used:long_name = "Switch to turn on and off PFTs (also see fates_initd for cold-start)" ;
 	float fates_phen_evergreen(fates_pft) ;
 		fates_phen_evergreen:units = "logical flag" ;
 		fates_phen_evergreen:long_name = "Binary flag for evergreen leaf habit" ;
@@ -930,8 +927,6 @@ data:
  fates_mort_scalar_cstarvation = 0.6, 0.6 ;
 
  fates_mort_scalar_hydrfailure = 0.6, 0.6 ;
-
- fates_pft_used = 1, 1 ;
 
  fates_phen_evergreen = 1, 1 ;
 

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -426,9 +426,9 @@ variables:
 	float fates_seed_germination_timescale(fates_pft) ;
 		fates_seed_germination_timescale:units = "1/yr" ;
 		fates_seed_germination_timescale:long_name = "turnover time for seeds with respect to decay" ;
-	float fates_seed_rain(fates_pft) ;
-		fates_seed_rain:units = "KgC/m2/yr" ;
-		fates_seed_rain:long_name = "External seed rain from outside site (non-mass conserving)" ;
+	float fates_seed_suppl(fates_pft) ;
+		fates_seed_suppl:units = "KgC/m2/yr" ;
+		fates_seed_suppl:long_name = "Supplemental external seed rain source term (non-mass conserving)" ;
 	float fates_smpsc(fates_pft) ;
 		fates_smpsc:units = "mm" ;
 		fates_smpsc:long_name = "Soil water potential at full stomatal closure" ;
@@ -974,7 +974,7 @@ data:
 
  fates_seed_germination_timescale = 0.5, 0.5 ;
 
- fates_seed_rain = 0.28, 0.28 ;
+ fates_seed_suppl = 0.28, 0.28 ;
 
  fates_smpsc = -255000, -255000 ;
 

--- a/parameter_files/fates_params_hydro_default.cdl
+++ b/parameter_files/fates_params_hydro_default.cdl
@@ -426,9 +426,9 @@ variables:
 	float fates_seed_germination_timescale(fates_pft) ;
 		fates_seed_germination_timescale:units = "1/yr" ;
 		fates_seed_germination_timescale:long_name = "turnover time for seeds with respect to decay" ;
-	float fates_seed_rain(fates_pft) ;
-		fates_seed_rain:units = "KgC/m2/yr" ;
-		fates_seed_rain:long_name = "External seed rain from outside site (non-mass conserving)" ;
+	float fates_seed_suppl(fates_pft) ;
+		fates_seed_suppl:units = "KgC/m2/yr" ;
+		fates_seed_suppl:long_name = "Supplemental external seed rain source term (non-mass conserving)" ;
 	float fates_smpsc(fates_pft) ;
 		fates_smpsc:units = "mm" ;
 		fates_smpsc:long_name = "Soil water potential at full stomatal closure" ;
@@ -984,7 +984,7 @@ data:
 
  fates_seed_germination_timescale = 0.5, 0.5 ;
 
- fates_seed_rain = 0.28, 0.28 ;
+ fates_seed_suppl = 0.28, 0.28 ;
 
  fates_smpsc = -255000, -255000 ;
 

--- a/parameter_files/fates_params_hydro_default.cdl
+++ b/parameter_files/fates_params_hydro_default.cdl
@@ -360,9 +360,6 @@ variables:
 	float fates_mort_scalar_hydrfailure(fates_pft) ;
 		fates_mort_scalar_hydrfailure:units = "1/yr" ;
 		fates_mort_scalar_hydrfailure:long_name = "maximum mortality rate from hydraulic failure" ;
-	float fates_pft_used(fates_pft) ;
-		fates_pft_used:units = "0 = off (dont use), 1 = on (use)" ;
-		fates_pft_used:long_name = "Switch to turn on and off PFTs (also see fates_initd for cold-start)" ;
 	float fates_phen_evergreen(fates_pft) ;
 		fates_phen_evergreen:units = "logical flag" ;
 		fates_phen_evergreen:long_name = "Binary flag for evergreen leaf habit" ;
@@ -561,6 +558,12 @@ variables:
 	float fates_phen_ncolddayslim(fates_scalar) ;
 		fates_phen_ncolddayslim:units = "days" ;
 		fates_phen_ncolddayslim:long_name = "day threshold exceedance for temperature leaf-drop" ;
+	float fates_drying_ratio ;
+		fates_drying_ratio:units = "NA" ;
+		fates_drying_ratio:long_name = "spitfire parameter, fire drying ratio for fuel moisture, alpha_FMC EQ 6 Thonicke et al 2010" ;
+	float fates_senleaf_long_fdrought(fates_pft) ;
+		fates_senleaf_long_fdrought:units = "unitless[0-1]" ;
+		fates_senleaf_long_fdrought:long_name = "multiplication factor for leaf longevity of senescent leaves during drought" ;
 	float fates_durat_slope ;
 		fates_durat_slope:units = "NA" ;
 		fates_durat_slope:long_name = "spitfire parameter, fire max duration slope, Equation 14 Thonicke et al 2010" ;
@@ -933,8 +936,6 @@ data:
 
  fates_mort_scalar_hydrfailure = 0.6, 0.6 ;
 
- fates_pft_used = 1, 1 ;
-
  fates_phen_evergreen = 1, 0 ;
 
  fates_phen_season_decid = 0, 0 ;
@@ -962,6 +963,10 @@ data:
  fates_rhosnir = 0.39, 0.39 ;
 
  fates_rhosvis = 0.16, 0.16 ;
+
+ fates_senleaf_long_fdrought = 1.0, 1.0 ;
+
+
 
  fates_root_long = 1, 1 ;
 
@@ -1068,6 +1073,8 @@ data:
  fates_phen_ncolddayslim = 5 ;
 
  fates_durat_slope = -11.06 ;
+
+ fates_drying_ratio = 13000 ;
 
  fates_fdi_a = 17.62 ;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

This PR contains updates to the parameter file. 

1) remove pft_used
2) potentially include naming convention changes to fire parameters (will review, TBD)
3) change seed_rain to seed_suppl (TBD)
4) May include consolidation of parameter datasets (TBD), as per: #444 

This PR should be synchronized with a default file update in CTSM.

<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

@jkshuman @lmkueppers @rosiealice @ckoven @glemieux 

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

This PR should be b4b with baseline.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

