### PR TITLE
leaf status and phenology fixes

### DIFF
--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -82,6 +82,7 @@ module EDCohortDynamicsMod
   use PRTAllometricCarbonMod, only : ac_bc_in_id_pft
   use PRTAllometricCarbonMod, only : ac_bc_in_id_ctrim
   use PRTAllometricCarbonMod, only : ac_bc_inout_id_dbh
+  use PRTAllometricCarbonMod, only : ac_bc_in_id_lstat
 
   !  use PRTAllometricCNPMod,    only : cnp_allom_prt_vartypes
   
@@ -354,7 +355,8 @@ contains
        call new_cohort%prt%RegisterBCInOut(ac_bc_inout_id_netdc,bc_rval = new_cohort%npp_acc)
        call new_cohort%prt%RegisterBCIn(ac_bc_in_id_pft,bc_ival = new_cohort%pft)
        call new_cohort%prt%RegisterBCIn(ac_bc_in_id_ctrim,bc_rval = new_cohort%canopy_trim)
-    
+       call new_cohort%prt%RegisterBCIn(ac_bc_in_id_lstat,bc_ival = new_cohort%status_coh)
+
     case (prt_cnp_flex_allom_hyp)
 
        write(fates_log(),*) 'You have not specified the boundary conditions for the'

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -961,7 +961,7 @@ contains
                    
                    if(store_c>nearzero) then
                    ! flush either the amount required from the laimemory, or -most- of the storage pool
-                   ! RF: added a criterium to stop the entire store pool emptying and triggering termination mortality
+                   ! RF: added a criterion to stop the entire store pool emptying and triggering termination mortality
                    ! n.b. this might not be necessary if we adopted a more gradual approach to leaf flushing... 
                        store_c_transfer_frac =  min((EDPftvarcon_inst%phenflush_fraction(ipft)* &
                             currentCohort%laimemory)/store_c,(1.0_r8-carbon_store_buffer))

--- a/parteh/PRTAllometricCarbonMod.F90
+++ b/parteh/PRTAllometricCarbonMod.F90
@@ -92,7 +92,7 @@ module PRTAllometricCarbonMod
   integer, public, parameter :: ac_bc_in_id_pft   = 1   ! Index for the PFT input BC
   integer, public, parameter :: ac_bc_in_id_ctrim = 2   ! Index for the canopy trim function
   integer, public, parameter :: ac_bc_in_id_lstat = 3   ! Leaf status (on or off)
-  integer, parameter         :: num_bc_in         = 3   ! Number of input boundary condition
+  integer, parameter         :: num_bc_in         = 3   ! Number of input boundary conditions
 
   ! THere are no purely output boundary conditions
   integer, parameter         :: num_bc_out        = 0   ! Number of purely output boundary condtions


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

This set of changes implements some phenology fixes, where 1) plants in nevercold status were surviving their initial leaf drops and persisting, 2) the zeroing of gdd counters was fixed to prevent re-flushing and 3) timer windows were adjusted.

Details are provided in #574 

### Collaborators:
main author: @rosiealice 
@rgknox 
@ckoven 


<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->


### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

This will change answers on default parameter sets for simulations lasting orders larger than months.  This answer changes should be considered bug fixes though, and only targetted cold-deciduous plants with incorrect phenology cycles.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

TBD


CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

