### PR TITLE
Canopy trimming subroutine optimization update

### DIFF
--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -525,13 +525,15 @@ contains
                 endif
 
                 ! Construct the arrays for a least square fit of the net_net_uptake versus the cumulative lai
-                nnu_clai_a(1,1) = nnu_clai_a(1,1) + 1 ! Increment for each layer used
-                nnu_clai_a(1,2) = nnu_clai_a(1,2) + currentCohort%year_net_uptake(z) - currentCohort%leaf_cost
-                nnu_clai_a(2,1) = nnu_clai_a(1,2)
-                nnu_clai_a(2,2) = nnu_clai_a(2,2) + (currentCohort%year_net_uptake(z) - currentCohort%leaf_cost)**2
-                nnu_clai_b(1,1) = nnu_clai_b(1,1) + cumulative_lai
-                nnu_clai_b(2,1) = nnu_clai_b(2,1) + (cumulative_lai * & 
-                                 (currentCohort%year_net_uptake(z) - currentCohort%leaf_cost))
+                if (currentCohort%nv - z < nll) then  ! Only for nll layers
+                  nnu_clai_a(1,1) = nnu_clai_a(1,1) + 1 ! Increment for each layer used
+                  nnu_clai_a(1,2) = nnu_clai_a(1,2) + currentCohort%year_net_uptake(z) - currentCohort%leaf_cost
+                  nnu_clai_a(2,1) = nnu_clai_a(1,2)
+                  nnu_clai_a(2,2) = nnu_clai_a(2,2) + (currentCohort%year_net_uptake(z) - currentCohort%leaf_cost)**2
+                  nnu_clai_b(1,1) = nnu_clai_b(1,1) + cumulative_lai
+                  nnu_clai_b(2,1) = nnu_clai_b(2,1) + (cumulative_lai * & 
+                                    (currentCohort%year_net_uptake(z) - currentCohort%leaf_cost))
+                end if
 
                 ! Check leaf cost against the yearly net uptake for that cohort leaf layer
                 if (currentCohort%year_net_uptake(z) < currentCohort%leaf_cost) then

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -550,6 +550,7 @@ contains
                   write(fates_log(),*) 'cumulative lai:', cumulative_lai
                   write(fates_log(),*) 'leaf_cost:', currentCohort%leaf_cost
                   write(fates_log(),*) 'year_net_uptake:', currentCohort%year_net_uptake(z)   
+                  write(fates_log(),*) 'canopy trim:', currentCohort%canopy_trim   
                 endif
 
                 ! Construct the arrays for a least square fit of the net_net_uptake versus the cumulative lai
@@ -568,10 +569,10 @@ contains
                    ! Make sure the cohort trim fraction is great than the pft trim limit
                    if (currentCohort%canopy_trim > EDPftvarcon_inst%trim_limit(ipft)) then
 
-                      if ( debug ) then
-                         write(fates_log(),*) 'trimming leaves', &
-                               currentCohort%canopy_trim!,currentCohort%leaf_cost
-                      endif
+                     !  if ( debug ) then
+                     !     write(fates_log(),*) 'trimming leaves', &
+                     !           currentCohort%canopy_trim,currentCohort%leaf_cost
+                     !  endif
 
                       ! keep trimming until none of the canopy is in negative carbon balance.              
                       if (currentCohort%hite > EDPftvarcon_inst%hgt_min(ipft)) then
@@ -581,9 +582,6 @@ contains
                          if (EDPftvarcon_inst%evergreen(ipft) /= 1) then
                             currentCohort%laimemory = currentCohort%laimemory * &
                                   (1.0_r8 - EDPftvarcon_inst%trim_inc(ipft)) 
-                            if ( debug ) then
-                              write(fates_log(),*) 'evergreen'
-                            endif      
                          endif
 
                          trimmed = .true.
@@ -631,7 +629,7 @@ contains
           endif 
 
           if ( debug ) then
-             write(fates_log(),*) 'trimming',currentCohort%canopy_trim
+             write(fates_log(),*) 'trimming:',currentCohort%canopy_trim
           endif
          
           ! currentCohort%canopy_trim = 1.0_r8 !FIX(RF,032414) this turns off ctrim for now. 

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -503,8 +503,11 @@ contains
                    currentCohort%leaf_cost = currentCohort%leaf_cost * &
                          (EDPftvarcon_inst%grperc(ipft) + 1._r8)
                 endif
-                if (currentCohort%year_net_uptake(z) < currentCohort%leaf_cost)then
-                   if (currentCohort%canopy_trim > EDPftvarcon_inst%trim_limit(ipft))then
+
+                ! Check leaf cost against the yearly net uptake for that cohort leaf layer
+                if (currentCohort%year_net_uptake(z) < currentCohort%leaf_cost) then
+                   ! Make sure the cohort trim fraction is great than the pft trim limit
+                   if (currentCohort%canopy_trim > EDPftvarcon_inst%trim_limit(ipft)) then
 
                       if ( debug ) then
                          write(fates_log(),*) 'trimming leaves', &
@@ -512,21 +515,27 @@ contains
                       endif
 
                       ! keep trimming until none of the canopy is in negative carbon balance.              
-                      if (currentCohort%hite > EDPftvarcon_inst%hgt_min(ipft))then
+                      if (currentCohort%hite > EDPftvarcon_inst%hgt_min(ipft)) then
                          currentCohort%canopy_trim = currentCohort%canopy_trim - &
                                EDPftvarcon_inst%trim_inc(ipft)
-                         if (EDPftvarcon_inst%evergreen(ipft) /= 1)then
+
+                         if (EDPftvarcon_inst%evergreen(ipft) /= 1) then
                             currentCohort%laimemory = currentCohort%laimemory * &
                                   (1.0_r8 - EDPftvarcon_inst%trim_inc(ipft)) 
                          endif
-                         trimmed = .true.
-                      endif
-                   endif
-                endif
-             endif !leaf activity? 
-          enddo !z
 
+                         trimmed = .true.
+
+                      endif ! hite check
+                   endif ! trim limit check
+                endif ! net uptake check
+             endif ! leaf activity check 
+          enddo ! z, leaf layer loop
+
+          ! Reset activity for the cohort for the start of the next year
           currentCohort%year_net_uptake(:) = 999.0_r8
+
+          ! Add to trim fraction if cohort not trimmed at all 
           if ( (.not.trimmed) .and.currentCohort%canopy_trim < 1.0_r8)then
              currentCohort%canopy_trim = currentCohort%canopy_trim + EDPftvarcon_inst%trim_inc(ipft)
           endif 

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -584,7 +584,7 @@ contains
             if (debug) then
                write(fates_log(),*) 'LLSF optimium LAI (intercept,slope):', nnu_clai_b
                write(fates_log(),*) 'LLSF optimium LAI info:', info
-               write(fates_log(),*) 'LAI fraction (cumulative lai/nnu_clai_b):', cumulative_lai/nnu_clai_b(1,1)
+               write(fates_log(),*) 'LAI fraction (cumulative lai/nnu_clai_b):', nnu_clai_b(1,1) / cumulative_lai
             endif
          endif
 

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -584,7 +584,7 @@ contains
             if (debug) then
                write(fates_log(),*) 'LLSF optimium LAI (intercept,slope):', nnu_clai_b
                write(fates_log(),*) 'LLSF optimium LAI info:', info
-               write(fates_log(),*) 'LAI fraction (cumulative lai/nnu_clai_b):', nnu_clai_b(1,1) / cumulative_lai
+               write(fates_log(),*) 'LAI fraction (optimum_lai/cumulative_lai):', nnu_clai_b(1,1) / cumulative_lai
             endif
          endif
 

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -530,7 +530,7 @@ contains
                 nnu_clai_a(2,1) = nnu_clai_a(1,2)
                 nnu_clai_a(2,2) = nnu_clai_a(2,2) + (currentCohort%year_net_uptake(z) - currentCohort%leaf_cost)**2
                 nnu_clai_b(1,1) = nnu_clai_b(1,1) + cumulative_lai
-                nnu_clai_b(2,1) = nnu_clai_b(1,1) + (cumulative_lai * & 
+                nnu_clai_b(2,1) = nnu_clai_b(2,1) + (cumulative_lai * & 
                                  (currentCohort%year_net_uptake(z) - currentCohort%leaf_cost))
 
                 ! Check leaf cost against the yearly net uptake for that cohort leaf layer

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -637,7 +637,7 @@ contains
                   trimmed = .true.
 
                endif
-
+            endif
          endif
 
           ! Reset activity for the cohort for the start of the next year

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -456,8 +456,8 @@ contains
           sla_max = EDPftvarcon_inst%slamax(ipft)
 
           ! Initialize nnu_clai_a
-          nnu_clai_a(:) = 0._r8
-          nnu_clai_b(:) = 0._r8
+          nnu_clai_a(:,:) = 0._r8
+          nnu_clai_b(:,:) = 0._r8
           
           !Leaf cost vs netuptake for each leaf layer. 
           do z = 1, currentCohort%nv
@@ -563,7 +563,7 @@ contains
 
           ! Compute the optimal cumulative lai based on the cohort net-net uptake profile if at least 2 leaf layers
           if (nnu_clai_a(1,1) > 1) then
-            
+
             ! Compute the optimum size of the work array
             lwork = -1 ! Ask sgels to compute optimal number of entries for work
             call dgels(trans, m, n, nrhs, nnu_clai_a, lda, nnu_clai_b, ldb, work, lwork, info)

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -566,7 +566,8 @@ contains
                 endif
 
                 ! Construct the arrays for a least square fit of the net_net_uptake versus the cumulative lai
-                ! if a least nll leaf layers are present in the current cohort
+                ! if at least nll leaf layers are present in the current cohort and only for the bottom nll 
+                ! leaf layers.
                 if (currentCohort%nv > nll .and. currentCohort%nv - z < nll) then 
 
                   ! Build the A matrix for the LHS of the linear system. A = [n  sum(x); sum(x)  sum(x^2)]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->
This PR updates the `trim_canopy` subroutine to resolve #383 (LAI oscillation issue).  The update approaches the issue by circumventing the use of a trim increment.  Currently, the subroutine compares the `leaf_cost` against the `net_uptake` for all leaf layers within a cohort and decreases or increases that cohort's `canopy_trim` value by a fixed parameter defined increment.  This can result in trimming values that appear bang back and forth around some median value.

@ckoven hypothesized that a better method would be to determine the 'optimum' cumulative LAI for the whole cohort based on the cumulative LAI versus the "net-net" uptake (leaf cost subtracted from the net uptake per leaf layer).  The optimum in this case being the LAI associated with a zero net-net uptake.  This optimum LAI can then be used to compute the fractional `canopy_trim` value.  

The optimum cumulative LAI is computed by forming a least squares linear fit from the last `nll` layers of a given cohort and using the `dgels` routine from lapack to solve.  If the minimum number of leaf layers is not present `trim_canopy` reverts back to using the original trim increment method.

Note issue #638 was generated in the course of testing this PR.  The calculations of `optimum_laimem` can not be evaluated in the context of the larger `trim_canopy` implementation.

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->
@ckoven @rgknox 

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->
Yes, there will be changes to the trimming per cohort and as such LAI and related values will be different.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [x] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results: 
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag: 242d6d14

CTSM (or) E3SM (specify which) baseline hash-tag: 242d6d14

FATES baseline hash-tag: 320a8fc0

Test Output:

Regression tests: All expected PASS

[ACRE comparison for 30 year BCI site run](https://github.com/glemieux/fates-jupyter/blob/develop/leaf-flutter/ACRE-output/issue383-comparison_plots.pdf)

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

