### PR TITLE
Remove unnecessary (and erroneous) calls to treesai and treelai 

### DIFF
--- a/main/EDMainMod.F90
+++ b/main/EDMainMod.F90
@@ -273,7 +273,6 @@ contains
     real(r8) :: dbh_old               ! dbh of plant before daily PRT [cm]
     real(r8) :: hite_old              ! height of plant before daily PRT [m]
     logical  :: is_drought            ! logical for if the plant (site) is in a drought state
-    real(r8) :: leaf_c
     real(r8) :: delta_dbh             ! correction for dbh
     real(r8) :: delta_hite            ! correction for hite
 

--- a/main/EDMainMod.F90
+++ b/main/EDMainMod.F90
@@ -354,15 +354,6 @@ contains
           
           currentSite%flux_in = currentSite%flux_in + currentCohort%npp_acc * currentCohort%n
 
-          leaf_c = currentCohort%prt%GetState(leaf_organ, all_carbon_elements)
-          currentCohort%treelai = tree_lai(leaf_c, currentCohort%pft, currentCohort%c_area, currentCohort%n, &
-               currentCohort%canopy_layer, currentPatch%canopy_layer_tlai, &
-               currentCohort%vcmax25top)
-          currentCohort%treesai = tree_sai(currentCohort%pft, currentCohort%dbh, currentCohort%canopy_trim, &
-               currentCohort%c_area, currentCohort%n, currentCohort%canopy_layer, &
-               currentPatch%canopy_layer_tlai, currentCohort%treelai,currentCohort%vcmax25top,6 )
-          
-
           ! Conduct Maintenance Turnover (parteh)
           call currentCohort%prt%CheckMassConservation(ft,3)
           if(any(currentSite%dstatus == [phen_dstat_moiston,phen_dstat_timeon])) then
@@ -372,15 +363,6 @@ contains
           end if
           call PRTMaintTurnover(currentCohort%prt,ft,is_drought)
           call currentCohort%prt%CheckMassConservation(ft,4)
-
-          leaf_c = currentCohort%prt%GetState(leaf_organ, all_carbon_elements)
-          currentCohort%treelai = tree_lai(leaf_c, currentCohort%pft, currentCohort%c_area, currentCohort%n, &
-               currentCohort%canopy_layer, currentPatch%canopy_layer_tlai, &
-               currentCohort%vcmax25top)
-          currentCohort%treesai = tree_sai(currentCohort%pft, currentCohort%dbh, currentCohort%canopy_trim, &
-               currentCohort%c_area, currentCohort%n, currentCohort%canopy_layer, &
-               currentPatch%canopy_layer_tlai, currentCohort%treelai,currentCohort%vcmax25top,7 )
-          
 
           ! If the current diameter of a plant is somehow less than what is consistent
           ! with what is allometrically consistent with the stuctural biomass, then
@@ -401,14 +383,6 @@ contains
           ! routine is also called following fusion
           call UpdateCohortBioPhysRates(currentCohort)
 
-          leaf_c = currentCohort%prt%GetState(leaf_organ, all_carbon_elements)
-          currentCohort%treelai = tree_lai(leaf_c, currentCohort%pft, currentCohort%c_area, currentCohort%n, &
-               currentCohort%canopy_layer, currentPatch%canopy_layer_tlai, &
-               currentCohort%vcmax25top)
-          currentCohort%treesai = tree_sai(currentCohort%pft, currentCohort%dbh, currentCohort%canopy_trim, &
-               currentCohort%c_area, currentCohort%n, currentCohort%canopy_layer, &
-               currentPatch%canopy_layer_tlai, currentCohort%treelai,currentCohort%vcmax25top,3 ) 
-          
           ! Transfer all reproductive tissues into seed production
           call PRTReproRelease(currentCohort%prt,repro_organ,carbon12_element, &
                                1.0_r8, currentCohort%seed_prod)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

There are several calls to calculate tree LAI and SAI during the growth portion of the dynamics driver that are unnecessary.  Moreover, without re-calculating crown area, the third call is erroneous and may generated errors.


<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

@jkshuman 

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

There should be no changes in answers.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [x] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

TESTS:

See discussion