### PR TITLE
Fixes to Live Plant Burning

### DIFF
--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -1161,7 +1161,7 @@ contains
              dead_tree_num = currentCohort%fire_mort * currentCohort%n*patch_site_areadis/currentPatch%area
 
              ! density of dead trees per m2 (spread over the new and pre-existing patch) 
-             dead_tree_density  = dead_tree_num / (new_patch%area + currentPatch%area-patch_site_areadis )  !AREA  
+             dead_tree_density  = dead_tree_num / (new_patch%area + currentPatch%area-patch_site_areadis )
              
              if( hlm_use_planthydro == itrue ) then
                 call AccumulateMortalityWaterStorage(currentSite,currentCohort,dead_tree_num)
@@ -1176,10 +1176,7 @@ contains
              currentPatch%leaf_litter(p) = currentPatch%leaf_litter(p) + dead_tree_density * &
                    leaf_c * (1.0_r8-currentCohort%fraction_crown_burned)
 
-
              new_patch%root_litter(p) = new_patch%root_litter(p) + dead_tree_density * (fnrt_c+store_c)
-
-             
 
              currentPatch%root_litter(p) = currentPatch%root_litter(p) + dead_tree_density * &
                   (fnrt_c + store_c)

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -1113,7 +1113,7 @@ contains
        !PART 1)  Burn the fractions of existing litter in the new patch that were consumed by the fire. 
        !************************************/ 
        do c = 1,ncwd
-          burned_litter = new_patch%cwd_ag(c) * patch_site_areadis/new_patch%area * &
+          burned_litter = currentPatch%cwd_ag(c) * patch_site_areadis/new_patch%area * &
                 currentPatch%burnt_frac_litter(c) !kG/m2/day
           new_patch%cwd_ag(c) = new_patch%cwd_ag(c) - burned_litter
           currentSite%flux_out = currentSite%flux_out + burned_litter * new_patch%area !kG/site/day
@@ -1122,7 +1122,7 @@ contains
        enddo
 
        do p = 1,numpft
-          burned_litter = new_patch%leaf_litter(p) * patch_site_areadis/new_patch%area * &
+          burned_litter = currentPatch%leaf_litter(p) * patch_site_areadis/new_patch%area * &
                 currentPatch%burnt_frac_litter(dl_sf)
           new_patch%leaf_litter(p) = new_patch%leaf_litter(p) - burned_litter
           currentSite%flux_out = currentSite%flux_out + burned_litter * new_patch%area !kG/site/day

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -348,6 +348,7 @@ contains
     real(r8) :: cwd_ag_local(ncwd)           ! initial value of above ground coarse woody debris. KgC/m2
     real(r8) :: cwd_bg_local(ncwd)           ! initial value of below ground coarse woody debris. KgC/m2
     integer  :: levcan                       ! canopy level
+    real(r8) :: leaf_burn_frac
     real(r8) :: leaf_c                       ! leaf carbon [kg]
     real(r8) :: fnrt_c                       ! fineroot carbon [kg]
     real(r8) :: sapw_c                       ! sapwood carbon [kg]
@@ -682,6 +683,33 @@ contains
                    nc%lmort_direct     = currentCohort%lmort_direct
                    nc%lmort_collateral = currentCohort%lmort_collateral
                    nc%lmort_infra      = currentCohort%lmort_infra
+
+                   ! --------------------------------------------------------------------
+                   ! Burn parts of trees that did *not* die in the fire.
+                   !         currently we only remove leaves. branch and associated 
+                   !         sapwood consumption coming soon.
+                   ! PART 4) Burn parts of grass that are consumed by the fire. 
+                   ! grasses are not killed directly by fire. They die by losing all of 
+                   ! their leaves and starving. 
+                   ! --------------------------------------------------------------------
+
+                   leaf_c   = nc%prt%GetState(leaf_organ, all_carbon_elements)
+                   
+                   if(EDPftvarcon_inst%woody(currentCohort%pft) == 1)then
+                       leaf_burn_frac = currentCohort%fraction_crown_burned
+                   else
+                       leaf_burn_frac = currentPatch%burnt_frac_litter(lg_sf)
+                   endif
+
+                   call PRTBurnLosses(nc%prt, leaf_organ, leaf_burn_frac)
+
+                   !KgC/gridcell/day                                                                                                                                                             
+                   currentSite%flux_out = currentSite%flux_out + leaf_burn_frac* leaf_c * nc%n
+                   
+                   currentSite%total_burn_flux_to_atm = currentSite%total_burn_flux_to_atm + leaf_burn_frac * leaf_c * nc%n
+                   
+                   currentCohort%fraction_crown_burned = 0.0_r8
+                   nc%fraction_crown_burned            = 0.0_r8
                    
                    
                 ! Logging is the dominant disturbance  
@@ -1064,8 +1092,6 @@ contains
     real(r8) :: bstem                ! amount of above ground stem biomass per cohort  kgC.(goes into CWG_AG)
     real(r8) :: dead_tree_density    ! no trees killed by fire per m2
     reaL(r8) :: burned_litter        ! amount of each litter pool burned by fire.  kgC/m2/day
-    real(r8) :: burned_leaves        ! amount of tissue consumed by fire for leaves. KgC/individual/day
-    real(r8) :: leaf_burn_frac       ! fraction of leaves burned 
     real(r8) :: leaf_c               ! leaf carbon [kg]
     real(r8) :: fnrt_c               ! fineroot carbon [kg]
     real(r8) :: sapw_c               ! sapwood carbon [kg]
@@ -1225,51 +1251,6 @@ contains
           currentCohort => currentCohort%taller
 
        enddo  ! currentCohort
-
-       !************************************/     
-       ! PART 3) Burn parts of trees that did *not* die in the fire.
-       !         currently we only remove leaves. branch and assocaited sapwood consumption coming soon.
-       ! PART 4) Burn parts of grass that are consumed by the fire. 
-       ! grasses are not killed directly by fire. They die by losing all of their leaves and starving. 
-       !************************************/ 
-       currentCohort => new_patch%shortest
-       do while(associated(currentCohort))
-
-          sapw_c   = currentCohort%prt%GetState(sapw_organ, all_carbon_elements)
-          leaf_c   = currentCohort%prt%GetState(leaf_organ, all_carbon_elements)
-
-          call carea_allom(currentCohort%dbh,currentCohort%n,currentSite%spread,currentCohort%pft,currentCohort%c_area)
-
-          if(EDPftvarcon_inst%woody(currentCohort%pft) == 1)then
-             burned_leaves = leaf_c * currentCohort%fraction_crown_burned
-          else
-             burned_leaves = leaf_c * currentPatch%burnt_frac_litter(lg_sf)
-          endif
-
-          if (burned_leaves > 0.0_r8) then
-
-             ! Remove burned leaves from the pool
-             if(leaf_c>nearzero) then
-                leaf_burn_frac = burned_leaves/leaf_c
-             else
-                leaf_burn_frac = 0.0_r8
-             end if
-             call PRTBurnLosses(currentCohort%prt, leaf_organ, leaf_burn_frac)
-             
-             !KgC/gridcell/day
-             currentSite%flux_out = currentSite%flux_out + burned_leaves * currentCohort%n * &
-                  patch_site_areadis/currentPatch%area * AREA 
-
-             currentSite%total_burn_flux_to_atm = currentSite%total_burn_flux_to_atm+ burned_leaves * currentCohort%n * &
-                  patch_site_areadis/currentPatch%area * AREA 
-
-          endif
-          currentCohort%fraction_crown_burned = 0.0_r8        
-
-          currentCohort => currentCohort%taller
-
-       enddo
-
     endif !currentPatch%fire. 
 
   end subroutine fire_litter_fluxes

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -1021,8 +1021,8 @@ contains
                 ! Equation 22 in Thonicke et al. 2010. 
                 currentCohort%crownfire_mort = EDPftvarcon_inst%crown_kill(currentCohort%pft)*currentCohort%fraction_crown_burned**3.0_r8
                 ! Equation 18 in Thonicke et al. 2010. 
-                currentCohort%fire_mort = currentCohort%crownfire_mort+currentCohort%cambial_mort- &
-                     (currentCohort%crownfire_mort*currentCohort%cambial_mort)  !joint prob.   
+                currentCohort%fire_mort = max(0._r8,min(1.0_r8,currentCohort%crownfire_mort+currentCohort%cambial_mort- &
+                     (currentCohort%crownfire_mort*currentCohort%cambial_mort)))  !joint prob.   
              else
                 currentCohort%fire_mort = 0.0_r8 !I have changed this to zero and made the mode of death removal of leaves... 
              endif !trees


### PR DESCRIPTION
### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

@jkshuman and I looked through the fire code and identified that we were doing some weird things with how we burn leaves off of plants surviving fire events.  The key issue was that this burning had been taking place during fire_litter_fluxes(), however at the time this subroutine is called, the surviving cohorts have not yet been inserted and copied into the new patch yet.  Thus, it appears the wrong cohorts were being burned, namely all the cohorts that had been inserted into the new patch from other events.


### Collaborators:

@jkshuman 

<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

This should change the results of spitfire enabled simulations only.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [x] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:

TBD 

<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag: clm5.0.dev008-122-g08fc9481

CTSM (or) E3SM (specify which) baseline hash-tag: clm5.0.dev008-122-g08fc9481

FATES baseline hash-tag: sci.1.27.3_api.7.3.0-7-g28052bd4

Test Output:
/glade/scratch/glemieux/clmed-tests/rgknox-burn-live-trees-fix.fates.cheyenne.intel.C08fc9481-F0b134540
<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

