### PR TITLE
SPITFIRE - ignitions, area burn, intensity, scorch height

### DIFF
--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -580,7 +580,7 @@ contains
 
     currentcohort%year_net_uptake(:) = 999._r8 ! this needs to be 999, or trimming of new cohorts will break. 
     currentcohort%ts_net_uptake(:)   = 0._r8
-    currentcohort%sh                 = 0._r8
+    currentcohort%scorch_ht          = 0._r8
     currentcohort%fraction_crown_burned = 0._r8 
     currentCohort%size_class            = 1
     currentCohort%seed_prod          = 0._r8
@@ -1655,7 +1655,7 @@ contains
     n%ddbhdt          = o%ddbhdt
 
     ! FIRE
-    n%sh                    = o%sh  
+    n%scorch_ht             = o%scorch_ht  
     n%fraction_crown_burned = o%fraction_crown_burned
     n%fire_mort             = o%fire_mort
     n%crownfire_mort        = o%crownfire_mort

--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -534,7 +534,7 @@ contains
     currentCohort%ddbhdt             = nan ! time derivative of dbh 
 
     ! FIRE
-    currentCohort%sh                    = nan ! scorch height affecting crown (m)
+    currentCohort%scorch_ht             = nan ! scorch height affecting crown (m)
     currentCohort%fraction_crown_burned = nan ! proportion of crown affected by fire
     currentCohort%cambial_mort          = nan ! probability that trees dies due to cambial char P&R (1986)
     currentCohort%crownfire_mort        = nan ! probability of tree post-fire mortality due to crown scorch

--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -534,7 +534,7 @@ contains
     currentCohort%ddbhdt             = nan ! time derivative of dbh 
 
     ! FIRE
-    currentCohort%scorch_ht             = nan ! scorch height affecting crown (m)
+    currentCohort%Scorch_ht             = nan ! scorch height affecting crown (m)
     currentCohort%fraction_crown_burned = nan ! proportion of crown affected by fire
     currentCohort%cambial_mort          = nan ! probability that trees dies due to cambial char P&R (1986)
     currentCohort%crownfire_mort        = nan ! probability of tree post-fire mortality due to crown scorch

--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -534,6 +534,7 @@ contains
     currentCohort%ddbhdt             = nan ! time derivative of dbh 
 
     ! FIRE
+    currentCohort%sh                    = nan ! scorch height affecting crown (m)
     currentCohort%fraction_crown_burned = nan ! proportion of crown affected by fire
     currentCohort%cambial_mort          = nan ! probability that trees dies due to cambial char P&R (1986)
     currentCohort%crownfire_mort        = nan ! probability of tree post-fire mortality due to crown scorch
@@ -579,6 +580,7 @@ contains
 
     currentcohort%year_net_uptake(:) = 999._r8 ! this needs to be 999, or trimming of new cohorts will break. 
     currentcohort%ts_net_uptake(:)   = 0._r8
+    currentcohort%sh                 = 0._r8
     currentcohort%fraction_crown_burned = 0._r8 
     currentCohort%size_class            = 1
     currentCohort%seed_prod          = 0._r8
@@ -1652,7 +1654,8 @@ contains
     n%dhdt            = o%dhdt
     n%ddbhdt          = o%ddbhdt
 
-    ! FIRE 
+    ! FIRE
+    n%sh                    = o%sh  
     n%fraction_crown_burned = o%fraction_crown_burned
     n%fire_mort             = o%fire_mort
     n%crownfire_mort        = o%crownfire_mort

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -1980,7 +1980,6 @@ contains
     currentPatch%fire                       = 999    ! sr decide_fire.1=fire hot enough to proceed. 0=stop everything- no fires today
     currentPatch%fd                         = 0.0_r8 ! fire duration (mins)
     currentPatch%ros_back                   = 0.0_r8 ! backward ros (m/min)
-    currentPatch%sh                         = 0.0_r8 ! average scorch height for the patch(m)
     currentPatch%frac_burnt                 = 0.0_r8 ! fraction burnt daily  
     currentPatch%burnt_frac_litter(:)       = 0.0_r8 
     currentPatch%btran_ft(:)                = 0.0_r8
@@ -2296,7 +2295,6 @@ contains
     rp%fi                   = (dp%fi*dp%area + rp%fi*rp%area) * inv_sum_area
     rp%fd                   = (dp%fd*dp%area + rp%fd*rp%area) * inv_sum_area
     rp%ros_back             = (dp%ros_back*dp%area + rp%ros_back*rp%area) * inv_sum_area
-    rp%sh                   = (dp%sh*dp%area + rp%sh*rp%area) * inv_sum_area
     rp%frac_burnt           = (dp%frac_burnt*dp%area + rp%frac_burnt*rp%area) * inv_sum_area
     rp%burnt_frac_litter(:) = (dp%burnt_frac_litter(:)*dp%area + rp%burnt_frac_litter(:)*rp%area) * inv_sum_area
     rp%btran_ft(:)          = (dp%btran_ft(:)*dp%area + rp%btran_ft(:)*rp%area) * inv_sum_area

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -676,7 +676,6 @@ contains
     real(r8),parameter :: CG_strikes = .20_r8      !cloud to ground lightning strikes
                                                    !Latham and Williams (2001)
 
-    currentSite%NF = 0.0_r8
     !NF = number of lighting strikes per day per km2
     currentSite%NF = ED_val_nignitions * years_per_day * CG_strikes
 

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -807,7 +807,7 @@ contains
 
     type(ed_site_type), intent(in), target :: currentSite
 
-    type(ed_patch_type), pointer :: currentPatch
+    type(ed_patch_type), pointer  :: currentPatch
     type(ed_cohort_type), pointer :: currentCohort
 
     real(r8) ::  tree_ag_biomass ! total amount of above-ground tree biomass in patch. kgC/m2
@@ -834,11 +834,11 @@ contains
                       EDPftvarcon_inst%allom_agb_frac(currentCohort%pft)*(sapw_c + struct_c))
  
 
-             currentCohort%SH = 0.0_r8
+             currentCohort%Scorch_ht = 0.0_r8
                 if (tree_ag_biomass > 0.0_r8) then 
 
                 !Equation 16 in Thonicke et al. 2010 !Van Wagner 1973 EQ8 !2/3 Byram (1959)
-                currentCohort%SH = EDPftvarcon_inst%fire_alpha_SH(currentCohort%pft) * (currentPatch%FI**0.667_r8)
+                currentCohort%Scorch_ht = EDPftvarcon_inst%fire_alpha_SH(currentCohort%pft) * (currentPatch%FI**0.667_r8)
              
                   if(write_SF == itrue)then
                      if ( hlm_masterproc == itrue ) write(fates_log(),*) 'currentCohort%SH',currentCohort%SH
@@ -879,16 +879,17 @@ contains
              if (EDPftvarcon_inst%woody(currentCohort%pft) == 1) then !trees only
                 ! Flames lower than bottom of canopy. 
                 ! c%hite is height of cohort
-                if (currentCohort%SH < (currentCohort%hite-currentCohort%hite*EDPftvarcon_inst%crown(currentCohort%pft))) then 
+                if (currentCohort%Scorch_ht < &
+                     (currentCohort%hite-currentCohort%hite*EDPftvarcon_inst%crown(currentCohort%pft))) then 
                    currentCohort%fraction_crown_burned = 0.0_r8
                 else
                    ! Flames part of way up canopy. 
                    ! Equation 17 in Thonicke et al. 2010. 
                    ! flames over bottom of canopy but not over top.
-                   if ((currentCohort%hite > 0.0_r8).and.(currentCohort%SH >=  &
+                   if ((currentCohort%hite > 0.0_r8).and.(currentCohort%Scorch_ht >=  &
                         (currentCohort%hite-currentCohort%hite*EDPftvarcon_inst%crown(currentCohort%pft)))) then 
 
-                           currentCohort%fraction_crown_burned =  (currentCohort%SH-currentCohort%hite*(1.0_r8- &
+                        currentCohort%fraction_crown_burned = (currentCohort%Scorch_ht-currentCohort%hite*(1.0_r8- &
                                 EDPftvarcon_inst%crown(currentCohort%pft)))/(currentCohort%hite* &
                                 EDPftvarcon_inst%crown(currentCohort%pft)) 
 

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -680,7 +680,7 @@ contains
     
     real(r8) size_of_fire !in m2
     real(r8),parameter :: km2_to_m2 = 1000000.0_r8 !area conversion for square km to square m
-    real(r8),parameter :: CG_strikes = .20_r8      !cloud to ground lightning strikes
+    real(r8),parameter :: CG_strikes = 0.20_r8     !cloud to ground lightning strikes
                                                    !Latham and Williams (2001)
 
     !  ---initialize site parameters to zero--- 
@@ -703,7 +703,7 @@ contains
        !  ---initialize patch parameters to zero---
        currentPatch%frac_burnt = 0.0_r8
 
-       if (currentSite%NF > 0) then
+       if (currentSite%NF > 0.0_r8) then
           
           ! Equation 14 in Thonicke et al. 2010
           ! fire duration in minutes

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -771,7 +771,7 @@ contains
          endif
 
          !'decide_fire' subroutine 
-         if (currentPatch%FI >= fire_threshold) then !50kW/m threshold for self-sustaining fire
+         if (currentPatch%FI > fire_threshold) then !track fires greater than kW/m2 energy threshold
             currentPatch%fire = 1 ! Fire...    :D
           
          else     

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -831,7 +831,7 @@ contains
  
 
              currentCohort%SH = 0.0_r8
-             if (tree_ag_biomass > 0.0_r8)) then 
+             if (tree_ag_biomass > 0.0_r8) then 
 
                 !Equation 16 in Thonicke et al. 2010   !2/3 Byram (1959)
                 currentCohort%SH = EDPftvarcon_inst%fire_alpha_SH(currentCohort%pft) * (currentPatch%FI**0.667_r8)

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -833,7 +833,7 @@ contains
              currentCohort%SH = 0.0_r8
                 if (tree_ag_biomass > 0.0_r8) then 
 
-                !Equation 16 in Thonicke et al. 2010   !2/3 Byram (1959)
+                !Equation 16 in Thonicke et al. 2010 !Van Wagner 1973 EQ8 !2/3 Byram (1959)
                 currentCohort%SH = EDPftvarcon_inst%fire_alpha_SH(currentCohort%pft) * (currentPatch%FI**0.667_r8)
              
                   if(write_SF == itrue)then

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -841,7 +841,7 @@ contains
                 currentCohort%Scorch_ht = EDPftvarcon_inst%fire_alpha_SH(currentCohort%pft) * (currentPatch%FI**0.667_r8)
              
                   if(write_SF == itrue)then
-                     if ( hlm_masterproc == itrue ) write(fates_log(),*) 'currentCohort%SH',currentCohort%SH
+                     if ( hlm_masterproc == itrue ) write(fates_log(),*) 'currentCohort%SH',currentCohort%Scorch_ht
                   endif
                 endif ! tree biomass
 

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -828,24 +828,17 @@ contains
                 tree_ag_biomass = tree_ag_biomass + &
                       currentCohort%n * (leaf_c + & 
                       EDPftvarcon_inst%allom_agb_frac(currentCohort%pft)*(sapw_c + struct_c))
-             endif !trees only
+ 
 
-             currentCohort=>currentCohort%shorter;
-
-          enddo !end cohort loop 
-
-          currentCohort => currentPatch%tallest;
-          do while(associated(currentCohort))
              currentCohort%SH = 0.0_r8
-             if (EDPftvarcon_inst%woody(currentCohort%pft) == 1 &
-                  .and. (tree_ag_biomass > 0.0_r8)) then !trees only
+             if (tree_ag_biomass > 0.0_r8)) then 
 
-                !equation 16 in Thonicke et al. 2010
+                !Equation 16 in Thonicke et al. 2010   !2/3 Byram (1959)
+                currentCohort%SH = EDPftvarcon_inst%fire_alpha_SH(currentCohort%pft) * (currentPatch%FI**0.667_r8)
+             
                 if(write_SF == itrue)then
                    if ( hlm_masterproc == itrue ) write(fates_log(),*) 'currentCohort%SH',currentCohort%SH
                 endif
-                !2/3 Byram (1959)
-                currentCohort%SH = EDPftvarcon_inst%fire_alpha_SH(currentCohort%pft) * (currentPatch%FI**0.667_r8) 
 
              endif !trees only
              currentCohort=>currentCohort%shorter;

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -701,7 +701,10 @@ contains
     currentPatch => currentSite%oldest_patch;  
     do while(associated(currentPatch))
        !  ---initialize patch parameters to zero---
+       currentPatch%fire       = 0
+       currentPatch%FD         = 0.0_r8
        currentPatch%frac_burnt = 0.0_r8
+       
 
        if (currentSite%NF > 0.0_r8) then
           
@@ -763,6 +766,7 @@ contains
          ROS   = currentPatch%ROS_front / 60.0_r8 !m/min to m/sec 
          W     = currentPatch%TFC_ROS / 0.45_r8 !kgC/m2 to kgbiomass/m2          
 
+         ! EQ 15 Thonicke et al 2010
          !units of fire intensity = (kJ/kg)*(kgBiomass/m2)*(m/min)*unitless_fraction
          currentPatch%FI = SF_val_fuel_energy * W * ROS * currentPatch%frac_burnt !kj/m/s, or kW/m
        

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -718,11 +718,6 @@ contains
           currentPatch%fire = 0 ! No fire... :-/
           currentPatch%FD   = 0.0_r8      
        endif
-       !  FIX(SPM,032414) needs a refactor
-       !  FIX(RF,032414) : should happen outside of SF loop - doing all spitfire code is inefficient otherwise. 
-       if( hlm_use_spitfire == ifalse )then   
-          currentPatch%fire = 0 !fudge to turn fire off
-       endif
 
        currentPatch => currentPatch%younger;
     enddo !end patch loop

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -831,14 +831,15 @@ contains
  
 
              currentCohort%SH = 0.0_r8
-             if (tree_ag_biomass > 0.0_r8) then 
+                if (tree_ag_biomass > 0.0_r8) then 
 
                 !Equation 16 in Thonicke et al. 2010   !2/3 Byram (1959)
                 currentCohort%SH = EDPftvarcon_inst%fire_alpha_SH(currentCohort%pft) * (currentPatch%FI**0.667_r8)
              
-                if(write_SF == itrue)then
-                   if ( hlm_masterproc == itrue ) write(fates_log(),*) 'currentCohort%SH',currentCohort%SH
-                endif
+                  if(write_SF == itrue)then
+                     if ( hlm_masterproc == itrue ) write(fates_log(),*) 'currentCohort%SH',currentCohort%SH
+                  endif
+                endif ! tree biomass
 
              endif !trees only
              currentCohort=>currentCohort%shorter;

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -256,7 +256,6 @@ contains
        cleafoff = 300 
        cstat    = phen_cstat_notcold     ! Leaves are on
        acc_NI   = 0.0_r8
-       NF       = 0.0_r8
        dstat    = phen_dstat_moiston     ! Leaves are on
        dleafoff = 300
        dleafon  = 100
@@ -282,7 +281,7 @@ contains
           sites(s)%dstatus = dstat
           
           sites(s)%acc_NI     = acc_NI
-          sites(s)%NF         = NF         
+          sites(s)%NF         = 0.0_r8         
           sites(s)%frac_burnt = 0.0_r8
 
           

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -174,6 +174,7 @@ contains
 
     ! FIRE 
     site_in%acc_ni           = 0.0_r8     ! daily nesterov index accumulating over time. time unlimited theoretically.
+    site_in%NF               = 0.0_r8     ! daily lightning strikes per km2 
     site_in%frac_burnt       = 0.0_r8     ! burn area read in from external file
 
     do el=1,num_elements
@@ -255,6 +256,7 @@ contains
        cleafoff = 300 
        cstat    = phen_cstat_notcold     ! Leaves are on
        acc_NI   = 0.0_r8
+       NF       = 0.0_r8
        dstat    = phen_dstat_moiston     ! Leaves are on
        dleafoff = 300
        dleafon  = 100
@@ -280,6 +282,7 @@ contains
           sites(s)%dstatus = dstat
           
           sites(s)%acc_NI     = acc_NI
+          sites(s)%NF         = NF         
           sites(s)%frac_burnt = 0.0_r8
 
           

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -2185,7 +2185,7 @@ contains
                 ( EDPFtvarcon_inst%phen_stem_drop_fraction(ipft) > 1 ) ) then
 
               write(fates_log(),*) ' Deciduous non-wood plants must keep 0-100% of their stems'
-              write(fates_log(),*) ' during the dedicous period.'
+              write(fates_log(),*) ' during the deciduous period.'
               write(fates_log(),*) ' PFT#: ',ipft
               write(fates_log(),*) ' evergreen flag: (shold be 0):',int(EDPftvarcon_inst%evergreen(ipft))
               write(fates_log(),*) ' phen_stem_drop_fraction: ', EDPFtvarcon_inst%phen_stem_drop_fraction(ipft)

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -687,7 +687,8 @@ module EDTypesMod
      real(r8) ::  wind                                         ! daily wind in m/min for Spitfire units 
      real(r8) ::  acc_ni                                       ! daily nesterov index accumulating over time.
      real(r8) ::  fdi                                          ! daily probability an ignition event will start a fire
-     real(r8) ::  frac_burnt                                   ! fraction of soil burnt in this day.
+     real(r8) ::  NF                                           ! daily ignitions in km2
+     real(r8) ::  frac_burnt                                   ! fraction of area burnt in this day.
 
      ! PLANT HYDRAULICS
      type(ed_site_hydr_type), pointer :: si_hydr

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -145,8 +145,8 @@ module EDTypesMod
   integer,  parameter, public :: dl_sf                = 5          ! array index of dead leaf pool for spitfire (dead grass and dead leaves)
   integer,  parameter, public :: lg_sf                = 6          ! array index of live grass pool for spitfire
 
-  !real(r8), parameter, public :: fire_threshold       = 50.0_r8    ! threshold for fires that spread or go out. KWm-2 (Pyne 1986)
-  real(r8), parameter, public :: fire_threshold       = 0.01_r8     ! track all fires with energy greater than .01 kW/m2
+  real(r8), parameter, public :: fire_threshold       = 50.0_r8    ! threshold for fires that spread or go out. KWm-2 (Pyne 1986)
+  !real(r8), parameter, public :: fire_threshold       = 0.01_r8     ! track all fires with energy greater than .01 kW/m2
 
   ! PATCH FUSION 
   real(r8), parameter, public :: force_patchfuse_min_biomass = 0.005_r8   ! min biomass (kg / m2 patch area) below which to force-fuse patches

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -146,7 +146,7 @@ module EDTypesMod
   integer,  parameter, public :: lg_sf                = 6          ! array index of live grass pool for spitfire
 
   !real(r8), parameter, public :: fire_threshold       = 50.0_r8    ! threshold for fires that spread or go out. KWm-2 (Pyne 1986)
-  real(r8), parameter, public :: fire_threshold       = 0.0_r8     ! track all fires with energy greater than 0 kW/m2
+  real(r8), parameter, public :: fire_threshold       = 0.01_r8     ! track all fires with energy greater than .01 kW/m2
 
   ! PATCH FUSION 
   real(r8), parameter, public :: force_patchfuse_min_biomass = 0.005_r8   ! min biomass (kg / m2 patch area) below which to force-fuse patches

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -146,7 +146,6 @@ module EDTypesMod
   integer,  parameter, public :: lg_sf                = 6          ! array index of live grass pool for spitfire
 
   real(r8), parameter, public :: fire_threshold       = 50.0_r8    ! threshold for fires that spread or go out. KWm-2 (Pyne 1986)
-  !real(r8), parameter, public :: fire_threshold       = 0.01_r8     ! track all fires with energy greater than .01 kW/m2
 
   ! PATCH FUSION 
   real(r8), parameter, public :: force_patchfuse_min_biomass = 0.005_r8   ! min biomass (kg / m2 patch area) below which to force-fuse patches

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -145,7 +145,8 @@ module EDTypesMod
   integer,  parameter, public :: dl_sf                = 5          ! array index of dead leaf pool for spitfire (dead grass and dead leaves)
   integer,  parameter, public :: lg_sf                = 6          ! array index of live grass pool for spitfire
 
-  real(r8), parameter, public :: fire_threshold       = 50.0_r8    ! threshold for fires that spread or go out. KWm-2 (Pyne 1986)
+  !real(r8), parameter, public :: fire_threshold       = 50.0_r8    ! threshold for fires that spread or go out. KWm-2 (Pyne 1986)
+  real(r8), parameter, public :: fire_threshold       = 0.0_r8     ! track all fires with energy greater than 0 kW/m2
 
   ! PATCH FUSION 
   real(r8), parameter, public :: force_patchfuse_min_biomass = 0.005_r8   ! min biomass (kg / m2 patch area) below which to force-fuse patches

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -343,7 +343,7 @@ module EDTypesMod
      real(r8) ::  dbdeaddt                               ! time derivative of dead biomass         : KgC/year
 
      ! FIRE
-     real(r8) ::  sh                                     ! scorch height: m 
+     real(r8) ::  scorch_ht                              ! scorch height: m 
      real(r8) ::  fraction_crown_burned                  ! proportion of crown affected by fire:-
      real(r8) ::  cambial_mort                           ! probability that trees dies due to cambial char 
                                                          ! (conditional on the tree being subjected to the fire)

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -342,6 +342,7 @@ module EDTypesMod
      real(r8) ::  dbdeaddt                               ! time derivative of dead biomass         : KgC/year
 
      ! FIRE
+     real(r8) ::  sh                                     ! scorch height: m 
      real(r8) ::  fraction_crown_burned                  ! proportion of crown affected by fire:-
      real(r8) ::  cambial_mort                           ! probability that trees dies due to cambial char 
                                                          ! (conditional on the tree being subjected to the fire)
@@ -519,7 +520,6 @@ module EDTypesMod
      real(r8) ::  fi                                               ! average fire intensity of flaming front:  kj/m/s or kw/m
      integer  ::  fire                                             ! Is there a fire? 1=yes 0=no
      real(r8) ::  fd                                               ! fire duration: mins
-     real(r8) ::  sh                                               ! average scorch height: m 
 
      ! FIRE EFFECTS     
      real(r8) ::  frac_burnt                                       ! fraction burnt: frac gridcell/day  

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -141,7 +141,7 @@ module FatesHistoryInterfaceMod
   integer :: ih_TFC_ROS_pa
   integer :: ih_fire_intensity_pa
   integer :: ih_fire_area_pa
-  integer :: ih_scorch_height_pa
+ ! integer :: ih_scorch_height_pa
   integer :: ih_fire_fuel_bulkd_pa
   integer :: ih_fire_fuel_eff_moist_pa
   integer :: ih_fire_fuel_sav_pa
@@ -2438,7 +2438,7 @@ end subroutine flush_hvars
             hio_tfc_ros_pa(io_pa)              = cpatch%TFC_ROS
             hio_fire_intensity_pa(io_pa)       = cpatch%FI
             hio_fire_area_pa(io_pa)            = cpatch%frac_burnt
-            hio_scorch_height_pa(io_pa)        = cpatch%SH
+            !hio_scorch_height_pa(io_pa)        = cpatch%SH
             hio_fire_fuel_bulkd_pa(io_pa)      = cpatch%fuel_bulkd
             hio_fire_fuel_eff_moist_pa(io_pa)  = cpatch%fuel_eff_moist
             hio_fire_fuel_sav_pa(io_pa)        = cpatch%fuel_sav
@@ -3906,10 +3906,10 @@ end subroutine flush_hvars
          avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
          ivar=ivar, initialize=initialize_variables, index = ih_fire_area_pa )
 
-    call this%set_history_var(vname='SCORCH_HEIGHT', units='m',                &
-         long='spitfire flame height:m', use_default='active',                    &
-         avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
-         ivar=ivar, initialize=initialize_variables, index = ih_scorch_height_pa )
+    !call this%set_history_var(vname='SCORCH_HEIGHT', units='m',                &
+     !    long='spitfire flame height:m', use_default='active',                    &
+     !    avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
+     !    ivar=ivar, initialize=initialize_variables, index = ih_scorch_height_pa )
 
     call this%set_history_var(vname='fire_fuel_mef', units='m',                &
          long='spitfire fuel moisture',  use_default='active',                  &

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -1631,7 +1631,7 @@ end subroutine flush_hvars
                hio_effect_wspeed_pa    => this%hvars(ih_effect_wspeed_pa)%r81d, &
                hio_fire_intensity_pa   => this%hvars(ih_fire_intensity_pa)%r81d, &
                hio_fire_area_pa        => this%hvars(ih_fire_area_pa)%r81d, &
-               hio_scorch_height_pa    => this%hvars(ih_scorch_height_pa)%r81d, &
+              ! hio_scorch_height_pa    => this%hvars(ih_scorch_height_pa)%r81d, &
                hio_fire_fuel_bulkd_pa  => this%hvars(ih_fire_fuel_bulkd_pa)%r81d, &
                hio_fire_fuel_eff_moist_pa => this%hvars(ih_fire_fuel_eff_moist_pa)%r81d, &
                hio_fire_fuel_sav_pa    => this%hvars(ih_fire_fuel_sav_pa)%r81d, &


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
This set of changes addresses fire behavior and effects updates to equations. A cloud to ground scaler on lightning ignitions is introduced per Latham and Williams (2001) (addresses #593). Ignitions must be greater than 0 to begin calculations of fire behavior (addresses issue #589).  Area burn and fire intensity subroutines are combined to allow for inclusion of fraction of patch burnt in calculation of fire intensity (FI) per Thonicke et al 2010. Ignition probability (FDI), fire duration (FD), area burnt (AB) and frac_burnt now calculated prior to FI to include this dependancy. Scorch height is updated to be at the cohort level and scaled by PFT trait "alpha_SH" using the patch level fire intensity (FI) per Van Wagner (1973) (addresses issue #477 and #476). This update maintains the fire threshold of 50 kW/m for fire events per Pyne (1986). 

This addresses issues #593 #589 #477 and #476

### Collaborators:
Discussions with @adrifoster @pollybuotte @rgknox @rosiealice @glemieux 

### Expectation of Answer Changes:
Updates will result in less ignitions, less area burn, and lower fire intensity compared to current master. Attached figure with difference between branch with update to ignitions only and branch using all ignitions for burned area (BA) and GPP after 4 years of simulation.
![Ignitions_CG_ign-all_ign_yr4](https://user-images.githubusercontent.com/22102918/69567573-e0c84400-0f76-11ea-8b29-c498fd3c5add.png)




### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [x] If answers were expected to change, evaluation was performed and provided


### Test Results:
TBD

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

