### PR TITLE
CG scaler on lightning, NF>0 for fire event

### DIFF
--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -676,7 +676,6 @@ contains
     real(r8),parameter :: CG_strikes = .20_r8      !cloud to ground lightning strikes
                                                    !Latham and Williams (2001)
 
-    currentSite%NF = 0.0_r8
     !NF = number of lighting strikes per day per km2
     currentSite%NF = ED_val_nignitions * years_per_day * CG_strikes
 

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -718,11 +718,6 @@ contains
           currentPatch%fire = 0 ! No fire... :-/
           currentPatch%FD   = 0.0_r8      
        endif
-       !  FIX(SPM,032414) needs a refactor
-       !  FIX(RF,032414) : should happen outside of SF loop - doing all spitfire code is inefficient otherwise. 
-       if( hlm_use_spitfire == ifalse )then   
-          currentPatch%fire = 0 !fudge to turn fire off
-       endif
 
        currentPatch => currentPatch%younger;
     enddo !end patch loop

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -256,7 +256,6 @@ contains
        cleafoff = 300 
        cstat    = phen_cstat_notcold     ! Leaves are on
        acc_NI   = 0.0_r8
-       NF       = 0.0_r8
        dstat    = phen_dstat_moiston     ! Leaves are on
        dleafoff = 300
        dleafon  = 100
@@ -282,7 +281,7 @@ contains
           sites(s)%dstatus = dstat
           
           sites(s)%acc_NI     = acc_NI
-          sites(s)%NF         = NF         
+          sites(s)%NF         = 0.0_r8         
           sites(s)%frac_burnt = 0.0_r8
 
           

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -174,6 +174,7 @@ contains
 
     ! FIRE 
     site_in%acc_ni           = 0.0_r8     ! daily nesterov index accumulating over time. time unlimited theoretically.
+    site_in%NF               = 0.0_r8     ! daily lightning strikes per km2 
     site_in%frac_burnt       = 0.0_r8     ! burn area read in from external file
 
     do el=1,num_elements
@@ -255,6 +256,7 @@ contains
        cleafoff = 300 
        cstat    = phen_cstat_notcold     ! Leaves are on
        acc_NI   = 0.0_r8
+       NF       = 0.0_r8
        dstat    = phen_dstat_moiston     ! Leaves are on
        dleafoff = 300
        dleafon  = 100
@@ -280,6 +282,7 @@ contains
           sites(s)%dstatus = dstat
           
           sites(s)%acc_NI     = acc_NI
+          sites(s)%NF         = NF         
           sites(s)%frac_burnt = 0.0_r8
 
           

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -687,7 +687,8 @@ module EDTypesMod
      real(r8) ::  wind                                         ! daily wind in m/min for Spitfire units 
      real(r8) ::  acc_ni                                       ! daily nesterov index accumulating over time.
      real(r8) ::  fdi                                          ! daily probability an ignition event will start a fire
-     real(r8) ::  frac_burnt                                   ! fraction of soil burnt in this day.
+     real(r8) ::  NF                                           ! daily ignitions in km2
+     real(r8) ::  frac_burnt                                   ! fraction of area burnt in this day.
 
      ! PLANT HYDRAULICS
      type(ed_site_hydr_type), pointer :: si_hydr


### PR DESCRIPTION
Add scaler for cloud to ground lightning strikes, and strikes >0 for fire event

### Description:
Portion of strikes that are cloud to ground (CG) included in calculation of ignitions per Thonicke
et al 2010 and Latham and Williams (2001).
Calculation of ignitions moved to fire_intensity subroutine. Ignitions greater than zero included 
as condition for successful fire event. 
This address issue #589 

### Collaborators:
@rgknox @slevisconsulting @rosiealice @adrifoster 

### Expectation of Answer Changes:
This will change answers with fire active. Specifically, it will reduce fire area. 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [x] If answers were expected to change, evaluation was performed and provided

### Test Results:
Simulations compiled and run across South America with and without fire. Comparison between prior default ignitions and scaled cloud to ground ignitions included.

Test Output:
Difference in Burned Fraction for year 4 (cloud to ground ignitions - all ignitions "default")
![Ignitions_CG_ign-all_ign_yr4](https://user-images.githubusercontent.com/22102918/68433355-886e0580-0173-11ea-811e-b0734fae315e.png)



<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

