### PR TITLE
Removing bc_in%t_veg24_si

### DIFF
--- a/biogeochem/EDMortalityFunctionsMod.F90
+++ b/biogeochem/EDMortalityFunctionsMod.F90
@@ -62,7 +62,7 @@ contains
     real(r8),intent(out) :: smort  ! size dependent senescence term
     real(r8),intent(out) :: asmort ! age dependent senescence term 
 
-
+    integer  :: ifp
     real(r8) :: frac  ! relativised stored carbohydrate
     real(r8) :: leaf_c_target      ! target leaf biomass kgC
     real(r8) :: store_c
@@ -173,7 +173,8 @@ if (hlm_use_ed_prescribed_phys .eq. ifalse) then
     !           Eastern US carbon sink.  Glob. Change Biol., 12, 2370-2390,              
     !           doi: 10.1111/j.1365-2486.2006.01254.x                                    
 
-    temp_in_C = bc_in%t_veg24_si - tfrz
+    ifp = cohort_in%patchptr%patchno
+    temp_in_C = bc_in%t_veg24_pa(ifp) - tfrz
     temp_dep_fraction  = max(0.0_r8, min(1.0_r8, 1.0_r8 - (temp_in_C - &
                          EDPftvarcon_inst%freezetol(cohort_in%pft))/frost_mort_buffer) )
     frmort    = EDPftvarcon_inst%mort_scalar_coldstress(cohort_in%pft) * temp_dep_fraction

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -25,6 +25,7 @@ module FatesInterfaceMod
    use EDTypesMod          , only : element_list
    use FatesConstantsMod   , only : r8 => fates_r8
    use FatesConstantsMod   , only : itrue,ifalse
+   use FatesConstantsMod   , only : fates_unset_r8
    use FatesGlobals        , only : fates_global_verbose
    use FatesGlobals        , only : fates_log
    use FatesGlobals        , only : endrun => fates_endrun
@@ -315,13 +316,11 @@ module FatesInterfaceMod
       ! Vegetation Dynamics
       ! ---------------------------------------------------------------------------------
 
-      ! The site level 24 hour vegetation temperature is used for various purposes during vegetation 
-      ! dynamics.  However, we are currently using the bare ground patch's value [K]
-      ! TO-DO: Get some consensus on the correct vegetation temperature used for phenology.
-      ! It is possible that the bare-ground value is where the average is being stored.
-      ! (RGK-01-2017)
+      ! THIS VARIABLE IS NOW DEPRECATED AND SHOULD NOT BE USED
+      ! THIS WILL BE REMOVED FROM THE API ALONG WITH THE NEXT MAJOR API CHANGE
       real(r8)             :: t_veg24_si
 
+      
       ! Patch 24 hour vegetation temperature [K]
       real(r8),allocatable :: t_veg24_pa(:)  
       
@@ -890,7 +889,7 @@ contains
 
       ! Input boundaries
       
-      this%bc_in(s)%t_veg24_si     = 0.0_r8
+      this%bc_in(s)%t_veg24_si     = fates_unset_r8
       this%bc_in(s)%t_veg24_pa(:)  = 0.0_r8
       this%bc_in(s)%precip24_pa(:) = 0.0_r8
       this%bc_in(s)%relhumid24_pa(:) = 0.0_r8

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -650,10 +650,10 @@ variables:
 		fates_phen_c:long_name = "GDD accumulation function, exponent parameter: gdd_thesh = a + b exp(c*ncd)" ;
 	double fates_phen_chiltemp ;
 		fates_phen_chiltemp:units = "degrees C" ;
-		fates_phen_chiltemp:long_name = "chilling day counting threshold" ;
+		fates_phen_chiltemp:long_name = "chilling day counting threshold for vegetation" ;
 	double fates_phen_coldtemp ;
 		fates_phen_coldtemp:units = "degrees C" ;
-		fates_phen_coldtemp:long_name = "temperature exceedance to flag a cold-day for temperature leaf drop" ;
+		fates_phen_coldtemp:long_name = "vegetation temperature exceedance that flags a cold-day for leaf-drop" ;
 	double fates_phen_doff_time ;
 		fates_phen_doff_time:units = "days" ;
 		fates_phen_doff_time:long_name = "day threshold compared against days since leaves became off-allometry" ;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

This set of changes removes usage of t_veg24_si.  @xuchongang identified in #636 that ELM is potentially deactivating the bare-ground patch,, and at the least is generating non dynamic changes on that patch, and we should not rely on that patch's temperature to make site-level decisions in FATES.  The fix applied here, removes its usage in FATES, and instead either takes the mean of the patch temperatures (for phenology timing), or uses the temperature from the patch of interest (for mortality).


### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

@xuchongang 

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

Yes, this should change answers.  This will generate subtle changes to phenology timing on cold-decidous, as well as freezing mortality in all plants.  In most cases, I'm guessing the differences will be very subtle, but potentially not.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:

TBD

<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

