### PR TITLE
Updates to fire history variables

### DIFF
--- a/main/EDMainMod.F90
+++ b/main/EDMainMod.F90
@@ -721,7 +721,6 @@ contains
       if(call_index == final_check_id) then
           site_mass%old_stock = total_stock
           site_mass%err_fates = net_flux - change_in_stock
-          call site_mass%ZeroMassBalFlux()
       end if
 
    end do

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -141,7 +141,6 @@ module FatesHistoryInterfaceMod
   integer :: ih_trimming_pa
   integer :: ih_area_plant_pa
   integer :: ih_area_treespread_pa
-  integer :: ih_nesterov_fire_danger_pa
   integer :: ih_spitfire_ROS_pa
   integer :: ih_effect_wspeed_pa
   integer :: ih_TFC_ROS_pa
@@ -268,6 +267,7 @@ module FatesHistoryInterfaceMod
   integer :: ih_dleafon_si
   integer :: ih_meanliqvol_si
 
+  integer :: ih_nesterov_fire_danger_si
 
   integer :: ih_nplant_si_scpf
   integer :: ih_gpp_si_scpf
@@ -326,7 +326,6 @@ module FatesHistoryInterfaceMod
   integer :: ih_ar_frootm_si_scpf
   
   integer :: ih_c13disc_si_scpf
-
 
   ! indices to (site x scls [size class bins]) variables
   integer :: ih_ba_si_scls
@@ -433,6 +432,10 @@ module FatesHistoryInterfaceMod
   integer :: ih_c_lblayer_si_age
   integer :: ih_agesince_anthrodist_si_age
   integer :: ih_secondaryforest_area_si_age
+  integer :: if_area_burnt_si_age
+  ! integer :: if_fire_rate_of_spread_front_si_age
+  ! integer :: if_fire_intensity_si_age
+  integer :: if_fire_sum_fuel_si_age
 
   ! indices to (site x height) variables
   integer :: ih_canopy_height_dist_si_height
@@ -1733,7 +1736,7 @@ end subroutine flush_hvars
                hio_recruitment_si_pft  => this%hvars(ih_recruitment_si_pft)%r82d, &
                hio_mortality_si_pft    => this%hvars(ih_mortality_si_pft)%r82d, &
                hio_crownarea_si_pft    => this%hvars(ih_crownarea_si_pft)%r82d, &
-               hio_nesterov_fire_danger_pa => this%hvars(ih_nesterov_fire_danger_pa)%r81d, &
+               hio_nesterov_fire_danger_si => this%hvars(ih_nesterov_fire_danger_si)%r81d, &
                hio_spitfire_ros_pa     => this%hvars(ih_spitfire_ROS_pa)%r81d, &
                hio_tfc_ros_pa          => this%hvars(ih_TFC_ROS_pa)%r81d, &
                hio_effect_wspeed_pa    => this%hvars(ih_effect_wspeed_pa)%r81d, &
@@ -1909,6 +1912,10 @@ end subroutine flush_hvars
                hio_woodproduct_si                 => this%hvars(ih_woodproduct_si)%r81d, &
                hio_agesince_anthrodist_si_age     => this%hvars(ih_agesince_anthrodist_si_age)%r82d, &
                hio_secondaryforest_area_si_age    => this%hvars(ih_secondaryforest_area_si_age)%r82d, &
+               hio_area_burnt_si_age              => this%hvars(ih_area_burnt_si_age)%r82d, &
+               ! hio_fire_rate_of_spread_front_si_age  => this%hvars(ih_fire_rate_of_spread_front_si_age)%r82d, &
+               ! hio_fire_intensity_si_age          => this%hvars(ih_fire_intensity_si_age)%r82d, &
+               hio_fire_sum_fuel_si_age           => this%hvars(ih_fire_sum_fuel_si_age)%r82d, &
                hio_canopy_height_dist_si_height   => this%hvars(ih_canopy_height_dist_si_height)%r82d, &
                hio_leaf_height_dist_si_height     => this%hvars(ih_leaf_height_dist_si_height)%r82d, &
                hio_litter_moisture_si_fuel        => this%hvars(ih_litter_moisture_si_fuel)%r82d, &
@@ -2007,6 +2014,8 @@ end subroutine flush_hvars
          hio_woodproduct_si(io_si)          = sites(s)%resources_management%trunk_product_site &
               * AREA_INV * g_per_kg
          
+         ! site-level fire variables
+         hio_nesterov_fire_danger_si(io_si) = sites(s)%acc_NI
 
          ! If hydraulics are turned on, track the error terms
          ! associated with dynamics
@@ -2061,14 +2070,26 @@ end subroutine flush_hvars
                     + cpatch%area * AREA_INV
             endif
             
+            !!! patch-age-resolved fire variables
             do i_pft = 1,numpft
                ! for scorch height, weight the value by patch area within any given age calss (in the event that there is
                ! more than one patch per age class.
                iagepft = cpatch%age_class + (i_pft-1) * nlevage
                hio_scorch_height_si_agepft(io_si,iagepft) = hio_scorch_height_si_agepft(io_si,iagepft) + &
                     cpatch%Scorch_ht(i_pft) * cpatch%area
-
             end do
+
+            hio_area_burnt_si_age(io_si,cpatch%age_class) = hio_area_burnt_si_age(io_si,cpatch%age_class) + &
+                 cpatch*frac_burnt * cpatch%area * AREA_INV
+
+            ! hio_fire_rate_of_spread_front_si_age(io_si, cpatch%age_class) = hio_fire_rate_of_spread_si_age(io_si, cpatch%age_class) + &
+            !      cpatch%ros_front * cpatch*frac_burnt * cpatch%area * AREA_INV
+
+            ! hio_fire_intensity_si_age(io_si, cpatch%age_class) = hio_fire_intensity_si_age(io_si, cpatch%age_class) + &
+            !      cpatch%FI * cpatch*frac_burnt * cpatch%area * AREA_INV
+
+            hio_fire_sum_fuel_si_age(io_si, cpatch%age_class) = hio_fire_sum_fuel_si_age(io_si, cpatch%age_class) + &
+                 cpatch%sum_fuel * cpatch%area * AREA_INV
              
             ccohort => cpatch%shortest
             do while(associated(ccohort))
@@ -2604,7 +2625,6 @@ end subroutine flush_hvars
             endif
             
             ! Update Fire Variables
-            hio_nesterov_fire_danger_pa(io_pa) = sites(s)%acc_NI
             hio_spitfire_ros_pa(io_pa)         = cpatch%ROS_front 
             hio_effect_wspeed_pa(io_pa)        = cpatch%effect_wspeed
             hio_tfc_ros_pa(io_pa)              = cpatch%TFC_ROS
@@ -4001,8 +4021,8 @@ end subroutine flush_hvars
 
     call this%set_history_var(vname='FIRE_NESTEROV_INDEX', units='none',       &
          long='nesterov_fire_danger index', use_default='active',               &
-         avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
-         ivar=ivar, initialize=initialize_variables, index = ih_nesterov_fire_danger_pa)
+         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
+         ivar=ivar, initialize=initialize_variables, index = ih_nesterov_fire_danger_si)
 
     call this%set_history_var(vname='FIRE_ROS', units='m/min',                 &
          long='fire rate of spread m/min', use_default='active',                &
@@ -4059,6 +4079,19 @@ end subroutine flush_hvars
          long='spitfire size-resolved fuel moisture', use_default='active',       &
          avgflag='A', vtype=site_fuel_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
          ivar=ivar, initialize=initialize_variables, index = ih_litter_moisture_si_fuel )
+
+    call this%set_history_var(vname='AREA_BURNT_BY_PATCH_AGE', units='m2/m2', &
+         long='spitfire area burnt by patch age (divide by patch_area_by_age to get burnt fraction by age)', &
+         use_default='active', &
+         avgflag='A', vtype=site_age_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1, &
+         ivar=ivar, initialize=initialize_variables, index = ih_area_burnt_si_age )
+
+    call this%set_history_var(vname='SUM_FUEL_BY_PATCH_AGE', units='gC / m2 of site area', &
+         long='spitfire ground fuel related to ros (omits 1000hr fuels) within each patch age bin (divide by patch_area_by_age to get fuel per unit area of that-age patch)', &
+         use_default='active', &
+         avgflag='A', vtype=site_age_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1, &
+         ivar=ivar, initialize=initialize_variables, index = ih_sum_fuel_si_age )
+
 
     ! Litter Variables
 

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -432,10 +432,10 @@ module FatesHistoryInterfaceMod
   integer :: ih_c_lblayer_si_age
   integer :: ih_agesince_anthrodist_si_age
   integer :: ih_secondaryforest_area_si_age
-  integer :: if_area_burnt_si_age
-  ! integer :: if_fire_rate_of_spread_front_si_age
-  ! integer :: if_fire_intensity_si_age
-  integer :: if_fire_sum_fuel_si_age
+  integer :: ih_area_burnt_si_age
+  ! integer :: ih_fire_rate_of_spread_front_si_age
+  ! integer :: ih_fire_intensity_si_age
+  integer :: ih_fire_sum_fuel_si_age
 
   ! indices to (site x height) variables
   integer :: ih_canopy_height_dist_si_height
@@ -2080,13 +2080,13 @@ end subroutine flush_hvars
             end do
 
             hio_area_burnt_si_age(io_si,cpatch%age_class) = hio_area_burnt_si_age(io_si,cpatch%age_class) + &
-                 cpatch*frac_burnt * cpatch%area * AREA_INV
+                 cpatch%frac_burnt * cpatch%area * AREA_INV
 
             ! hio_fire_rate_of_spread_front_si_age(io_si, cpatch%age_class) = hio_fire_rate_of_spread_si_age(io_si, cpatch%age_class) + &
             !      cpatch%ros_front * cpatch*frac_burnt * cpatch%area * AREA_INV
 
             ! hio_fire_intensity_si_age(io_si, cpatch%age_class) = hio_fire_intensity_si_age(io_si, cpatch%age_class) + &
-            !      cpatch%FI * cpatch*frac_burnt * cpatch%area * AREA_INV
+            !      cpatch%FI * cpatch%frac_burnt * cpatch%area * AREA_INV
 
             hio_fire_sum_fuel_si_age(io_si, cpatch%age_class) = hio_fire_sum_fuel_si_age(io_si, cpatch%age_class) + &
                  cpatch%sum_fuel * cpatch%area * AREA_INV
@@ -4090,7 +4090,7 @@ end subroutine flush_hvars
          long='spitfire ground fuel related to ros (omits 1000hr fuels) within each patch age bin (divide by patch_area_by_age to get fuel per unit area of that-age patch)', &
          use_default='active', &
          avgflag='A', vtype=site_age_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1, &
-         ivar=ivar, initialize=initialize_variables, index = ih_sum_fuel_si_age )
+         ivar=ivar, initialize=initialize_variables, index = ih_fire_sum_fuel_si_age )
 
 
     ! Litter Variables

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -1685,7 +1685,6 @@ end subroutine flush_hvars
     
     real(r8) :: n_density   ! individual of cohort per m2.
     real(r8) :: n_perm2     ! individuals per m2 for the whole column
-    real(r8) :: patch_scaling_scalar ! ratio of canopy to patch area for counteracting patch scaling
     real(r8) :: dbh         ! diameter ("at breast height")
     real(r8) :: coage       ! cohort age 
     real(r8) :: npp_partition_error ! a check that the NPP partitions sum to carbon allocation
@@ -1738,7 +1737,7 @@ end subroutine flush_hvars
                hio_mortality_si_pft    => this%hvars(ih_mortality_si_pft)%r82d, &
                hio_crownarea_si_pft    => this%hvars(ih_crownarea_si_pft)%r82d, &
                hio_nesterov_fire_danger_si => this%hvars(ih_nesterov_fire_danger_si)%r81d, &
-               hio_spitfire_ros_si     => this%hvars(ih_spitfire_ROS_si)%r81d, &
+               hio_spitfire_ROS_si     => this%hvars(ih_spitfire_ROS_si)%r81d, &
                hio_tfc_ros_si          => this%hvars(ih_TFC_ROS_si)%r81d, &
                hio_effect_wspeed_si    => this%hvars(ih_effect_wspeed_si)%r81d, &
                hio_fire_intensity_si   => this%hvars(ih_fire_intensity_si)%r81d, &
@@ -2619,13 +2618,7 @@ end subroutine flush_hvars
             ! Patch specific variables that are already calculated
             ! These things are all duplicated. Should they all be converted to LL or array structures RF? 
             ! define scalar to counteract the patch albedo scaling logic for conserved quantities
-            
-            if (cpatch%area .gt. 0._r8 .and. cpatch%total_canopy_area .gt.0 ) then
-               patch_scaling_scalar  = min(1._r8, cpatch%area / cpatch%total_canopy_area)
-            else
-               patch_scaling_scalar = 0._r8
-            endif
-            
+                        
             ! Update Fire Variables
             hio_spitfire_ros_si(io_si)         = hio_spitfire_ros_si(io_si) + cpatch%ROS_front * cpatch%area * AREA_INV
             hio_effect_wspeed_si(io_si)        = hio_effect_wspeed_si(io_si) + cpatch%effect_wspeed * cpatch%area * AREA_INV
@@ -2636,7 +2629,7 @@ end subroutine flush_hvars
             hio_fire_fuel_eff_moist_si(io_si)  = hio_fire_fuel_eff_moist_si(io_si) + cpatch%fuel_eff_moist * cpatch%area * AREA_INV
             hio_fire_fuel_sav_si(io_si)        = hio_fire_fuel_sav_si(io_si) + cpatch%fuel_sav * cpatch%area * AREA_INV
             hio_fire_fuel_mef_si(io_si)        = hio_fire_fuel_mef_si(io_si) + cpatch%fuel_mef * cpatch%area * AREA_INV
-            hio_sum_fuel_si(io_si)             = hio_sum_fuel_si(io_si) + cpatch%sum_fuel * g_per_kg * patch_scaling_scalar * cpatch%area * AREA_INV
+            hio_sum_fuel_si(io_si)             = hio_sum_fuel_si(io_si) + cpatch%sum_fuel * g_per_kg * cpatch%area * AREA_INV
             
             do i_fuel = 1,nfsc
                hio_litter_moisture_si_fuel(io_si, i_fuel) = hio_litter_moisture_si_fuel(io_si, i_fuel) + &
@@ -3825,17 +3818,17 @@ end subroutine flush_hvars
     call this%set_history_var(vname='TRIMMING', units='none',                   &
          long='Degree to which canopy expansion is limited by leaf economics',  & 
          use_default='active', &
-         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=1.0_r8, upfreq=1,    &
+         avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=1.0_r8, upfreq=1,    &
          ivar=ivar, initialize=initialize_variables, index = ih_trimming_pa)
     
     call this%set_history_var(vname='AREA_PLANT', units='m2',                   &
          long='area occupied by all plants', use_default='active',              &
-         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,    &
+         avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,    &
          ivar=ivar, initialize=initialize_variables, index = ih_area_plant_pa)
     
     call this%set_history_var(vname='AREA_TREES', units='m2',                   &
          long='area occupied by woody plants', use_default='active',            &
-         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,    &
+         avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,    &
          ivar=ivar, initialize=initialize_variables, index = ih_area_treespread_pa)
 
     call this%set_history_var(vname='SITE_COLD_STATUS', units='0,1,2', &

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -141,16 +141,6 @@ module FatesHistoryInterfaceMod
   integer :: ih_trimming_pa
   integer :: ih_area_plant_pa
   integer :: ih_area_treespread_pa
-  integer :: ih_spitfire_ROS_pa
-  integer :: ih_effect_wspeed_pa
-  integer :: ih_TFC_ROS_pa
-  integer :: ih_fire_intensity_pa
-  integer :: ih_fire_area_pa
-  integer :: ih_fire_fuel_bulkd_pa
-  integer :: ih_fire_fuel_eff_moist_pa
-  integer :: ih_fire_fuel_sav_pa
-  integer :: ih_fire_fuel_mef_pa
-  integer :: ih_sum_fuel_pa
 
   integer :: ih_cwd_elcwd
 
@@ -269,6 +259,16 @@ module FatesHistoryInterfaceMod
 
   integer :: ih_nesterov_fire_danger_si
   integer :: ih_fire_intensity_area_product_si
+  integer :: ih_spitfire_ROS_si
+  integer :: ih_effect_wspeed_si
+  integer :: ih_TFC_ROS_si
+  integer :: ih_fire_intensity_si
+  integer :: ih_fire_area_si
+  integer :: ih_fire_fuel_bulkd_si
+  integer :: ih_fire_fuel_eff_moist_si
+  integer :: ih_fire_fuel_sav_si
+  integer :: ih_fire_fuel_mef_si
+  integer :: ih_sum_fuel_si
 
   integer :: ih_nplant_si_scpf
   integer :: ih_gpp_si_scpf
@@ -1738,17 +1738,17 @@ end subroutine flush_hvars
                hio_mortality_si_pft    => this%hvars(ih_mortality_si_pft)%r82d, &
                hio_crownarea_si_pft    => this%hvars(ih_crownarea_si_pft)%r82d, &
                hio_nesterov_fire_danger_si => this%hvars(ih_nesterov_fire_danger_si)%r81d, &
-               hio_spitfire_ros_pa     => this%hvars(ih_spitfire_ROS_pa)%r81d, &
-               hio_tfc_ros_pa          => this%hvars(ih_TFC_ROS_pa)%r81d, &
-               hio_effect_wspeed_pa    => this%hvars(ih_effect_wspeed_pa)%r81d, &
-               hio_fire_intensity_pa   => this%hvars(ih_fire_intensity_pa)%r81d, &
+               hio_spitfire_ros_si     => this%hvars(ih_spitfire_ROS_si)%r81d, &
+               hio_tfc_ros_si          => this%hvars(ih_TFC_ROS_si)%r81d, &
+               hio_effect_wspeed_si    => this%hvars(ih_effect_wspeed_si)%r81d, &
+               hio_fire_intensity_si   => this%hvars(ih_fire_intensity_si)%r81d, &
                hio_fire_intensity_area_product_si => this%hvars(ih_fire_intensity_area_product_si)%r81d, &
-               hio_fire_area_pa        => this%hvars(ih_fire_area_pa)%r81d, &
-               hio_fire_fuel_bulkd_pa  => this%hvars(ih_fire_fuel_bulkd_pa)%r81d, &
-               hio_fire_fuel_eff_moist_pa => this%hvars(ih_fire_fuel_eff_moist_pa)%r81d, &
-               hio_fire_fuel_sav_pa    => this%hvars(ih_fire_fuel_sav_pa)%r81d, &
-               hio_fire_fuel_mef_pa    => this%hvars(ih_fire_fuel_mef_pa)%r81d, &
-               hio_sum_fuel_pa         => this%hvars(ih_sum_fuel_pa)%r81d,  &
+               hio_fire_area_si        => this%hvars(ih_fire_area_si)%r81d, &
+               hio_fire_fuel_bulkd_si  => this%hvars(ih_fire_fuel_bulkd_si)%r81d, &
+               hio_fire_fuel_eff_moist_si => this%hvars(ih_fire_fuel_eff_moist_si)%r81d, &
+               hio_fire_fuel_sav_si    => this%hvars(ih_fire_fuel_sav_si)%r81d, &
+               hio_fire_fuel_mef_si    => this%hvars(ih_fire_fuel_mef_si)%r81d, &
+               hio_sum_fuel_si         => this%hvars(ih_sum_fuel_si)%r81d,  &
                hio_litter_in_si        => this%hvars(ih_litter_in_si)%r81d, &
                hio_litter_out_si       => this%hvars(ih_litter_out_si)%r81d, &
                hio_seed_bank_si        => this%hvars(ih_seed_bank_si)%r81d, &
@@ -2627,16 +2627,16 @@ end subroutine flush_hvars
             endif
             
             ! Update Fire Variables
-            hio_spitfire_ros_pa(io_pa)         = cpatch%ROS_front 
-            hio_effect_wspeed_pa(io_pa)        = cpatch%effect_wspeed
-            hio_tfc_ros_pa(io_pa)              = cpatch%TFC_ROS
-            hio_fire_intensity_pa(io_pa)       = cpatch%FI
-            hio_fire_area_pa(io_pa)            = cpatch%frac_burnt
-            hio_fire_fuel_bulkd_pa(io_pa)      = cpatch%fuel_bulkd
-            hio_fire_fuel_eff_moist_pa(io_pa)  = cpatch%fuel_eff_moist
-            hio_fire_fuel_sav_pa(io_pa)        = cpatch%fuel_sav
-            hio_fire_fuel_mef_pa(io_pa)        = cpatch%fuel_mef
-            hio_sum_fuel_pa(io_pa)             = cpatch%sum_fuel * g_per_kg * patch_scaling_scalar
+            hio_spitfire_ros_si(io_si)         = hio_spitfire_ros_si(io_si) + cpatch%ROS_front * cpatch%area * AREA_INV
+            hio_effect_wspeed_si(io_si)        = hio_effect_wspeed_si(io_si) + cpatch%effect_wspeed * cpatch%area * AREA_INV
+            hio_tfc_ros_si(io_si)              = hio_tfc_ros_si(io_si) + cpatch%TFC_ROS * cpatch%area * AREA_INV
+            hio_fire_intensity_si(io_si)       = hio_fire_intensity_si(io_si) + cpatch%FI * cpatch%area * AREA_INV
+            hio_fire_area_si(io_si)            = hio_fire_area_si(io_si) + cpatch%frac_burnt * cpatch%area * AREA_INV
+            hio_fire_fuel_bulkd_si(io_si)      = hio_fire_fuel_bulkd_si(io_si) + cpatch%fuel_bulkd * cpatch%area * AREA_INV
+            hio_fire_fuel_eff_moist_si(io_si)  = hio_fire_fuel_eff_moist_si(io_si) + cpatch%fuel_eff_moist * cpatch%area * AREA_INV
+            hio_fire_fuel_sav_si(io_si)        = hio_fire_fuel_sav_si(io_si) + cpatch%fuel_sav * cpatch%area * AREA_INV
+            hio_fire_fuel_mef_si(io_si)        = hio_fire_fuel_mef_si(io_si) + cpatch%fuel_mef * cpatch%area * AREA_INV
+            hio_sum_fuel_si(io_si)             = hio_sum_fuel_si(io_si) + cpatch%sum_fuel * g_per_kg * patch_scaling_scalar * cpatch%area * AREA_INV
             
             do i_fuel = 1,nfsc
                hio_litter_moisture_si_fuel(io_si, i_fuel) = hio_litter_moisture_si_fuel(io_si, i_fuel) + &
@@ -3825,17 +3825,17 @@ end subroutine flush_hvars
     call this%set_history_var(vname='TRIMMING', units='none',                   &
          long='Degree to which canopy expansion is limited by leaf economics',  & 
          use_default='active', &
-         avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=1.0_r8, upfreq=1,    &
+         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=1.0_r8, upfreq=1,    &
          ivar=ivar, initialize=initialize_variables, index = ih_trimming_pa)
     
     call this%set_history_var(vname='AREA_PLANT', units='m2',                   &
          long='area occupied by all plants', use_default='active',              &
-         avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,    &
+         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,    &
          ivar=ivar, initialize=initialize_variables, index = ih_area_plant_pa)
     
     call this%set_history_var(vname='AREA_TREES', units='m2',                   &
          long='area occupied by woody plants', use_default='active',            &
-         avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,    &
+         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,    &
          ivar=ivar, initialize=initialize_variables, index = ih_area_treespread_pa)
 
     call this%set_history_var(vname='SITE_COLD_STATUS', units='0,1,2', &
@@ -4032,23 +4032,23 @@ end subroutine flush_hvars
 
     call this%set_history_var(vname='FIRE_ROS', units='m/min',                 &
          long='fire rate of spread m/min', use_default='active',                &
-         avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
-         ivar=ivar, initialize=initialize_variables, index = ih_spitfire_ROS_pa)
+         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
+         ivar=ivar, initialize=initialize_variables, index = ih_spitfire_ROS_si)
 
     call this%set_history_var(vname='EFFECT_WSPEED', units='none',             &
          long ='effective windspeed for fire spread', use_default='active',     &
-         avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
-         ivar=ivar, initialize=initialize_variables, index = ih_effect_wspeed_pa )
+         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
+         ivar=ivar, initialize=initialize_variables, index = ih_effect_wspeed_si )
 
     call this%set_history_var(vname='FIRE_TFC_ROS', units='kgC/m2',              &
          long ='total fuel consumed', use_default='active',                     &
-         avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
-         ivar=ivar, initialize=initialize_variables, index = ih_TFC_ROS_pa )
+         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
+         ivar=ivar, initialize=initialize_variables, index = ih_TFC_ROS_si )
 
     call this%set_history_var(vname='FIRE_INTENSITY', units='kJ/m/s',          &
          long='spitfire fire intensity: kJ/m/s', use_default='active',          &
-         avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
-         ivar=ivar, initialize=initialize_variables, index = ih_fire_intensity_pa )
+         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
+         ivar=ivar, initialize=initialize_variables, index = ih_fire_intensity_si )
 
     call this%set_history_var(vname='FIRE_INTENSITY_AREA_PRODUCT', units='kJ/m/s',          &
          long='spitfire product of fire intensity and burned area (divide by FIRE_AREA to get area-weifghted mean intensity)', &
@@ -4058,34 +4058,34 @@ end subroutine flush_hvars
 
     call this%set_history_var(vname='FIRE_AREA', units='fraction',             &
          long='spitfire fire area burn fraction', use_default='active',                    &
-         avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
-         ivar=ivar, initialize=initialize_variables, index = ih_fire_area_pa )
+         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
+         ivar=ivar, initialize=initialize_variables, index = ih_fire_area_si )
 
     call this%set_history_var(vname='fire_fuel_mef', units='m',                &
          long='spitfire fuel moisture',  use_default='active',                  &
-         avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
-         ivar=ivar, initialize=initialize_variables, index = ih_fire_fuel_mef_pa )
+         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
+         ivar=ivar, initialize=initialize_variables, index = ih_fire_fuel_mef_si )
 
     call this%set_history_var(vname='fire_fuel_bulkd', units='kg biomass/m3',              &
          long='spitfire fuel bulk density',  use_default='active',              &
-         avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
-         ivar=ivar, initialize=initialize_variables, index = ih_fire_fuel_bulkd_pa )
+         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
+         ivar=ivar, initialize=initialize_variables, index = ih_fire_fuel_bulkd_si )
 
     call this%set_history_var(vname='FIRE_FUEL_EFF_MOIST', units='m',          &
          long='spitfire fuel moisture', use_default='active',                   &
-         avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
-         ivar=ivar, initialize=initialize_variables, index = ih_fire_fuel_eff_moist_pa )
+         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
+         ivar=ivar, initialize=initialize_variables, index = ih_fire_fuel_eff_moist_si )
 
     call this%set_history_var(vname='fire_fuel_sav', units='per m',                &
          long='spitfire fuel surface/volume ',  use_default='active',           &
-         avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
-         ivar=ivar, initialize=initialize_variables, index = ih_fire_fuel_sav_pa )
+         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
+         ivar=ivar, initialize=initialize_variables, index = ih_fire_fuel_sav_si )
 
     call this%set_history_var(vname='SUM_FUEL', units='gC m-2',                &
          long='total ground fuel related to ros (omits 1000hr fuels)',          & 
          use_default='active',                                                  & 
-         avgflag='A', vtype=patch_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
-         ivar=ivar, initialize=initialize_variables, index = ih_sum_fuel_pa )
+         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
+         ivar=ivar, initialize=initialize_variables, index = ih_sum_fuel_si )
 
     call this%set_history_var(vname='FUEL_MOISTURE_NFSC', units='-',                &
          long='spitfire size-resolved fuel moisture', use_default='active',       &

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -259,9 +259,11 @@ module FatesHistoryInterfaceMod
 
   integer :: ih_nesterov_fire_danger_si
   integer :: ih_fire_intensity_area_product_si
-  integer :: ih_spitfire_ROS_si
+  integer :: ih_spitfire_ros_si
+  integer :: ih_fire_ros_area_product_si
   integer :: ih_effect_wspeed_si
-  integer :: ih_TFC_ROS_si
+  integer :: ih_tfc_ros_si
+  integer :: ih_tfc_ros_area_product_si
   integer :: ih_fire_intensity_si
   integer :: ih_fire_area_si
   integer :: ih_fire_fuel_bulkd_si
@@ -1737,8 +1739,10 @@ end subroutine flush_hvars
                hio_mortality_si_pft    => this%hvars(ih_mortality_si_pft)%r82d, &
                hio_crownarea_si_pft    => this%hvars(ih_crownarea_si_pft)%r82d, &
                hio_nesterov_fire_danger_si => this%hvars(ih_nesterov_fire_danger_si)%r81d, &
-               hio_spitfire_ROS_si     => this%hvars(ih_spitfire_ROS_si)%r81d, &
-               hio_tfc_ros_si          => this%hvars(ih_TFC_ROS_si)%r81d, &
+               hio_spitfire_ros_si     => this%hvars(ih_spitfire_ros_si)%r81d, &
+               hio_fire_ros_area_product_si=> this%hvars(ih_fire_ros_area_product_si)%r81d, &
+               hio_tfc_ros_si          => this%hvars(ih_tfc_ros_si)%r81d, &
+               hio_tfc_ros_area_product_si => this%hvars(ih_tfc_ros_area_product_si)%r81d, &
                hio_effect_wspeed_si    => this%hvars(ih_effect_wspeed_si)%r81d, &
                hio_fire_intensity_si   => this%hvars(ih_fire_intensity_si)%r81d, &
                hio_fire_intensity_area_product_si => this%hvars(ih_fire_intensity_area_product_si)%r81d, &
@@ -2621,8 +2625,12 @@ end subroutine flush_hvars
                         
             ! Update Fire Variables
             hio_spitfire_ros_si(io_si)         = hio_spitfire_ros_si(io_si) + cpatch%ROS_front * cpatch%area * AREA_INV
+            hio_fire_ros_area_product_si(io_si)= hio_fire_ros_area_product_si(io_si) + &
+                 cpatch%frac_burnt * cpatch%ROS_front * cpatch%area * AREA_INV
             hio_effect_wspeed_si(io_si)        = hio_effect_wspeed_si(io_si) + cpatch%effect_wspeed * cpatch%area * AREA_INV
             hio_tfc_ros_si(io_si)              = hio_tfc_ros_si(io_si) + cpatch%TFC_ROS * cpatch%area * AREA_INV
+            hio_tfc_ros_area_product_si(io_si) = hio_tfc_ros_area_product_si(io_si) + &
+                 cpatch%frac_burnt * cpatch%TFC_ROS * cpatch%area * AREA_INV
             hio_fire_intensity_si(io_si)       = hio_fire_intensity_si(io_si) + cpatch%FI * cpatch%area * AREA_INV
             hio_fire_area_si(io_si)            = hio_fire_area_si(io_si) + cpatch%frac_burnt * cpatch%area * AREA_INV
             hio_fire_fuel_bulkd_si(io_si)      = hio_fire_fuel_bulkd_si(io_si) + cpatch%fuel_bulkd * cpatch%area * AREA_INV
@@ -4026,7 +4034,12 @@ end subroutine flush_hvars
     call this%set_history_var(vname='FIRE_ROS', units='m/min',                 &
          long='fire rate of spread m/min', use_default='active',                &
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
-         ivar=ivar, initialize=initialize_variables, index = ih_spitfire_ROS_si)
+         ivar=ivar, initialize=initialize_variables, index = ih_spitfire_ros_si)
+
+    call this%set_history_var(vname='FIRE_ROS_AREA_PRODUCT', units='m/min',                 &
+         long='product of fire rate of spread (m/min) and burned area (fraction)--divide by FIRE_AREA to get burned-area-weighted-mean ROS', use_default='active',                &
+         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
+         ivar=ivar, initialize=initialize_variables, index = ih_fire_ros_area_product_si)
 
     call this%set_history_var(vname='EFFECT_WSPEED', units='none',             &
          long ='effective windspeed for fire spread', use_default='active',     &
@@ -4036,7 +4049,12 @@ end subroutine flush_hvars
     call this%set_history_var(vname='FIRE_TFC_ROS', units='kgC/m2',              &
          long ='total fuel consumed', use_default='active',                     &
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
-         ivar=ivar, initialize=initialize_variables, index = ih_TFC_ROS_si )
+         ivar=ivar, initialize=initialize_variables, index = ih_tfc_ros_si )
+
+    call this%set_history_var(vname='FIRE_TFC_ROS_AREA_PRODUCT', units='kgC/m2',              &
+         long ='product of total fuel consumed and burned area--divide by FIRE_AREA to get burned-area-weighted-mean TFC', use_default='active',                     &
+         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
+         ivar=ivar, initialize=initialize_variables, index = ih_tfc_ros_area_product_si )
 
     call this%set_history_var(vname='FIRE_INTENSITY', units='kJ/m/s',          &
          long='spitfire fire intensity: kJ/m/s', use_default='active',          &

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -4075,7 +4075,7 @@ end subroutine flush_hvars
          ivar=ivar, initialize=initialize_variables, index = ih_fire_intensity_si )
 
     call this%set_history_var(vname='FIRE_INTENSITY_AREA_PRODUCT', units='kJ/m/s',          &
-         long='spitfire product of fire intensity and burned area (divide by FIRE_AREA to get area-weifghted mean intensity)', &
+         long='spitfire product of fire intensity and burned area (divide by FIRE_AREA to get area-weighted mean intensity)', &
          use_default='active',          &
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
          ivar=ivar, initialize=initialize_variables, index = ih_fire_intensity_area_product_si )
@@ -4085,12 +4085,12 @@ end subroutine flush_hvars
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
          ivar=ivar, initialize=initialize_variables, index = ih_fire_area_si )
 
-    call this%set_history_var(vname='fire_fuel_mef', units='m',                &
+    call this%set_history_var(vname='FIRE_FUEL_MEF', units='m',                &
          long='spitfire fuel moisture',  use_default='active',                  &
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
          ivar=ivar, initialize=initialize_variables, index = ih_fire_fuel_mef_si )
 
-    call this%set_history_var(vname='fire_fuel_bulkd', units='kg biomass/m3',              &
+    call this%set_history_var(vname='FIRE_FUEL_BULKD', units='kg biomass/m3',              &
          long='spitfire fuel bulk density',  use_default='active',              &
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
          ivar=ivar, initialize=initialize_variables, index = ih_fire_fuel_bulkd_si )
@@ -4100,7 +4100,7 @@ end subroutine flush_hvars
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
          ivar=ivar, initialize=initialize_variables, index = ih_fire_fuel_eff_moist_si )
 
-    call this%set_history_var(vname='fire_fuel_sav', units='per m',                &
+    call this%set_history_var(vname='FIRE_FUEL_SAV', units='per m',                &
          long='spitfire fuel surface/volume ',  use_default='active',           &
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
          ivar=ivar, initialize=initialize_variables, index = ih_fire_fuel_sav_si )
@@ -5300,7 +5300,7 @@ end subroutine flush_hvars
           upfreq=1, ivar=ivar, initialize=initialize_variables, index = ih_fire_c_to_atm_si )
    
     call this%set_history_var(vname='FIRE_FLUX', units='g/m^2/s', &
-          long='ED/SPitfire loss to atmosphere of elements', use_default='active', &
+          long='ED-spitfire loss to atmosphere of elements', use_default='active', &
           avgflag='A', vtype=site_elem_r8, hlms='CLM:ALM', flushval=hlm_hio_ignore_val,    &
           upfreq=1, ivar=ivar, initialize=initialize_variables, index = ih_burn_flux_elem )
    


### PR DESCRIPTION
A bunch of updates to fire-related history variables, including moving all of the ones that had been on the patch structure off of it, fixing the fire carbon loss variable to not be zero'd out before history writing, and adding some further diagnostics.

### Description:
Sort of a grab bag of changes, but all related to outputting fire behavior information to the history fields:
1. Eleven variables that had been on the patch structure needed to get moved off of it (so that we can deprecate that way of doing history weighting, see #630).
2. the variable `Fire_Closs` was just passing zeros, because the structure it is on was getting zeroed before the history call. I also added another variable, `FIRE_FLUX `, which has the PARTEH ELEMENT dimension, so that when we start adding nutrients we can keep track of fire-related N and P losses too.  Its possible that we could thus delete `Fire_Closs` as redundant to the carbon index of `FIRE_FLUX` but I haven't done that here.
3. some of the variables, such as fire intensity and rate of spread, were being averaged in an evenly-weighted manner, whether or not a fire had occurred on a given patch on a given timestep.  Since we typically look at monthly or longer period for time averaging, these were thus getting diluted by the many times when no fire was occurring.  So I added a few new variables, like the product (intensity * area).  That way one can calculate the longer-term burned-area-weighted mean intensity as the ratio mean(intensity * area) / mean(area).  The variables that I've added this for are intensity, rate of spread, and total fuel consumption.  The names on this are a bit awkward, but so far I am thinking that calling them XXX_AREA_PRODUCT is simplest so that one can see that they only make sense if you divide by burned area; so they are currently: `FIRE_INTENSITY_AREA_PRODUCT`, `FIRE_ROS_AREA_PRODUCT`, and `FIRE_TFC_ROS_AREA_PRODUCT`. I don't love that, but it seemed safer than calling them averages, since they are not actually average quantities, but needed to calculate the averages.
4. I added three new patch-age-structured variables and one new fuel-pool-structured variable so as to be able to better see what's going on in the fire model.  The three patch-age-structured variables are: `AREA_BURNT_BY_PATCH_AGE`, `FIRE_INTENSITY_BY_PATCH_AGE`, and `SUM_FUEL_BY_PATCH_AGE`.  The fuel-pool-structured variable is the fraction of fuel combusted, which I output as in (3) above, as multiplied by burned area so that one can calculate burned-area-weighted means of this.


### Collaborators:
changes based on discussions with @jkshuman, @rgknox 

### Expectation of Answer Changes:
Expected changes only to the history variables that I've messed with in some way.  I'm not totally sure that I understand why changing the _pa variables to use the site-level weighting leads to greater than roundoff changes, but I think maybe it has to do with patches where the canopy isn't closed not having been weighted properly in the old system (which is part of the reason why we want to get rid of that).


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
none as yet.

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

