### PR TITLE
litter_moisture initialization fix

### DIFF
--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -1604,6 +1604,7 @@ contains
     currentPatch%root_litter_out(:) = 0.0_r8 ! As a newly created patch with no age, no frag or decomp has happened yet
 
     ! FIRE
+    currentPatch%litter_moisture(:)         = 0.0_r8 ! litter moisture was not previously initialized
     currentPatch%fuel_eff_moist             = 0.0_r8 ! average fuel moisture content of the ground fuel 
     ! (incl. live grasses. omits 1000hr fuels)
     currentPatch%livegrass                  = 0.0_r8 ! total ag grass biomass in patch. 1=c3 grass, 2=c4 grass. gc/m2

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -1604,7 +1604,7 @@ contains
     currentPatch%root_litter_out(:) = 0.0_r8 ! As a newly created patch with no age, no frag or decomp has happened yet
 
     ! FIRE
-    currentPatch%litter_moisture(:)         = 0.0_r8 ! litter moisture was not previously initialized
+    currentPatch%litter_moisture(:)         = 0.0_r8 ! litter moisture
     currentPatch%fuel_eff_moist             = 0.0_r8 ! average fuel moisture content of the ground fuel 
     ! (incl. live grasses. omits 1000hr fuels)
     currentPatch%livegrass                  = 0.0_r8 ! total ag grass biomass in patch. 1=c3 grass, 2=c4 grass. gc/m2


### PR DESCRIPTION
This adds `litter_moisture` to the the `zero_patch` subroutine to make sure new patches don't have random values for `litter_moisture`. 

### Description:
This PR is in response to issue #549.   Jessie was noticing that `FUEL_MOISTURE_NFSC` was outputting what appeared to be junk data even with spitfire turned off.  On lobata and eddi, this would result in an eventual crash, unless the debug mode was enabled.  Based on that and comparing some other fire history variables that are initialized in `zero_patch` regardless, I added `litter_moisture` (which is used to calculate `FUEL_MOISTURE_NFSC`) to this procedure.  This produces the expected results and results in full runs on eddi without crashes.

On a related note, I started another issue, #551, to address why this didn't seem to come up in our standard tests.

### Collaborators:
@JessicaNeedham

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->
None

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [x] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag: clm5.0.dev008-122-g08fc9481

CTSM (or) E3SM (specify which) baseline hash-tag: clm5.0.dev008-122-g08fc9481

FATES baseline hash-tag: sci.1.27.3_api.7.3.0-7-g28052bd4

Test Output:
All expected pass:
/glade/scratch/glemieux/clmed-tests/glemieux-litter-moisture-fix.fates.cheyenne.intel.C08fc9481-F5740d068
<!--- paste in test results here -->



<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

