### PR TITLE
Remove char() call inline during write to fates_log

### DIFF
--- a/biogeophys/FatesPlantHydraulicsMod.F90
+++ b/biogeophys/FatesPlantHydraulicsMod.F90
@@ -3784,7 +3784,7 @@ contains
 	     bc_in%bsw_sisl(1),     &
              flc_node)
        case default
-          write(fates_log(),*) 'ERROR: invalid soil water characteristic function specified, iswc = '//char(iswc)
+          write(fates_log(),*) 'ERROR: invalid soil water characteristic function specified, iswc = ', iswc
           call endrun(msg=errMsg(sourcefile, __LINE__))
        end select
     end if
@@ -3838,7 +3838,7 @@ contains
 	     bc_in%bsw_sisl(1),     &
              dflcdpsi_node)
        case default
-          write(fates_log(),*) 'ERROR: invalid soil water characteristic function specified, iswc = '//char(iswc)
+          write(fates_log(),*) 'ERROR: invalid soil water characteristic function specified, iswc = ', iswc
           call endrun(msg=errMsg(sourcefile, __LINE__))
        end select
     end if
@@ -3886,7 +3886,7 @@ contains
        call psi_from_th(ft, pm, th_node, psi_check )
 
        if(psi_check > -1.e-8_r8) then
-          write(fates_log(),*)'bisect_pv returned positive value for water potential at pm = ', char(pm)
+          write(fates_log(),*)'bisect_pv returned positive value for water potential at pm = ', pm
           call endrun(msg=errMsg(sourcefile, __LINE__))
        end if
        
@@ -3917,7 +3917,7 @@ contains
                   bc_in%watsat_sisl(1),   &
                   th_node)
        case default
-          write(fates_log(),*)  'invalid soil water characteristic function specified, iswc = '//char(iswc)
+          write(fates_log(),*)  'invalid soil water characteristic function specified, iswc = ', iswc
           call endrun(msg=errMsg(sourcefile, __LINE__))
        end select
     end if
@@ -4035,7 +4035,7 @@ contains
 	          bc_in%bsw_sisl(1),     &
                   psi_node)
        case default
-          write(fates_log(),*) 'ERROR: invalid soil water characteristic function specified, iswc = '//char(iswc)
+          write(fates_log(),*) 'ERROR: invalid soil water characteristic function specified, iswc = ', iswc
           call endrun(msg=errMsg(sourcefile, __LINE__))
        end select
 
@@ -4086,7 +4086,7 @@ contains
 	          bc_in%bsw_sisl(1),     &
                   y)
        case default
-          write(fates_log(),*) 'ERROR: invalid soil water characteristic function specified, iswc = '//char(iswc)
+          write(fates_log(),*) 'ERROR: invalid soil water characteristic function specified, iswc = ', iswc
           call endrun(msg=errMsg(sourcefile, __LINE__))
        end select
     end if


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
During the debug of issue #508 we found that `index_nan` was not writing to the fates_log correctly.  After merging PR #555, I found a bunch of other calls to `char()` for writing to fates_log. 
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
None expected
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
Build test only TBD
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

