### PR TITLE
Use lightning data coming in from the CTSM

### DIFF
--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -41,6 +41,9 @@
   use PRTGenericMod,          only : SetState
   use FatesInterfaceTypesMod     , only : numpft
 
+  use CNFireFactoryMod, only: no_fire, scalar_lightning, &
+          lightning_from_data, successful_ignitions, anthro_ignitions
+
   implicit none
   private
 
@@ -59,7 +62,6 @@
   ! The following parameter represents one of the values of hlm_spitfire_mode
   ! and more of these appear in subroutine area_burnt_intensity below
   ! NB. The same parameters are set in /src/biogeochem/CNFireFactoryMod
-  integer, parameter :: no_fire = 0  ! value of the no_fire mode
   integer :: write_SF = 0     ! for debugging
   logical :: debug = .false.  ! for debugging
 
@@ -685,13 +687,8 @@ contains
     
     real(r8) size_of_fire !in m2
     real(r8) cloud_to_ground_strikes  ! [fraction] depends on hlm_spitfire_mode
-    real(r8) anthro_ign_count              ! anthropogenic ignition count/km2/day
+    real(r8) anthro_ign_count  ! anthropogenic ignition count/km2/day
     integer :: iofp  ! index of oldest fates patch
-    ! The following three parameters represent values of hlm_spitfire_mode
-    ! NB. The same parameters are set in /src/biogeochem/CNFireFactoryMod
-    integer, parameter :: scalar_lightning = 1  ! value of scalar_lightning mode
-    integer, parameter :: successful_ignitions = 3  ! value of successful_ignitions mode
-    integer, parameter :: anthro_ignitions = 4  ! value of anthro_ignitions mode
     real(r8), parameter :: pot_hmn_ign_counts_alpha = 0.0035_r8  ! Potential human ignition counts (alpha in Li et al. 2012) (#/person/month)
     real(r8),parameter :: km2_to_m2 = 1000000.0_r8 !area conversion for square km to square m
 

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -693,6 +693,7 @@ contains
     ! FDI 0.1 = low, 0.3 moderate, 0.75 high, and 1 = extreme ignition potential for alpha 0.000337
     if (hlm_spitfire_mode == successful_ignitions) then
        currentSite%FDI = 1.0_r8  ! READING "SUCCESSFUL IGNITION" DATA
+       cg_strikes = 1.0_r8
     else  ! USING LIGHTNING DATA
        currentSite%FDI  = 1.0_r8 - exp(-SF_val_fdi_alpha*currentSite%acc_NI)
     end if

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -56,6 +56,9 @@
   public :: cambial_damage_kill
   public :: post_fire_mortality
 
+  ! The following parameter represents one of the values of hlm_spitfire_mode
+  ! and more of these appear in subroutine area_burnt_intensity below
+  ! NB. The same parameters are set in /src/biogeochem/CNFireFactoryMod
   integer, parameter :: no_fire = 0  ! value of the no_fire mode
   integer :: write_SF = 0     ! for debugging
   logical :: debug = .false.  ! for debugging
@@ -683,6 +686,8 @@ contains
     real(r8) size_of_fire !in m2
     real(r8) cloud_to_ground_strikes  ! [fraction] depends on hlm_spitfire_mode
     integer :: iofp  ! index of oldest fates patch
+    ! The following three parameters represent values of hlm_spitfire_mode
+    ! NB. The same parameters are set in /src/biogeochem/CNFireFactoryMod
     integer, parameter :: scalar_lightning = 1  ! value of scalar_lightning mode
     integer, parameter :: successful_ignitions = 3  ! value of successful_ignitions mode
     integer, parameter :: anthro_ignitions = 4  ! value of anthro_ignitions mode

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -56,7 +56,7 @@
   public :: cambial_damage_kill
   public :: post_fire_mortality
 
-  integer :: no_fire = 0  ! value of the no_fire mode
+  integer, parameter :: no_fire = 0  ! value of the no_fire mode
   integer :: write_SF = 0     ! for debugging
   logical :: debug = .false.  ! for debugging
 
@@ -683,9 +683,9 @@ contains
     real(r8) size_of_fire !in m2
     real(r8) cloud_to_ground_strikes  ! [fraction] depends on hlm_spitfire_mode
     integer :: iofp  ! index of oldest fates patch
-    integer :: scalar_lightning = 1  ! value of scalar_lightning mode
-    integer :: successful_ignitions = 3  ! value of successful_ignitions mode
-    integer :: anthro_ignitions = 4  ! value of anthro_ignitions mode
+    integer, parameter :: scalar_lightning = 1  ! value of scalar_lightning mode
+    integer, parameter :: successful_ignitions = 3  ! value of successful_ignitions mode
+    integer, parameter :: anthro_ignitions = 4  ! value of anthro_ignitions mode
     real(r8), parameter :: pot_hmn_ign_counts_alpha = 0.0035_r8  ! Potential human ignition counts (alpha in Li et. al. 2012) (#/person/month)
     real(r8),parameter :: km2_to_m2 = 1000000.0_r8 !area conversion for square km to square m
 

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -681,6 +681,7 @@ contains
     real(r8) AB               !daily area burnt in m2 per km2
     
     real(r8) size_of_fire !in m2
+    real(r8) cloud_to_ground_strikes  ! [fraction] depends on hlm_spitfire_mode
     integer :: iofp  ! index of oldest fates patch
     integer :: successful_ignitions = 3  ! value of successful_ignitions mode
     real(r8),parameter :: km2_to_m2 = 1000000.0_r8 !area conversion for square km to square m
@@ -693,14 +694,15 @@ contains
     ! FDI 0.1 = low, 0.3 moderate, 0.75 high, and 1 = extreme ignition potential for alpha 0.000337
     if (hlm_spitfire_mode == successful_ignitions) then
        currentSite%FDI = 1.0_r8  ! READING "SUCCESSFUL IGNITION" DATA
-       cg_strikes = 1.0_r8
+       cloud_to_ground_strikes = 1.0_r8
     else  ! USING LIGHTNING DATA
        currentSite%FDI  = 1.0_r8 - exp(-SF_val_fdi_alpha*currentSite%acc_NI)
+       cloud_to_ground_strikes = cg_strikes
     end if
     
     !NF = number of lighting strikes per day per km2 scaled by cloud to ground strikes
     iofp = currentSite%oldest_patch%patchno
-    currentSite%NF = bc_in%lightning24(iofp) * cg_strikes
+    currentSite%NF = bc_in%lightning24(iofp) * cloud_to_ground_strikes
 
     ! If there are 15  lightning strikes per year, per km2. (approx from NASA product for S.A.) 
     ! then there are 15 * 1/365 strikes/km2 each day 

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -691,7 +691,7 @@ contains
     integer, parameter :: scalar_lightning = 1  ! value of scalar_lightning mode
     integer, parameter :: successful_ignitions = 3  ! value of successful_ignitions mode
     integer, parameter :: anthro_ignitions = 4  ! value of anthro_ignitions mode
-    real(r8), parameter :: pot_hmn_ign_counts_alpha = 0.0035_r8  ! Potential human ignition counts (alpha in Li et. al. 2012) (#/person/month)
+    real(r8), parameter :: pot_hmn_ign_counts_alpha = 0.0035_r8  ! Potential human ignition counts (alpha in Li et al. 2012) (#/person/month)
     real(r8),parameter :: km2_to_m2 = 1000000.0_r8 !area conversion for square km to square m
 
     !  ---initialize site parameters to zero--- 
@@ -719,7 +719,8 @@ contains
     ! If there are 15  lightning strikes per year, per km2. (approx from NASA product for S.A.) 
     ! then there are 15 * 1/365 strikes/km2 each day 
  
-    ! Calculate and add anthropogenic ignitions to ignitions by lightning
+    ! Calculate anthropogenic ignitions according to Li et al. (2012)
+    ! Add to ignitions by lightning
     if (hlm_spitfire_mode == anthro_ignitions) then
        currentSite%NF = currentSite%NF + pot_hmn_ign_counts_alpha * 6.8_r8 * bc_in%pop_density(iofp)**0.43_r8 / 30._r8 / 24._r8  ! divides by hrs/day and by approximate days per month
     end if

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -983,7 +983,7 @@ contains
          hlm_max_patch_per_site = unset_int
          hlm_use_vertsoilc = unset_int
          hlm_parteh_mode   = unset_int
-         hlm_use_spitfire  = unset_int
+         hlm_spitfire_mode = unset_int
          hlm_use_planthydro = unset_int
          hlm_use_cohort_age_tracking = unset_int
          hlm_use_logging   = unset_int
@@ -1182,9 +1182,9 @@ contains
             call endrun(msg=errMsg(sourcefile, __LINE__))
          end if
 
-         if(hlm_use_spitfire .eq. unset_int) then
+         if(hlm_spitfire_mode .eq. unset_int) then
             if (fates_global_verbose()) then
-               write(fates_log(), *) 'switch for SPITFIRE unset: hlm_use_spitfire, exiting'
+               write(fates_log(), *) 'switch for SPITFIRE unset: hlm_spitfire_mode, exiting'
             end if
             call endrun(msg=errMsg(sourcefile, __LINE__))
          end if
@@ -1267,10 +1267,10 @@ contains
                   write(fates_log(),*) 'Transfering hlm_parteh_mode= ',ival,' to FATES'
                end if
 
-            case('use_spitfire')
-               hlm_use_spitfire = ival
+            case('spitfire_mode')
+               hlm_spitfire_mode = ival
                if (fates_global_verbose()) then
-                  write(fates_log(),*) 'Transfering hlm_use_spitfire= ',ival,' to FATES'
+                  write(fates_log(),*) 'Transfering hlm_spitfire_mode =',ival,' to FATES'
                end if
                
             case('use_planthydro')

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -129,6 +129,7 @@ contains
     fates%bc_in(s)%wind24_pa(:)     = 0.0_r8
 
     fates%bc_in(s)%lightning24(:)      = 0.0_r8
+    fates%bc_in(s)%pop_density(:)      = 0.0_r8
     fates%bc_in(s)%solad_parb(:,:)     = 0.0_r8
     fates%bc_in(s)%solai_parb(:,:)     = 0.0_r8
     fates%bc_in(s)%smp_sl(:)           = 0.0_r8
@@ -299,8 +300,9 @@ contains
       allocate(bc_in%decomp_id(nlevsoil_in))
       allocate(bc_in%dz_decomp_sisl(nlevdecomp_in))
 
-      ! Lightning or ignitions
+      ! Lightning (or successful ignitions) and population density
       allocate(bc_in%lightning24(maxPatchesPerSite))
+      allocate(bc_in%pop_density(maxPatchesPerSite))
 
       ! Vegetation Dynamics
       allocate(bc_in%t_veg24_pa(maxPatchesPerSite))

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -327,6 +327,7 @@ module FatesInterfaceMod
       ! TO-DO: Get some consensus on the correct vegetation temperature used for phenology.
       ! It is possible that the bare-ground value is where the average is being stored.
       ! (RGK-01-2017)
+      real(r8)             :: lightning24
       real(r8)             :: t_veg24_si
 
       ! Patch 24 hour vegetation temperature [K]
@@ -888,6 +889,7 @@ contains
 
       ! Input boundaries
       
+      this%bc_in(s)%lightning24    = 0.0_r8
       this%bc_in(s)%t_veg24_si     = 0.0_r8
       this%bc_in(s)%t_veg24_pa(:)  = 0.0_r8
       this%bc_in(s)%precip24_pa(:) = 0.0_r8

--- a/main/FatesInterfaceTypesMod.F90
+++ b/main/FatesInterfaceTypesMod.F90
@@ -87,6 +87,7 @@ module FatesInterfaceTypesMod
    
    integer, public :: hlm_spitfire_mode  ! Flag to signal SPITFIRE mode
                                          ! See namelist_definition_clm4_5.xml
+                                         ! ignitions: 1=constant, >1=external data sources (lightning and/or anthropogenic)
 
 
    integer, public :: hlm_use_logging       ! This flag signals whether or not to use

--- a/main/FatesInterfaceTypesMod.F90
+++ b/main/FatesInterfaceTypesMod.F90
@@ -85,8 +85,8 @@ module FatesInterfaceTypesMod
                                                    ! soil carbon
                                                    ! 1 = TRUE,  0 = FALSE
    
-   integer, public :: hlm_use_spitfire  ! This flag signals whether or not to use SPITFIRE
-                                                   ! 1 = TRUE, 0 = FALSE
+   integer, public :: hlm_spitfire_mode  ! Flag to signal SPITFIRE mode
+                                         ! 0 = no fire, 1 = global constant lightning value from fates_params file, 2 = Lightning dataset, 3 = Successful ignitions dataset
 
 
    integer, public :: hlm_use_logging       ! This flag signals whether or not to use
@@ -280,6 +280,9 @@ module FatesInterfaceTypesMod
 
       ! Vegetation Dynamics
       ! ---------------------------------------------------------------------------------
+
+      ! 24-hour lightning or ignitions [#/km2/day]
+      real(r8),allocatable :: lightning24(:)
 
       ! Patch 24 hour vegetation temperature [K]
       real(r8),allocatable :: t_veg24_pa(:)  

--- a/main/FatesInterfaceTypesMod.F90
+++ b/main/FatesInterfaceTypesMod.F90
@@ -86,7 +86,7 @@ module FatesInterfaceTypesMod
                                                    ! 1 = TRUE,  0 = FALSE
    
    integer, public :: hlm_spitfire_mode  ! Flag to signal SPITFIRE mode
-                                         ! 0 = no fire, 1 = global constant lightning value from fates_params file, 2 = Lightning dataset, 3 = Successful ignitions dataset
+                                         ! See namelist_definition_clm4_5.xml
 
 
    integer, public :: hlm_use_logging       ! This flag signals whether or not to use
@@ -286,6 +286,9 @@ module FatesInterfaceTypesMod
 
       ! 24-hour lightning or ignitions [#/km2/day]
       real(r8),allocatable :: lightning24(:)
+
+      ! Population density [#/km2]
+      real(r8),allocatable :: pop_density(:)
 
       ! Patch 24 hour vegetation temperature [K]
       real(r8),allocatable :: t_veg24_pa(:)  


### PR DESCRIPTION
### Description:
Introduced `bc_in` variable `lightning24` to replace the parameter `ED_val_nignitions`. Now all lightning/ignition info enters FATES via `clmfates_interfaceMod`.

Issue numbers:
#562 
https://github.com/ESCOMP/CTSM/issues/982
https://github.com/ESCOMP/CTSM/issues/983
#670 

### Collaborators:
@ekluzek @rgknox @ckoven @lmkueppers @jkshuman 

### Expectation of Answer Changes:
Answers will change when using lightning or ignition data and not the default ED_val_nignitions value. The latter is still available by setting `use_fates_spitfire = 1`
Other settings include:
`use_fates_spitfire = 0` for no fire
`use_fates_spitfire = 2` for Li et al lightning data
`use_fates_spitfire = 3` for successful ignitions data

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

