### PR TITLE
Zeroing a litter diagnostic that was not being zerod

### DIFF
--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -2679,13 +2679,13 @@ end subroutine flush_hvars
 
          hio_cwd_elcwd(io_si,:)   = 0._r8
 
-
+         
          do el = 1, num_elements
             
             flux_diags => sites(s)%flux_diags(el)
             
             ! Sum up all input litter fluxes (above below, fines, cwd)
-            hio_litter_in_elem(io_si, el) = hio_litter_in_elem(io_si, el) + &
+            hio_litter_in_elem(io_si, el) =  & 
                  sum(flux_diags%cwd_ag_input(:)) + & 
                  sum(flux_diags%cwd_bg_input(:)) + &
                  sum(flux_diags%leaf_litter_input(:)) + &
@@ -2701,6 +2701,7 @@ end subroutine flush_hvars
             hio_seed_decay_elem(io_si,el)     = 0._r8
             hio_seeds_in_local_elem(io_si,el) = 0._r8
             hio_seed_in_extern_elem(io_si,el) = 0._r8
+            hio_litter_out_elem(io_si,el)     = 0._r8
             
             cpatch => sites(s)%oldest_patch
             do while(associated(cpatch))
@@ -2715,7 +2716,7 @@ end subroutine flush_hvars
                      sum(litt%root_fines_frag(:,:)) + &
                      sum(litt%ag_cwd_frag(:)) + & 
                      sum(litt%bg_cwd_frag(:,:))) * area_frac
-               
+
                hio_seed_bank_elem(io_si,el) = hio_seed_bank_elem(io_si,el) + & 
                     sum(litt%seed(:)) * area_frac
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

Two output variables, LITTER_IN_ELEM and LITTER_OUT_ELEM were not being zero'd inside columns (sites) prior to accumulating values. This caused their info to not be written, left as no data values.  This was causing problems for tests because these arrays had no real data and confused cprnc.

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

 @dqwu and @bishtgautam

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

this only effects those two diagnostics 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [x] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

TBD

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

