### PR TITLE
patch fusion fix to prevent patch heterogeneity collapse

### DIFF
--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -1701,13 +1701,13 @@ contains
     do i_disttype = 1, n_anthro_disturbance_categories
 
        !---------------------------------------------------------------------!
-       !  We only really care about fusing patches if nopatches > 1           !
+       !  We only really care about fusing patches if nopatches > 1          !
        !---------------------------------------------------------------------!
 
        iterate = 1
 
        !---------------------------------------------------------------------!
-       !  Keep doing this until nopatches >= maxPatchesPerSite                         !
+       !  Keep doing this until nopatches <= maxPatchesPerSite               !
        !---------------------------------------------------------------------!
 
        do while(iterate == 1)
@@ -1720,9 +1720,9 @@ contains
              currentPatch => currentPatch%older
           enddo
 
-          !---------------------------------------------------------------------!
+          !-------------------------------------------------------------------------------!
           ! Loop round current & target (currentPatch,tpp) patches to assess combinations !
-          !---------------------------------------------------------------------!   
+          !-------------------------------------------------------------------------------!   
           currentPatch => currentSite%youngest_patch
           do while(associated(currentPatch))      
              tpp => currentSite%youngest_patch
@@ -1733,8 +1733,10 @@ contains
                 endif
 
                 if(associated(tpp).and.associated(currentPatch))then
-
-                   ! only fuse patches whose anthropogenic disturbance categroy matches taht of the outer loop that we are in
+                   !--------------------------------------------------------------------!
+                   ! only fuse patches whose anthropogenic disturbance category matches !
+                   ! that of the outer loop that we are in                              !
+                   !--------------------------------------------------------------------!
                    if ( tpp%anthro_disturbance_label .eq. i_disttype .and. &
                         currentPatch%anthro_disturbance_label .eq. i_disttype) then
 
@@ -1780,15 +1782,16 @@ contains
                                   do z = 1,n_dbh_bins      ! loop over hgt bins 
 
                                      !----------------------------------
-                                     !is there biomass in this category?
+                                     ! is there biomass in this category?
                                      !----------------------------------
 
                                      if(currentPatch%pft_agb_profile(ft,z)  > 0.0_r8 .or.  &
                                           tpp%pft_agb_profile(ft,z) > 0.0_r8)then 
 
-                                        !-------------------------------------------------------------------------------------
-                                        ! what is the relative difference in biomass i nthis category between the two patches?
-                                        !-------------------------------------------------------------------------------------
+                                        !---------------------------------------------------------------------!
+                                        ! what is the relative difference in biomass in this category between
+                                        ! the two patches?
+                                        !---------------------------------------------------------------------!
 
                                         norm = abs(currentPatch%pft_agb_profile(ft,z) - &
                                              tpp%pft_agb_profile(ft,z))/(0.5_r8 * &
@@ -1815,12 +1818,31 @@ contains
                          ! or both are older than forced fusion age                                !
                          !-------------------------------------------------------------------------!
 
-                         if(fuse_flag  ==  1)then 
+                         if(fuse_flag  ==  1)then
+                            
+                            !-----------------------!
+                            ! fuse the two patches  !
+                            !-----------------------!
+                            
                             tmpptr => currentPatch%older       
                             call fuse_2_patches(csite, currentPatch, tpp)
                             call fuse_cohorts(csite,tpp, bc_in)
                             call sort_cohorts(tpp)
                             currentPatch => tmpptr
+
+                            !------------------------------------------------------------------------!
+                            ! since we've just fused two patches, but are still in the midst of      !
+                            ! a patch x patch loop, reset the patch fusion tolerance to the starting !
+                            ! value so that any subsequent fusions in this loop are done with that   !
+                            ! value. otherwise we can end up in a situation where we've loosened the !
+                            ! fusion tolerance to get nopatches <= maxPatchesPerSite, but then,      !
+                            ! having accomplished that, we continue through all the patch x patch    !
+                            ! combinations and then all the patches get fused, ending up with        !
+                            ! nopatches << maxPatchesPerSite and losing all heterogeneity.           !
+                            !------------------------------------------------------------------------!
+
+                            profiletol = ED_val_patch_fusion_tol
+                            
                          else
                             ! write(fates_log(),*) 'patches not fused'
                          endif


### PR DESCRIPTION
This code slightly changes the patch fusion code to prevent an edge case that has been happening fairly frequently, whereby the patches would all get fused, thereby losing all the heterogeneity.

### Description:
basically this just resets the patch fusion tolerance after every fusion event, so that if the code had encountered a situation where it needed to fuse two patches that were dissimilar enough that the worst biomass bin comparison between the two patches was that one patch had some biomass in a given bin and the other didn't, the looping structure would then proceed to fuse all of the patches. now that shouldn't happen.

note this also changes the outcome of inventory initialization.  earlier code was tending to collapse all the quadrats at BCI into a single patch.  This code leaves several patches after the initial round of patch fusion during inventory initialization using the BCI census data.

fixes #323.

### Collaborators:
some email discussion with @rgknox and @rosiealice.

### Expectation of Answer Changes:
this should change answers, but possibly only for long runs.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [SORT OF] If answers were expected to change, evaluation was performed and provided .  I write "sort of" because I actually did the evaluation on e27deac, not db47637.  the current PR (db47637) is the same logic but applied to master (and also with some added documentation and cleaned up documentation earlier in the code block).


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 
