### PR TITLE
fix the direct-logging caused changes in trunk product, CWD, and litt…

### DIFF
--- a/biogeochem/EDLoggingMortalityMod.F90
+++ b/biogeochem/EDLoggingMortalityMod.F90
@@ -249,15 +249,17 @@ contains
       !        the mortality rates governing the fluxes, follow a different rule set.
       !        We also compute an export flux (product) that does not go to litter.  
       !
-      !  Trunk Product Flux: Only usable wood is exported from a site.  This is the above-ground
-      !                      portion of the bole, and only boles associated with direct-logging,
-      !                      not inftrastructure or collateral damage mortality.
+      !  Trunk Product Flux: Only usable wood is exported from a site, substracted by a 
+      !        transportation loss fraction. This is the above-ground portion of the bole, 
+      !        and only boles associated with direct-logging, not inftrastructure or 
+      !        collateral damage mortality.
       !        
       ! -------------------------------------------------------------------------------------------
 
 
       !USES:
       use SFParamsMod,  only : SF_val_cwd_frac
+      use EDParamsMod,  only : logging_export_frac
       use EDtypesMod,   only : area
       use EDtypesMod,   only : ed_site_type
       use EDtypesMod,   only : ed_patch_type
@@ -432,17 +434,33 @@ contains
          
          ! ----------------------------------------------------------------------------------------
          ! Handle harvest (export, flux-out) flux for the above ground boles 
-         ! In this case the boles from direct logging are exported off-site and are not added 
-         ! to the litter pools.  That is why we handle this outside the loop above. Only the 
-         ! collateral damange and infrastructure logging is applied to litter
+         ! In this case a fraction (export_frac) of the boles from direct logging are 
+         ! exported off-site, while the remainder (1-export_frac) is added to the litter pools.   
          ! 
          ! Losses to the system as a whole, for C-balancing (kGC/site/day)
          ! Site level product, (kgC/site, accumulated over simulation)
          ! ----------------------------------------------------------------------------------------
-         
-         trunk_product_site = trunk_product_site + &
-               SF_val_CWD_frac(ncwd) * agb_frac * direct_dead * (struct_c + sapw_c)
 
+         ! CWD contributed by logged boles due to losses in transportation
+         newPatch%cwd_ag(ncwd)     = newPatch%cwd_ag(ncwd)     + agb_frac * &
+               (1.0_r8-logging_export_frac) * cwd_litter_density * np_mult
+         currentPatch%cwd_ag(ncwd) = currentPatch%cwd_ag(ncwd) + &
+               (1.0_r8 - logging_export_frac) * agb_frac * cwd_litter_density 
+
+         currentSite%CWD_AG_diagnostic_input_carbonflux(ncwd) =       &
+               currentSite%CWD_AG_diagnostic_input_carbonflux(ncwd) + &
+               (1.0_r8-logging_export_frac) * SF_val_CWD_frac(ncwd) * &
+               woody_litter * hlm_days_per_year * agb_frac/ AREA
+
+         delta_litter_stock  = delta_litter_stock  + (1.0_r8-logging_export_frac) *&
+               woody_litter * SF_val_CWD_frac(ncwd)
+
+         ! Send export_frac * AGB component of boles from direct-logging activities to
+         ! export/harvest pool
+         ! Generate trunk product (kgC/day/site)
+         trunk_product_site = trunk_product_site + &
+               logging_export_frac * SF_val_CWD_frac(ncwd) * agb_frac * &
+               direct_dead * (struct_c + sapw_c)
 
          ! ----------------------------------------------------------------------------------------
          ! Handle fluxes of leaf, root and storage carbon into litter pools. 

--- a/biogeochem/EDLoggingMortalityMod.F90
+++ b/biogeochem/EDLoggingMortalityMod.F90
@@ -61,8 +61,6 @@ module EDLoggingMortalityMod
          __FILE__
 
 
-   real(r8), public, parameter :: logging_export_frac = 0.8_r8
-   
    public :: LoggingMortality_frac
    public :: logging_litter_fluxes
    public :: logging_time

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -51,7 +51,6 @@ module EDPhysiologyMod
   use EDParamsMod           , only : fates_mortality_disturbance_fraction
   use EDParamsMod           , only : q10_mr
   use EDParamsMod           , only : q10_froz
-  use EDParamsMod           , only : logging_export_frac
 
   use FatesPlantHydraulicsMod  , only : AccumulateMortalityWaterStorage
   
@@ -1340,25 +1339,6 @@ contains
                  SF_val_CWD_frac(c) * (dead_n_natural+ dead_n_ilogging) * &
                  EDPftvarcon_inst%allom_agb_frac(currentCohort%pft)
             
-            ! CWD contributed by logged boles due to losses in transportation
-            currentPatch%cwd_AG_in(c) = currentPatch%cwd_AG_in(c) + &
-                 (1.0_r8 - logging_export_frac) * (struct_c + sapw_c) * SF_val_CWD_frac(c) * &
-                 dead_n_dlogging * EDPftvarcon_inst%allom_agb_frac(currentCohort%pft)
-            
-            ! Send AGB component of boles from direct-logging activities to
-            ! export/harvest pool
-            ! Generate trunk product (kgC/day/site)
-            trunk_product =  logging_export_frac * (struct_c + sapw_c) * &
-                 SF_val_CWD_frac(c) * dead_n_dlogging * EDPftvarcon_inst%allom_agb_frac(currentCohort%pft) * &
-                 hlm_freq_day * currentPatch%area
-            
-            currentSite%flux_out = currentSite%flux_out + trunk_product
-            
-            ! Update diagnostics that track resource management
-            currentSite%resources_management%trunk_product_site  = &
-                 currentSite%resources_management%trunk_product_site + &
-                 trunk_product
-                
          else
             
             currentPatch%cwd_AG_in(c) = currentPatch%cwd_AG_in(c) + (struct_c + sapw_c) * & 

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -1332,7 +1332,9 @@ contains
          currentPatch%cwd_BG_in(c) = currentPatch%cwd_BG_in(c) + (struct_c + sapw_c) * & 
               SF_val_CWD_frac(c) * dead_n * (1.0_r8-EDPftvarcon_inst%allom_agb_frac(currentCohort%pft))
          
-         ! Send AGB component of boles from both direct and non-direct logging activities to AGB litter pool
+         ! Send AGB component of boles from logging activities into the litter.  
+         ! This includes fluxes from indirect modes of death, as well as the 
+         ! non-exported boles due to direct harvesting.
          if (c==ncwd) then
             
             ! CWD contributed by indirect damage
@@ -1340,7 +1342,7 @@ contains
                  SF_val_CWD_frac(c) * (dead_n_natural+ dead_n_ilogging) * &
                  EDPftvarcon_inst%allom_agb_frac(currentCohort%pft)
 
-            ! CWD contributed by logged boles due to losses in transportation
+            ! CWD contributed by directly logged boles due to losses in transportation
             currentPatch%cwd_AG_in(c) = currentPatch%cwd_AG_in(c) + &
                  (1.0_r8 - logging_export_frac) * (struct_c + sapw_c) * &
                  SF_val_CWD_frac(c) * dead_n_dlogging * &


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This PR aims to fix the logic in generating truck product, CWD, and litter stock associated with direct logging and transpiration loss. The direct-logging induced perturbation should not affect the non direct-logging calculations

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->
Modified biogeochem/EDLoggingMortalityMod.F90 and biogeochem/EDPhysiologyMod.F90

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->
@rgknox 

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->
Yes, but only when the logging module is active.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [X] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [X] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

