### PR TITLE
Use HLM-provided land-use time series data to drive FATES harvest

### DIFF
--- a/biogeochem/EDLoggingMortalityMod.F90
+++ b/biogeochem/EDLoggingMortalityMod.F90
@@ -187,8 +187,8 @@ contains
       integer,  intent(in)  :: pft_i            ! pft index 
       real(r8), intent(in)  :: dbh              ! diameter at breast height (cm)
       integer,  intent(in)  :: canopy_layer     ! canopy layer of this cohort
-      real(r8), intent(in) :: hlm_harvest       ! annual harvest rate per hlm category
-      character(len=64), intent(in) :: hlm_harvest_catnames ! names of hlm harvest categories
+      real(r8), intent(in) :: hlm_harvest(:)       ! annual harvest rate per hlm category
+      character(len=64), intent(in) :: hlm_harvest_catnames(:) ! names of hlm harvest categories
       integer, intent(in) :: use_history        ! patch level anthro_disturbance_label
       real(r8), intent(in) :: secondary_age     ! patch level age_since_anthro_disturbance
       real(r8), intent(out) :: lmort_direct     ! direct (harvestable) mortality fraction

--- a/biogeochem/EDLoggingMortalityMod.F90
+++ b/biogeochem/EDLoggingMortalityMod.F90
@@ -45,7 +45,7 @@ module EDLoggingMortalityMod
    use FatesInterfaceMod , only : hlm_day_of_year 
    use FatesInterfaceMod , only : hlm_days_per_year
    use FatesInterfaceMod , only : hlm_use_lu_harvest
-   use FatesInterfaceMod , only : hlm_use_num_lu_harvest_cats
+   use FatesInterfaceMod , only : hlm_num_lu_harvest_cats
    use FatesInterfaceMod , only : hlm_use_logging 
    use FatesInterfaceMod , only : hlm_use_planthydro
    use FatesConstantsMod , only : itrue,ifalse
@@ -239,7 +239,7 @@ contains
 
                ! determine the annual hlm harvest rate for the current cohort based on patch info
                harvest_rate = 0._r8
-               do h_index = 1,hlm_use_num_lu_harvest_cats
+               do h_index = 1,hlm_num_lu_harvest_cats
                   if (use_history .eq. primaryforest) then
                      if(hlm_harvest_catnames(h_index) .eq. "HARVEST_VH1" .or. &
                         hlm_harvest_catnames(h_index) .eq. "HARVEST_VH2")

--- a/biogeochem/EDLoggingMortalityMod.F90
+++ b/biogeochem/EDLoggingMortalityMod.F90
@@ -289,8 +289,7 @@ contains
 
          ! the area occupied by all plants in the canopy that aren't killed is still disturbed at the harvest rate
          if (canopy_layer .eq. 1) then
-            l_degrad = harvest_rate * (1._r8 - &
-                 (logging_direct_frac + logging_collateral_frac + logging_mechanical_frac)) ! fraction passed to 'degraded' forest.
+            l_degrad = harvest_rate - (lmort_direct + lmort_infra + lmort_collateral) ! fraction passed to 'degraded' forest.
          else
             l_degrad = 0._r8
          endif

--- a/biogeochem/EDLoggingMortalityMod.F90
+++ b/biogeochem/EDLoggingMortalityMod.F90
@@ -60,6 +60,7 @@ module EDLoggingMortalityMod
    use FatesAllometryMod , only : set_root_fraction
    use FatesConstantsMod , only : primaryforest, secondaryforest, secondary_age_threshold
    use FatesConstantsMod , only : fates_tiny
+   use FatesConstantsMod, only : fates_check_param_set
 
    implicit none
    private

--- a/biogeochem/EDLoggingMortalityMod.F90
+++ b/biogeochem/EDLoggingMortalityMod.F90
@@ -210,10 +210,10 @@ contains
 
       ! todo: add a logging_dbhmax parameter, and probably lower the dbhmin one to 30 cm
       ! todo: change the default logging_event_code to 1 september (-244)
-      ! todo: change the default logging_direct_frac to 0.7, which is closer to a clearcut event
-      ! todo: check secondary forest creation
+      ! todo: change the default logging_direct_frac to 1.0 for cmip inputs
       ! todo: check outputs against the LUH2 carbon data
       ! todo: eventually set up distinct harvest practices, each with a set of input paramaeters
+      ! todo: implement harvested carbon inputs
       
       if (logging_time) then 
          ! Pass logging rates to cohort level 
@@ -247,14 +247,16 @@ contains
             call endrun(msg=errMsg(sourcefile, __LINE__))
          endif
 
+         ! transfer of area to secondary land is based on overall area affected, not just logged crown area
+         ! l_degrad accounts for the affected area between logged crowns
          if(EDPftvarcon_inst%woody(pft_i) == 1)then ! only set logging rates for trees
             
             if (dbh >= logging_dbhmin ) then
                lmort_direct = harvest_rate * logging_direct_frac
-               l_degrad = 0._r8
+               l_degrad = harvest_rate * (1._r8 - logging_direct_frac)
             else
                lmort_direct = 0.0_r8
-               l_degrad = harvest_rate * logging_direct_frac
+               l_degrad = harvest_rate
             end if
 
             if (dbh >= logging_dbhmax_infra) then
@@ -281,7 +283,7 @@ contains
             lmort_direct    = 0.0_r8
             lmort_collateral = 0.0_r8
             lmort_infra      = harvest_rate * logging_mechanical_frac
-            l_degrad         = harvest_rate * logging_direct_frac
+            l_degrad         = harvest_rate
          end if
       else 
          lmort_direct    = 0.0_r8

--- a/biogeochem/EDLoggingMortalityMod.F90
+++ b/biogeochem/EDLoggingMortalityMod.F90
@@ -214,101 +214,101 @@ contains
       real(r8), parameter :: months_per_year = 12.0
 
       if (logging_time) then 
-         if(EDPftvarcon_inst%woody(pft_i) == 1)then ! only set logging rates for trees
-
-! todo: add a logging_dbhmax parameter, and probably lower the dbhmin one to 30 cm
-! todo: change the default logging_event_code to 1 september (-244)
-! todo: change the default logging_direct_frac to 0.7, which is closer to a clearcut event
-! todo: check secondary forest creation
-! todo: check outputs against the LUH2 carbon data
-! todo: eventually set up distinct harvest practices, each with a set of input paramaeters
-
-            ! Pass logging rates to cohort level 
-
-            if (hlm_use_lu_harvest == 0) then
-               ! 0=use fates logging parameters directly when logging_time == .true.
-               ! this means harvest the whole cohort area
-               harvest_rate = 1._r8
-
-            else if (hlm_use_lu_harvest == hlm_harvest_area_fraction) then
-               ! 1=use area fraction from hlm
-               ! combine forest and non-forest fracs and then apply:
-               ! primary and secondary area fractions to the logging rates, which are fates parameters
-
-               ! Definitions of the underlying harvest land category variables
-               ! these are hardcoded to match the LUH input data via landuse.timseries file (see dynHarvestMod)
-               ! these are fraction of vegetated area harvested, split into five land category variables
-               ! HARVEST_VH1 = harvest from primary forest
-               ! HARVEST_VH2 = harvest from primary non-forest
-               ! HARVEST_SH1 = harvest from secondary mature forest
-               ! HARVEST_SH2 = harvest from secondary young forest
-               ! HARVEST_SH3 = harvest from secondary non-forest (assume this is young for biomass)
-
-               ! determine the annual hlm harvest rate for the current cohort based on patch info
-               harvest_rate = 0._r8
-               do h_index = 1,hlm_num_lu_harvest_cats
-                  if (use_history .eq. primaryforest) then
-                     if(hlm_harvest_catnames(h_index) .eq. "HARVEST_VH1" .or. &
-                        hlm_harvest_catnames(h_index) .eq. "HARVEST_VH2") then
-                        harvest_rate = harvest_rate + hlm_harvest(h_index)
-                     endif
-                  else if (use_history .eq. secondaryforest .and. &
-                     secondary_age >= secondary_age_threshold) then
-                     if(hlm_harvest_catnames(h_index) .eq. "HARVEST_SH1") then
-                        harvest_rate = harvest_rate + hlm_harvest(h_index)
-                     endif
-                  else if (use_history .eq. secondaryforest .and. &
-                     secondary_age < secondary_age_threshold) then
-                     if(hlm_harvest_catnames(h_index) .eq. "HARVEST_SH2" .or. &
-                        hlm_harvest_catnames(h_index) .eq. "HARVEST_SH3") then
-                        harvest_rate = harvest_rate + hlm_harvest(h_index)
-                     endif
-                  endif
-               end do
-
-               ! normalize by site-level fractio primary or secondary forest fraction
-               ! since harvest_rate is specified in fraction of the gridcell
-               ! also need to put a cap so as not to harvest more primary or secondary area than there is in a gridcell
+         ! todo: add a logging_dbhmax parameter, and probably lower the dbhmin one to 30 cm
+         ! todo: change the default logging_event_code to 1 september (-244)
+         ! todo: change the default logging_direct_frac to 0.7, which is closer to a clearcut event
+         ! todo: check secondary forest creation
+         ! todo: check outputs against the LUH2 carbon data
+         ! todo: eventually set up distinct harvest practices, each with a set of input paramaeters
+         
+         ! Pass logging rates to cohort level 
+         
+         if (hlm_use_lu_harvest == 0) then
+            ! 0=use fates logging parameters directly when logging_time == .true.
+            ! this means harvest the whole cohort area
+            harvest_rate = 1._r8
+            
+         else if (hlm_use_lu_harvest == hlm_harvest_area_fraction) then
+            ! 1=use area fraction from hlm
+            ! combine forest and non-forest fracs and then apply:
+            ! primary and secondary area fractions to the logging rates, which are fates parameters
+            
+            ! Definitions of the underlying harvest land category variables
+            ! these are hardcoded to match the LUH input data via landuse.timseries file (see dynHarvestMod)
+            ! these are fraction of vegetated area harvested, split into five land category variables
+            ! HARVEST_VH1 = harvest from primary forest
+            ! HARVEST_VH2 = harvest from primary non-forest
+            ! HARVEST_SH1 = harvest from secondary mature forest
+            ! HARVEST_SH2 = harvest from secondary young forest
+            ! HARVEST_SH3 = harvest from secondary non-forest (assume this is young for biomass)
+            
+            ! determine the annual hlm harvest rate for the current cohort based on patch info
+            harvest_rate = 0._r8
+            do h_index = 1,hlm_num_lu_harvest_cats
                if (use_history .eq. primaryforest) then
-                  if (frac_site_primary .gt. fates_tiny) then
-                     harvest_rate = min((harvest_rate / frac_site_primary),frac_site_primary)
-                  else
-                     harvest_rate = 0._r8
+                  if(hlm_harvest_catnames(h_index) .eq. "HARVEST_VH1" .or. &
+                       hlm_harvest_catnames(h_index) .eq. "HARVEST_VH2") then
+                     harvest_rate = harvest_rate + hlm_harvest(h_index)
                   endif
-               else
-                  if ((1._r8-frac_site_primary) .gt. fates_tiny) then
-                     harvest_rate = min((harvest_rate / (1._r8-frac_site_primary)),&
-                          (1._r8-frac_site_primary))
-                  else
-                     harvest_rate = 0._r8
+               else if (use_history .eq. secondaryforest .and. &
+                    secondary_age >= secondary_age_threshold) then
+                  if(hlm_harvest_catnames(h_index) .eq. "HARVEST_SH1") then
+                     harvest_rate = harvest_rate + hlm_harvest(h_index)
+                  endif
+               else if (use_history .eq. secondaryforest .and. &
+                    secondary_age < secondary_age_threshold) then
+                  if(hlm_harvest_catnames(h_index) .eq. "HARVEST_SH2" .or. &
+                       hlm_harvest_catnames(h_index) .eq. "HARVEST_SH3") then
+                     harvest_rate = harvest_rate + hlm_harvest(h_index)
                   endif
                endif
+            end do
 
-               ! calculate today's harvest rate
-               ! whether to harvest today has already been determined by IsItLoggingTime
-               ! for icode == 2, icode < 0, and icode > 10000 apply the annual rate one time (no calc)
-               ! Bad logging event flag is caught in IsItLoggingTime, so don't check it here
-               icode = int(logging_event_code)
-               if(icode .eq. 1) then
-                  ! Logging is turned off - not sure why we need another switch
+            ! normalize by site-level fractio primary or secondary forest fraction
+            ! since harvest_rate is specified in fraction of the gridcell
+            ! also need to put a cap so as not to harvest more primary or secondary area than there is in a gridcell
+            if (use_history .eq. primaryforest) then
+               if (frac_site_primary .gt. fates_tiny) then
+                  harvest_rate = min((harvest_rate / frac_site_primary),frac_site_primary)
+               else
                   harvest_rate = 0._r8
-               else if(icode .eq. 3) then
-                  ! Logging event every day - this may not work due to the mortality exclusivity
-                  harvest_rate = harvest_rate / hlm_days_per_year
-               else if(icode .eq. 4) then
-                  ! logging event once a month
-                  if(hlm_current_day.eq.1  ) then
-                     harvest_rate = harvest_rate / months_per_year
-                  end if
-               end if
-
-            else if (hlm_use_lu_harvest == hlm_harvest_carbon) then
-               ! 2=use carbon from hlm
-               ! not implemented yet
-               write(fates_log(),*) 'HLM harvest carbon data not implemented yet. Exiting.'
-               call endrun(msg=errMsg(sourcefile, __LINE__))
+               endif
+            else
+               if ((1._r8-frac_site_primary) .gt. fates_tiny) then
+                  harvest_rate = min((harvest_rate / (1._r8-frac_site_primary)),&
+                       (1._r8-frac_site_primary))
+               else
+                  harvest_rate = 0._r8
+               endif
             endif
 
+            ! calculate today's harvest rate
+            ! whether to harvest today has already been determined by IsItLoggingTime
+            ! for icode == 2, icode < 0, and icode > 10000 apply the annual rate one time (no calc)
+            ! Bad logging event flag is caught in IsItLoggingTime, so don't check it here
+            icode = int(logging_event_code)
+            if(icode .eq. 1) then
+               ! Logging is turned off - not sure why we need another switch
+               harvest_rate = 0._r8
+            else if(icode .eq. 3) then
+               ! Logging event every day - this may not work due to the mortality exclusivity
+               harvest_rate = harvest_rate / hlm_days_per_year
+            else if(icode .eq. 4) then
+               ! logging event once a month
+               if(hlm_current_day.eq.1  ) then
+                  harvest_rate = harvest_rate / months_per_year
+               end if
+            end if
+
+         else if (hlm_use_lu_harvest == hlm_harvest_carbon) then
+            ! 2=use carbon from hlm
+            ! not implemented yet
+            write(fates_log(),*) 'HLM harvest carbon data not implemented yet. Exiting.'
+            call endrun(msg=errMsg(sourcefile, __LINE__))
+         endif
+
+         if(EDPftvarcon_inst%woody(pft_i) == 1)then ! only set logging rates for trees
+            
             if (dbh >= logging_dbhmin ) then
                lmort_direct = harvest_rate * logging_direct_frac * adjustment
                l_degrad = 0._r8
@@ -337,11 +337,11 @@ contains
                lmort_collateral = 0._r8
             endif
 
-         else
+         else  ! non-woody plants in the canopy still become moved to secondary patch at same rate
             lmort_direct    = 0.0_r8
             lmort_collateral = 0.0_r8
-            lmort_infra      = 0.0_r8
-            l_degrad         = 0.0_r8
+            lmort_infra      = harvest_rate * logging_mechanical_frac * adjustment
+            l_degrad         = harvest_rate * logging_direct_frac * adjustment
          end if
       else 
          lmort_direct    = 0.0_r8

--- a/biogeochem/EDLoggingMortalityMod.F90
+++ b/biogeochem/EDLoggingMortalityMod.F90
@@ -44,6 +44,8 @@ module EDLoggingMortalityMod
    use FatesInterfaceMod , only : hlm_model_day
    use FatesInterfaceMod , only : hlm_day_of_year 
    use FatesInterfaceMod , only : hlm_days_per_year
+   use FatesInterfaceMod , only : hlm_use_harvest_area
+   use FatesInterfaceMod , only : hlm_use_harvest_c
    use FatesInterfaceMod , only : hlm_use_logging 
    use FatesInterfaceMod , only : hlm_use_planthydro
    use FatesConstantsMod , only : itrue,ifalse
@@ -106,6 +108,8 @@ contains
       icode = int(logging_event_code)
 
       if(hlm_use_logging.eq.ifalse) return
+
+! todo: deal with hlm_use_harvest_area and the do_harvest in bc_in
 
       if(icode .eq. 1) then
          ! Logging is turned off
@@ -188,6 +192,8 @@ contains
  
       if (logging_time) then 
          if(EDPftvarcon_inst%woody(pft_i) == 1)then ! only set logging rates for trees
+
+! todo: deal with hlm_use_harvest_area vs. biomass here also
 
             ! Pass logging rates to cohort level 
 

--- a/biogeochem/EDLoggingMortalityMod.F90
+++ b/biogeochem/EDLoggingMortalityMod.F90
@@ -33,6 +33,7 @@ module EDLoggingMortalityMod
    use EDParamsMod       , only : logging_export_frac
    use EDParamsMod       , only : logging_event_code
    use EDParamsMod       , only : logging_dbhmin
+   use EDParamsMod       , only : logging_dbhmax
    use EDParamsMod       , only : logging_collateral_frac 
    use EDParamsMod       , only : logging_direct_frac
    use EDParamsMod       , only : logging_mechanical_frac 
@@ -207,7 +208,7 @@ contains
       ! Local variables
       real(r8) :: harvest_rate ! the final harvest rate to apply to this cohort today
 
-      ! todo: add a logging_dbhmax parameter, and probably lower the dbhmin one to 30 cm
+      ! todo: probably lower the dbhmin default value to 30 cm
       ! todo: change the default logging_event_code to 1 september (-244)
       ! todo: change the default logging_direct_frac to 1.0 for cmip inputs
       ! todo: check outputs against the LUH2 carbon data
@@ -250,7 +251,8 @@ contains
          ! l_degrad accounts for the affected area between logged crowns
          if(EDPftvarcon_inst%woody(pft_i) == 1)then ! only set logging rates for trees
             
-            if (dbh >= logging_dbhmin ) then
+            if (dbh >= logging_dbhmin .and. .not. &
+                 ((logging_dbhmax < fates_check_param_set) .and. (dbh < logging_dbhmax )) ) then
                lmort_direct = harvest_rate * logging_direct_frac
                l_degrad = harvest_rate * (1._r8 - logging_direct_frac)
             else

--- a/biogeochem/EDMortalityFunctionsMod.F90
+++ b/biogeochem/EDMortalityFunctionsMod.F90
@@ -198,7 +198,11 @@ contains
                                currentCohort%lmort_direct,                       &
                                currentCohort%lmort_collateral,                    &
                                currentCohort%lmort_infra,                        &
-                               currentCohort%l_degrad)
+                               currentCohort%l_degrad, &
+                               bc_in%hlm_harvest, &
+                               bc_in%hlm_harvest_catnames, &
+                               currentCohort%patchptr%anthro_disturbance_label, &
+                               currentCohort%patchptr%age_since_anthro_disturbance)
 
     
     

--- a/biogeochem/EDMortalityFunctionsMod.F90
+++ b/biogeochem/EDMortalityFunctionsMod.F90
@@ -208,7 +208,7 @@ if (hlm_use_ed_prescribed_phys .eq. ifalse) then
 
  ! ============================================================================
 
- subroutine Mortality_Derivative( currentSite, currentCohort, bc_in)
+ subroutine Mortality_Derivative( currentSite, currentCohort, bc_in, frac_site_primary)
 
     !
     ! !DESCRIPTION:
@@ -224,6 +224,7 @@ if (hlm_use_ed_prescribed_phys .eq. ifalse) then
     type(ed_site_type), intent(inout), target  :: currentSite
     type(ed_cohort_type),intent(inout), target :: currentCohort
     type(bc_in_type), intent(in)               :: bc_in
+    real(r8), intent(in)                       :: frac_site_primary
     !
     ! !LOCAL VARIABLES:
     real(r8) :: cmort    ! starvation mortality rate (fraction per year)
@@ -249,7 +250,8 @@ if (hlm_use_ed_prescribed_phys .eq. ifalse) then
                                bc_in%hlm_harvest, &
                                bc_in%hlm_harvest_catnames, &
                                currentCohort%patchptr%anthro_disturbance_label, &
-                               currentCohort%patchptr%age_since_anthro_disturbance)
+                               currentCohort%patchptr%age_since_anthro_disturbance, &
+                               frac_site_primary)
 
     
     

--- a/biogeochem/EDMortalityFunctionsMod.F90
+++ b/biogeochem/EDMortalityFunctionsMod.F90
@@ -247,7 +247,7 @@ if (hlm_use_ed_prescribed_phys .eq. ifalse) then
                                currentCohort%lmort_collateral,                    &
                                currentCohort%lmort_infra,                        &
                                currentCohort%l_degrad, &
-                               bc_in%hlm_harvest, &
+                               bc_in%hlm_harvest_rates, &
                                bc_in%hlm_harvest_catnames, &
                                currentCohort%patchptr%anthro_disturbance_label, &
                                currentCohort%patchptr%age_since_anthro_disturbance, &

--- a/biogeochem/EDMortalityFunctionsMod.F90
+++ b/biogeochem/EDMortalityFunctionsMod.F90
@@ -249,6 +249,7 @@ if (hlm_use_ed_prescribed_phys .eq. ifalse) then
                                currentCohort%l_degrad, &
                                bc_in%hlm_harvest_rates, &
                                bc_in%hlm_harvest_catnames, &
+                               bc_in%hlm_harvest_units, &
                                currentCohort%patchptr%anthro_disturbance_label, &
                                currentCohort%patchptr%age_since_anthro_disturbance, &
                                frac_site_primary)

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -215,6 +215,7 @@ contains
                 lmort_direct,lmort_collateral,lmort_infra,l_degrad,&
                 bc_in%hlm_harvest_rates, &
                 bc_in%hlm_harvest_catnames, &
+                bc_in%hlm_harvest_units, &
                 currentPatch%anthro_disturbance_label, &
                 currentPatch%age_since_anthro_disturbance, &
                 frac_site_primary)

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -474,7 +474,7 @@ contains
     real(r8) :: leaf_burn_frac               ! fraction of leaves burned in fire
                                              ! for both woody and grass species
     real(r8) :: leaf_m                       ! leaf mass during partial burn calculations
-    logical  :: foundfirstprimary            ! logical for finding the first primary forest patch
+    logical  :: found_youngest_primary       ! logical for finding the first primary forest patch
     !---------------------------------------------------------------------
 
     storesmallcohort => null() ! storage of the smallest cohort for insertion routine
@@ -1091,18 +1091,19 @@ contains
 
       !*************************/
       !**  INSERT NEW PATCH(ES) INTO LINKED LIST    
-      !**********`***************/
+      !*************************/
        
       if ( site_areadis_primary .gt. nearzero) then
           currentPatch               => currentSite%youngest_patch
-          ! insert first primary patch after all the secondary patches, if there are any
+          ! insert new youngest primary patch after all the secondary patches, if there are any.
+          ! this requires first finding the current youngest primary to insert the new one ahead of
           if (currentPatch%anthro_disturbance_label .eq. secondaryforest ) then
-             foundfirstprimary = .false.
-             do while(associated(currentPatch) .and. .not. foundfirstprimary) 
+             found_youngest_primary = .false.
+             do while(associated(currentPatch) .and. .not. found_youngest_primary) 
                 currentPatch => currentPatch%older
                 if (associated(currentPatch)) then
                    if (currentPatch%anthro_disturbance_label .eq. primaryforest) then
-                      foundfirstprimary = .true.
+                      found_youngest_primary = .true.
                    endif
                 endif
              end do
@@ -1113,7 +1114,8 @@ contains
                 currentPatch%younger%older => new_patch_primary
                 currentPatch%younger       => new_patch_primary
              else
-                ! the case where we haven't, and are putting a primary patch at the oldest end of the 
+                ! the case where we haven't, because the patches are all secondaary, 
+                ! and are putting a primary patch at the oldest end of the 
                 ! linked list (not sure how this could happen, but who knows...)
                 new_patch_primary%older    => null()
                 new_patch_primary%younger  => currentSite%oldest_patch

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -301,22 +301,18 @@ contains
        ! equivalent to the fradction loged to account for transfer of interstitial ground area to new secondary lands
        if ( logging_time .and. &
             (currentPatch%area - currentPatch%total_canopy_area) .gt. fates_tiny ) then
-! The canopy is NOT closed. 
+          ! The canopy is NOT closed. 
+
           call get_harvest_rate_area (currentPatch%anthro_disturbance_label, bc_in%hlm_harvest_catnames, &
                bc_in%hlm_harvest_rates, frac_site_primary, currentPatch%age_since_anthro_disturbance, harvest_rate)
 
           currentPatch%disturbance_rates(dtype_ilog) = currentPatch%disturbance_rates(dtype_ilog) + &
                (currentPatch%area - currentPatch%total_canopy_area) * harvest_rate / currentPatch%area
 
-          ! Non-harvested part of the logging disturbance rate                                                                                                                                                                
+          ! Non-harvested part of the logging disturbance rate
           dist_rate_ldist_notharvested = dist_rate_ldist_notharvested + &
                (currentPatch%area - currentPatch%total_canopy_area) * harvest_rate / currentPatch%area
        endif
-! Sum of disturbance rates for different classes of disturbance across all patches in this site. 
-       do i_dist = 1,N_DIST_TYPES
-          site_in%potential_disturbance_rates(i_dist) = site_in%potential_disturbance_rates(i_dist) + &
-               currentPatch%disturbance_rates(i_dist) * currentPatch%area * AREA_INV
-       end do
 
        ! fraction of the logging disturbance rate that is non-harvested
        if (currentPatch%disturbance_rates(dtype_ilog) .gt. nearzero) then
@@ -326,6 +322,12 @@ contains
 
        ! Fire Disturbance Rate
        currentPatch%disturbance_rates(dtype_ifire) = currentPatch%frac_burnt
+
+       ! calculate a disgnostic sum of disturbance rates for different classes of disturbance across all patches in this site. 
+       do i_dist = 1,N_DIST_TYPES
+          site_in%potential_disturbance_rates(i_dist) = site_in%potential_disturbance_rates(i_dist) + &
+               currentPatch%disturbance_rates(i_dist) * currentPatch%area * AREA_INV
+       end do
 
        ! Fires can't burn the whole patch, as this causes /0 errors. 
        if (debug) then

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -193,7 +193,11 @@ contains
           currentCohort%frmort = frmort
 
           call LoggingMortality_frac(currentCohort%pft, currentCohort%dbh, currentCohort%canopy_layer, &
-                lmort_direct,lmort_collateral,lmort_infra,l_degrad )
+                lmort_direct,lmort_collateral,lmort_infra,l_degrad,&
+                bc_in%hlm_harvest, &
+                bc_in%hlm_harvest_catnames, &
+                currentPatch%anthro_disturbance_label, &
+                currentPatch%age_since_anthro_disturbance)
          
           currentCohort%lmort_direct     = lmort_direct
           currentCohort%lmort_collateral = lmort_collateral

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -293,14 +293,14 @@ contains
 
        ! for non-closed-canopy areas subject to logging, add an additional increment of area disturbed
        ! equivalent to the fradction loged to account for transfer of interstitial ground area to new secondary lands
-       if ( currentPatch%disturbance_rates(dtype_ilog) .gt. fates_tiny .and. &
+       if ( logging_time .and. &
             (currentPatch%area - currentPatch%total_canopy_area) .gt. fates_tiny ) then
 
           call get_harvest_rate_area (currentPatch%anthro_disturbance_label, bc_in%hlm_harvest_catnames, bc_in%hlm_harvest, &
                  frac_site_primary, currentPatch%age_since_anthro_disturbance, harvest_rate)
 
           currentPatch%disturbance_rates(dtype_ilog) = currentPatch%disturbance_rates(dtype_ilog) + &
-               (currentPatch%area - currentPatch%total_canopy_area) * harvest_rate * AREA_INV
+               (currentPatch%area - currentPatch%total_canopy_area) * harvest_rate / currentPatch%area
        endif
 
        do i_dist = 1,N_DIST_TYPES

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -172,12 +172,23 @@ contains
     real(r8) :: dist_rate_ldist_notharvested
     integer  :: threshold_sizeclass
     integer  :: i_dist
+    real(r8) :: frac_site_primary
 
     !----------------------------------------------------------------------------------------------
     ! Calculate Mortality Rates (these were previously calculated during growth derivatives)
     ! And the same rates in understory plants have already been applied to %dndt
     !----------------------------------------------------------------------------------------------
     
+    ! first calculate the fractino of the site that is primary land
+    frac_site_primary = 0._r8
+    currentPatch => site_in%oldest_patch
+    do while (associated(currentPatch))   
+       if (currentPatch%anthro_disturbance_label .eq. primaryforest) then
+          frac_site_primary = frac_site_primary + currentPatch%area * AREA_INV
+       endif
+       currentPatch => currentPatch%younger
+    end do
+
     currentPatch => site_in%oldest_patch
     do while (associated(currentPatch))   
 
@@ -204,7 +215,8 @@ contains
                 bc_in%hlm_harvest, &
                 bc_in%hlm_harvest_catnames, &
                 currentPatch%anthro_disturbance_label, &
-                currentPatch%age_since_anthro_disturbance)
+                currentPatch%age_since_anthro_disturbance, &
+                frac_site_primary)
          
           currentCohort%lmort_direct     = lmort_direct
           currentCohort%lmort_collateral = lmort_collateral

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -1161,7 +1161,7 @@ contains
     ! !USES:
     !
     ! !ARGUMENTS:
-    type(ed_site_type), intent(in), target  :: currentSite 
+    type(ed_site_type), intent(inout), target  :: currentSite 
     !
     ! !LOCAL VARIABLES:
     real(r8)                     :: areatot
@@ -1216,6 +1216,9 @@ contains
                  currentSite%mass_balance(el)%patch_resize_err + mass_gain
 
        end do
+
+       currentSite%patch_area_conservation_error = currentSite%patch_area_conservation_error + &
+            area_site-areatot
        
        largestPatch%area = largestPatch%area + (area_site-areatot)
        

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -2003,7 +2003,7 @@ contains
     if (label .eq. secondaryforest) then
        new_patch%age_since_anthro_disturbance = age
     else
-       new_patch%age_since_anthro_disturbance = -1._r8   ! replace with fates_unset_r8 when possible
+       new_patch%age_since_anthro_disturbance = fates_unset_r8
     endif
 
     ! This new value will be generated when the calculate disturbance

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -233,6 +233,20 @@ contains
     ! zero the diagnostic disturbance rate fields
     site_in%potential_disturbance_rates(1:N_DIST_TYPES) = 0._r8
 
+    ! summarize how open the canopy is prior to resolving the disturbance
+    currentPatch => site_in%oldest_patch
+    do while (associated(currentPatch))
+       currentPatch%total_canopy_area = 0._r8
+       currentCohort => currentPatch%shortest
+       do while(associated(currentCohort))   
+          if(currentCohort%canopy_layer==1)then
+             currentPatch%total_canopy_area = currentPatch%total_canopy_area + currentCohort%c_area
+          end if
+          currentCohort => currentCohort%taller
+       end do
+       currentPatch => currentPatch%younger
+    end do
+
     currentPatch => site_in%oldest_patch
     do while (associated(currentPatch))   
        

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -1161,7 +1161,7 @@ contains
     ! !USES:
     !
     ! !ARGUMENTS:
-    type(ed_site_type), intent(inout), target  :: currentSite 
+    type(ed_site_type), intent(in), target  :: currentSite 
     !
     ! !LOCAL VARIABLES:
     real(r8)                     :: areatot
@@ -1216,9 +1216,6 @@ contains
                  currentSite%mass_balance(el)%patch_resize_err + mass_gain
 
        end do
-
-       currentSite%patch_area_conservation_error = currentSite%patch_area_conservation_error + &
-            area_site-areatot
        
        largestPatch%area = largestPatch%area + (area_site-areatot)
        

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -297,15 +297,6 @@ contains
           currentCohort => currentCohort%taller
        enddo !currentCohort
 
-       ! fraction of the logging disturbance rate that is non-harvested
-       if (currentPatch%disturbance_rates(dtype_ilog) .gt. nearzero) then
-          currentPatch%fract_ldist_not_harvested = dist_rate_ldist_notharvested / &
-               currentPatch%disturbance_rates(dtype_ilog)
-       endif
-
-       ! Fire Disturbance Rate
-       currentPatch%disturbance_rates(dtype_ifire) = currentPatch%frac_burnt
-
        ! for non-closed-canopy areas subject to logging, add an additional increment of area disturbed
        ! equivalent to the fradction loged to account for transfer of interstitial ground area to new secondary lands
        if ( logging_time .and. &
@@ -316,12 +307,25 @@ contains
 
           currentPatch%disturbance_rates(dtype_ilog) = currentPatch%disturbance_rates(dtype_ilog) + &
                (currentPatch%area - currentPatch%total_canopy_area) * harvest_rate / currentPatch%area
+
+          ! Non-harvested part of the logging disturbance rate                                                                                                                                                                
+          dist_rate_ldist_notharvested = dist_rate_ldist_notharvested + &
+               (currentPatch%area - currentPatch%total_canopy_area) * harvest_rate / currentPatch%area
        endif
 ! Sum of disturbance rates for different classes of disturbance across all patches in this site. 
        do i_dist = 1,N_DIST_TYPES
           site_in%potential_disturbance_rates(i_dist) = site_in%potential_disturbance_rates(i_dist) + &
                currentPatch%disturbance_rates(i_dist) * currentPatch%area * AREA_INV
        end do
+
+       ! fraction of the logging disturbance rate that is non-harvested
+       if (currentPatch%disturbance_rates(dtype_ilog) .gt. nearzero) then
+          currentPatch%fract_ldist_not_harvested = dist_rate_ldist_notharvested / &
+               currentPatch%disturbance_rates(dtype_ilog)
+       endif
+
+       ! Fire Disturbance Rate
+       currentPatch%disturbance_rates(dtype_ifire) = currentPatch%frac_burnt
 
        ! Fires can't burn the whole patch, as this causes /0 errors. 
        if (debug) then

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -84,6 +84,7 @@ module EDPatchDynamicsMod
   use PRTGenericMod,          only : prt_cnp_flex_allom_hyp
   use SFParamsMod,            only : SF_VAL_CWD_FRAC
   use EDParamsMod,            only : logging_event_code
+  use EDParamsMod,            only : logging_export_frac
 
   ! CIME globals
   use shr_infnan_mod       , only : nan => shr_infnan_nan, assignment(=)
@@ -223,14 +224,15 @@ contains
           currentCohort%lmort_collateral = lmort_collateral
           currentCohort%lmort_infra      = lmort_infra
           currentCohort%l_degrad         = l_degrad
-          
-          if (currentCohort%canopy_layer==1) then
+
+          ! estimate the wood product (trunk_product_site)
+          if (currentCohort%canopy_layer>=1) then
              site_in%harvest_carbon_flux = site_in%harvest_carbon_flux + &
-                  currentCohort%lmort_direct * &
+                  currentCohort%lmort_direct * currentCohort%n * &
                   ( currentCohort%prt%GetState(sapw_organ, all_carbon_elements) + &
                   currentCohort%prt%GetState(struct_organ, all_carbon_elements)) * &
                   EDPftvarcon_inst%allom_agb_frac(currentCohort%pft) * &
-                  SF_val_CWD_frac(ncwd)
+                  SF_val_CWD_frac(ncwd) * logging_export_frac
           endif
 
           currentCohort => currentCohort%taller

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -213,7 +213,7 @@ contains
 
           call LoggingMortality_frac(currentCohort%pft, currentCohort%dbh, currentCohort%canopy_layer, &
                 lmort_direct,lmort_collateral,lmort_infra,l_degrad,&
-                bc_in%hlm_harvest, &
+                bc_in%hlm_harvest_rates, &
                 bc_in%hlm_harvest_catnames, &
                 currentPatch%anthro_disturbance_label, &
                 currentPatch%age_since_anthro_disturbance, &
@@ -310,8 +310,8 @@ contains
        if ( logging_time .and. &
             (currentPatch%area - currentPatch%total_canopy_area) .gt. fates_tiny ) then
 ! The canopy is NOT closed. 
-          call get_harvest_rate_area (currentPatch%anthro_disturbance_label, bc_in%hlm_harvest_catnames, bc_in%hlm_harvest, &
-                 frac_site_primary, currentPatch%age_since_anthro_disturbance, harvest_rate)
+          call get_harvest_rate_area (currentPatch%anthro_disturbance_label, bc_in%hlm_harvest_catnames, &
+               bc_in%hlm_harvest_rates, frac_site_primary, currentPatch%age_since_anthro_disturbance, harvest_rate)
 
           currentPatch%disturbance_rates(dtype_ilog) = currentPatch%disturbance_rates(dtype_ilog) + &
                (currentPatch%area - currentPatch%total_canopy_area) * harvest_rate / currentPatch%area

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -2436,6 +2436,8 @@ contains
     inv_sum_area = 1.0_r8/(dp%area + rp%area)
     
     rp%age = (dp%age * dp%area + rp%age * rp%area) * inv_sum_area
+    rp%age_since_anthro_disturbance = (dp%age_since_anthro_disturbance * dp%area &
+         + rp%age_since_anthro_disturbance * rp%area) * inv_sum_area
 
     rp%age_class = get_age_class_index(rp%age)
     

--- a/main/EDMainMod.F90
+++ b/main/EDMainMod.F90
@@ -241,6 +241,9 @@ contains
     ! Patch dynamics sub-routines: fusion, new patch creation (spwaning), termination.
     !*********************************************************************************
 
+    ! zero site-level patch area error tracking
+    currentSite%patch_area_conservation_error = 0._r8
+
     ! make new patches from disturbed land
     if ( hlm_use_ed_st3.eq.ifalse ) then
        call spawn_patches(currentSite, bc_in)

--- a/main/EDMainMod.F90
+++ b/main/EDMainMod.F90
@@ -68,6 +68,7 @@ module EDMainMod
   use FatesAllometryMod        , only : h_allom,tree_sai,tree_lai
   use FatesPlantHydraulicsMod  , only : UpdateSizeDepRhizHydStates
   use EDLoggingMortalityMod    , only : IsItLoggingTime
+  use EDPatchDynamicsMod       , only : get_frac_site_primary
   use FatesGlobals             , only : endrun => fates_endrun
   use ChecksBalancesMod        , only : SiteMassStock
   use EDMortalityFunctionsMod  , only : Mortality_Derivative
@@ -307,15 +308,8 @@ contains
     !-----------------------------------------------------------------------
     real(r8) :: frac_site_primary
 
-    ! first calculate the fractino of the site that is primary land
-    frac_site_primary = 0._r8
-    currentPatch => currentSite%oldest_patch
-    do while (associated(currentPatch))   
-       if (currentPatch%anthro_disturbance_label .eq. primaryforest) then
-          frac_site_primary = frac_site_primary + currentPatch%area * AREA_INV
-       endif
-       currentPatch => currentPatch%younger
-    end do
+
+    call get_frac_site_primary(currentSite, frac_site_primary)
 
     ! Set a pointer to this sites carbon12 mass balance
     site_cmass => currentSite%mass_balance(element_pos(carbon12_element))

--- a/main/EDMainMod.F90
+++ b/main/EDMainMod.F90
@@ -71,7 +71,7 @@ module EDMainMod
   use FatesGlobals             , only : endrun => fates_endrun
   use ChecksBalancesMod        , only : SiteMassStock
   use EDMortalityFunctionsMod  , only : Mortality_Derivative
-
+  use EDTypesMod               , only : AREA_INV
   use PRTGenericMod,          only : carbon12_element
   use PRTGenericMod,          only : all_carbon_elements
   use PRTGenericMod,          only : leaf_organ
@@ -305,6 +305,17 @@ contains
 
     real(r8) :: current_npp           ! place holder for calculating npp each year in prescribed physiology mode
     !-----------------------------------------------------------------------
+    real(r8) :: frac_site_primary
+
+    ! first calculate the fractino of the site that is primary land
+    frac_site_primary = 0._r8
+    currentPatch => currentSite%oldest_patch
+    do while (associated(currentPatch))   
+       if (currentPatch%anthro_disturbance_label .eq. primaryforest) then
+          frac_site_primary = frac_site_primary + currentPatch%area * AREA_INV
+       endif
+       currentPatch => currentPatch%younger
+    end do
 
     ! Set a pointer to this sites carbon12 mass balance
     site_cmass => currentSite%mass_balance(element_pos(carbon12_element))
@@ -338,7 +349,7 @@ contains
           ft = currentCohort%pft
 
           ! Calculate the mortality derivatives
-          call Mortality_Derivative( currentSite, currentCohort, bc_in )
+          call Mortality_Derivative( currentSite, currentCohort, bc_in, frac_site_primary )
 
           ! -----------------------------------------------------------------------------
           ! Apply Plant Allocation and Reactive Transport

--- a/main/EDMainMod.F90
+++ b/main/EDMainMod.F90
@@ -241,9 +241,6 @@ contains
     ! Patch dynamics sub-routines: fusion, new patch creation (spwaning), termination.
     !*********************************************************************************
 
-    ! zero site-level patch area error tracking
-    currentSite%patch_area_conservation_error = 0._r8
-
     ! make new patches from disturbed land
     if ( hlm_use_ed_st3.eq.ifalse ) then
        call spawn_patches(currentSite, bc_in)

--- a/main/EDParamsMod.F90
+++ b/main/EDParamsMod.F90
@@ -126,7 +126,6 @@ module EDParamsMod
 
    real(r8),protected,public :: logging_dbhmax              ! Maximum dbh at which logging is applied (cm)
                                                             ! Typically associated with fire suppression
-                                                            ! (THIS PARAMETER IS NOT USED YET)
    character(len=param_string_length),parameter,public :: logging_name_dbhmax = "fates_logging_dbhmax"
 
 

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -2118,6 +2118,7 @@ contains
      ! -----------------------------------------------------------------------------------
     use FatesConstantsMod  , only : fates_check_param_set
     use FatesConstantsMod  , only : itrue, ifalse
+    use EDParamsMod        , only : logging_mechanical_frac, logging_collateral_frac, logging_direct_frac
     
      ! Argument
      logical, intent(in) :: is_master    ! Only log if this is the master proc
@@ -2172,7 +2173,13 @@ contains
         call endrun(msg=errMsg(sourcefile, __LINE__))
      end if
 
-
+     ! logging parameters, make sure they make sense
+     if ( (logging_mechanical_frac + logging_collateral_frac + logging_direct_frac) .gt. 1._r8) then
+        write(fates_log(),*) 'the sum of logging_mechanical_frac + logging_collateral_frac + logging_direct_frac'
+        write(fates_log(),*) 'must be less than or equal to 1.'
+        write(fates_log(),*) 'Exiting'
+        call endrun(msg=errMsg(sourcefile, __LINE__))
+     endif
      
      do ipft = 1,npft
         

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -771,6 +771,7 @@ module EDTypesMod
      real(r8) :: disturbance_rates_secondary_to_secondary(N_DIST_TYPES)  ! actual disturbance rates from secondary patches to secondary patches [m2/m2/day]
      real(r8) :: potential_disturbance_rates(N_DIST_TYPES)               ! "potential" disturb rates (i.e. prior to the "which is most" logic) [m2/m2/day]
      real(r8) :: primary_land_patchfusion_error                          ! error term in total area of primary patches associated with patch fusion [m2/m2/day]
+     real(r8) :: patch_area_conservation_error                           ! error term in total area of patches associated with patch area conservation [m2/m2/day]   
      
   end type ed_site_type
 

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -764,6 +764,12 @@ module EDTypesMod
 
      ! Canopy Spread
      real(r8) ::  spread                                          ! dynamic canopy allometric term [unitless]
+
+     ! site-level variables to keep track of the disturbance rates, both actual and "potential"
+     real(r8) :: disturbance_rates_primary_to_primary(N_DIST_TYPES)      ! actual disturbance rates from primary patches to primary patches [m2/m2/day]
+     real(r8) :: disturbance_rates_primary_to_secondary(N_DIST_TYPES)    ! actual disturbance rates from primary patches to secondary patches [m2/m2/day]
+     real(r8) :: disturbance_rates_secondary_to_secondary(N_DIST_TYPES)  ! actual disturbance rates from secondary patches to secondary patches [m2/m2/day]
+     real(r8) :: potential_disturbance_rates(N_DIST_TYPES)               ! "potential" disturb rates (i.e. prior to the "which is most" logic) [m2/m2/day]
      
   end type ed_site_type
 

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -771,6 +771,7 @@ module EDTypesMod
      real(r8) :: disturbance_rates_secondary_to_secondary(N_DIST_TYPES)  ! actual disturbance rates from secondary patches to secondary patches [m2/m2/day]
      real(r8) :: potential_disturbance_rates(N_DIST_TYPES)               ! "potential" disturb rates (i.e. prior to the "which is most" logic) [m2/m2/day]
      real(r8) :: primary_land_patchfusion_error                          ! error term in total area of primary patches associated with patch fusion [m2/m2/day]
+     real(r8) :: harvest_carbon_flux                                     ! diagnostic site level flux of carbon as harvested plants [kg C / m2 / day]
      
   end type ed_site_type
 

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -770,6 +770,7 @@ module EDTypesMod
      real(r8) :: disturbance_rates_primary_to_secondary(N_DIST_TYPES)    ! actual disturbance rates from primary patches to secondary patches [m2/m2/day]
      real(r8) :: disturbance_rates_secondary_to_secondary(N_DIST_TYPES)  ! actual disturbance rates from secondary patches to secondary patches [m2/m2/day]
      real(r8) :: potential_disturbance_rates(N_DIST_TYPES)               ! "potential" disturb rates (i.e. prior to the "which is most" logic) [m2/m2/day]
+     real(r8) :: primary_land_patchfusion_error                          ! error term in total area of primary patches associated with patch fusion [m2/m2/day]
      
   end type ed_site_type
 

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -948,6 +948,8 @@ module EDTypesMod
      write(fates_log(),*) 'pa%c_stomata          = ',cpatch%c_stomata
      write(fates_log(),*) 'pa%c_lblayer          = ',cpatch%c_lblayer
      write(fates_log(),*) 'pa%disturbance_rate   = ',cpatch%disturbance_rate
+     write(fates_log(),*) 'pa%disturbance_rates  = ',cpatch%disturbance_rates(:)
+     write(fates_log(),*) 'pa%anthro_disturbance_label = ',cpatch%anthro_disturbance_label
      write(fates_log(),*) '----------------------------------------'
      do el = 1,num_elements
         write(fates_log(),*) 'element id: ',element_list(el)

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -771,7 +771,6 @@ module EDTypesMod
      real(r8) :: disturbance_rates_secondary_to_secondary(N_DIST_TYPES)  ! actual disturbance rates from secondary patches to secondary patches [m2/m2/day]
      real(r8) :: potential_disturbance_rates(N_DIST_TYPES)               ! "potential" disturb rates (i.e. prior to the "which is most" logic) [m2/m2/day]
      real(r8) :: primary_land_patchfusion_error                          ! error term in total area of primary patches associated with patch fusion [m2/m2/day]
-     real(r8) :: patch_area_conservation_error                           ! error term in total area of patches associated with patch area conservation [m2/m2/day]   
      
   end type ed_site_type
 

--- a/main/FatesConstantsMod.F90
+++ b/main/FatesConstantsMod.F90
@@ -34,7 +34,7 @@ module FatesConstantsMod
   integer, parameter, public :: n_anthro_disturbance_categories = 2
   integer, parameter, public :: primaryforest = 1
   integer, parameter, public :: secondaryforest = 2
-  integer, parameter, public :: secondary_age_threshold = 94 ! less than this value is young
+  real(fates_r8), parameter, public :: secondary_age_threshold = 94._fates_r8 ! less than this value is young secondary land
                                                             ! based on average age of global
                                                             ! secondary 1900s land in hurtt-2011
   

--- a/main/FatesConstantsMod.F90
+++ b/main/FatesConstantsMod.F90
@@ -137,7 +137,10 @@ module FatesConstantsMod
   ! Conversion: years per day. assume HLM uses 365 day calendar.  
   ! If we need to link to 365.25-day-calendared HLM, rewire to pass through interface
   real(fates_r8), parameter, public :: years_per_day = 1.0_fates_r8/365.00_fates_r8
-  
+
+  ! Conversion: months per year
+  real(fates_r8), parameter, public :: months_per_year = 12.0_fates_r8
+
   ! Physical constants
 
   ! universal gas constant [J/K/kmol]

--- a/main/FatesConstantsMod.F90
+++ b/main/FatesConstantsMod.F90
@@ -30,6 +30,9 @@ module FatesConstantsMod
   integer, parameter, public :: n_anthro_disturbance_categories = 2
   integer, parameter, public :: primaryforest = 1
   integer, parameter, public :: secondaryforest = 2
+  integer, parameter, public :: secondary_age_threshold = 94 ! less than this value is young
+                                                            ! based on average age of global
+                                                            ! secondary 1900s land in hurtt-2011
   
   ! Error Tolerances
 

--- a/main/FatesConstantsMod.F90
+++ b/main/FatesConstantsMod.F90
@@ -37,6 +37,10 @@ module FatesConstantsMod
   real(fates_r8), parameter, public :: secondary_age_threshold = 94._fates_r8 ! less than this value is young secondary land
                                                             ! based on average age of global
                                                             ! secondary 1900s land in hurtt-2011
+
+  ! integer labels for specifying harvest units
+  integer, parameter, public :: hlm_harvest_area_fraction = 1 ! Code for harvesting by area
+  integer, parameter, public :: hlm_harvest_carbon = 2 ! Code for harvesting based on carbon extracted. 
   
   ! Error Tolerances
 

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -199,7 +199,6 @@ module FatesHistoryInterfaceMod
   integer :: ih_logging_disturbance_rate_si
   integer :: ih_fall_disturbance_rate_si
   integer :: ih_potential_disturbance_rate_si
-  integer :: ih_harvest_primary_bcin_si
 
   ! Indices to site by size-class by age variables
   integer :: ih_nplant_si_scag
@@ -1639,7 +1638,7 @@ end subroutine flush_hvars
 
   ! ====================================================================================
   
-  subroutine update_history_dyn(this,nc,nsites,sites,bc_in)
+  subroutine update_history_dyn(this,nc,nsites,sites)
     
     ! ---------------------------------------------------------------------------------
     ! This is the call to update the history IO arrays that are expected to only change
@@ -1666,7 +1665,6 @@ end subroutine flush_hvars
     integer                 , intent(in)            :: nc   ! clump index
     integer                 , intent(in)            :: nsites
     type(ed_site_type)      , intent(inout), target :: sites(nsites)
-    type(bc_in_type)        , intent(in)            :: bc_in(nsites)
     
     ! Locals
     type(litter_type), pointer         :: litt_c   ! Pointer to the carbon12 litter pool
@@ -1797,7 +1795,6 @@ end subroutine flush_hvars
                hio_logging_disturbance_rate_si   => this%hvars(ih_logging_disturbance_rate_si)%r81d, &
                hio_fall_disturbance_rate_si      => this%hvars(ih_fall_disturbance_rate_si)%r81d, &
                hio_potential_disturbance_rate_si => this%hvars(ih_potential_disturbance_rate_si)%r81d, &
-               hio_harvest_primary_bcin_si => this%hvars(ih_harvest_primary_bcin_si)%r81d, &
                hio_gpp_si_scpf         => this%hvars(ih_gpp_si_scpf)%r82d, &
                hio_npp_totl_si_scpf    => this%hvars(ih_npp_totl_si_scpf)%r82d, &
                hio_npp_leaf_si_scpf    => this%hvars(ih_npp_leaf_si_scpf)%r82d, &
@@ -2082,8 +2079,6 @@ end subroutine flush_hvars
               sites(s)%disturbance_rates_secondary_to_secondary(dtype_ifall)
 
          hio_potential_disturbance_rate_si = sum(sites(s)%potential_disturbance_rates(1:N_DIST_TYPES))
-
-         hio_harvest_primary_bcin_si = sum(bc_in(s)%hlm_harvest(1:2))
 
          ipa = 0
          cpatch => sites(s)%oldest_patch
@@ -4288,11 +4283,6 @@ end subroutine flush_hvars
          long='Potential (i.e., including unresolved) disturbance rate',  use_default='active',     &
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
          ivar=ivar, initialize=initialize_variables, index = ih_potential_disturbance_rate_si )
-
-    call this%set_history_var(vname='HARVEST_PRIMARY_RATE_BCIN', units='m2 m-2 d-1',                   &
-         long='harvest disturbance rate input from HLM',  use_default='active',     &
-         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
-         ivar=ivar, initialize=initialize_variables, index = ih_harvest_primary_bcin_si )
 
     ! Canopy Resistance 
 

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -433,7 +433,7 @@ module FatesHistoryInterfaceMod
   integer :: ih_recruitment_si_pft
   integer :: ih_mortality_si_pft
   integer :: ih_crownarea_si_pft
-
+  integer :: ih_canopycrownarea_si_pft
 
   ! indices to (site x patch-age) variables
   integer :: ih_area_si_age
@@ -1752,6 +1752,7 @@ end subroutine flush_hvars
                hio_recruitment_si_pft  => this%hvars(ih_recruitment_si_pft)%r82d, &
                hio_mortality_si_pft    => this%hvars(ih_mortality_si_pft)%r82d, &
                hio_crownarea_si_pft    => this%hvars(ih_crownarea_si_pft)%r82d, &
+               hio_canopycrownarea_si_pft  => this%hvars(ih_canopycrownarea_si_pft)%r82d, &
                hio_nesterov_fire_danger_si => this%hvars(ih_nesterov_fire_danger_si)%r81d, &
                hio_spitfire_ros_si     => this%hvars(ih_spitfire_ros_si)%r81d, &
                hio_fire_ros_area_product_si=> this%hvars(ih_fire_ros_area_product_si)%r81d, &
@@ -2245,6 +2246,12 @@ end subroutine flush_hvars
                ! Update PFT crown area
                hio_crownarea_si_pft(io_si, ft) = hio_crownarea_si_pft(io_si, ft) + &
                     ccohort%c_area 
+
+               if (ccohort%canopy_layer .eq. 1) then
+                  ! Update PFT canopy crown area
+                  hio_canopycrownarea_si_pft(io_si, ft) = hio_canopycrownarea_si_pft(io_si, ft) + &
+                       ccohort%c_area 
+               end if
 
                ! update total biomass per age bin
                hio_biomass_si_age(io_si,cpatch%age_class) = hio_biomass_si_age(io_si,cpatch%age_class) &
@@ -3935,6 +3942,11 @@ end subroutine flush_hvars
          long='total PFT level crown area', use_default='inactive',              &
          avgflag='A', vtype=site_pft_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1, &
          ivar=ivar, initialize=initialize_variables, index = ih_crownarea_si_pft )
+    
+    call this%set_history_var(vname='PFTcanopycrownarea',  units='m2/ha',            &
+         long='total PFT-level canopy-layer crown area', use_default='inactive',     &
+         avgflag='A', vtype=site_pft_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1, &
+         ivar=ivar, initialize=initialize_variables, index = ih_canopycrownarea_si_pft )
     
     call this%set_history_var(vname='PFTnindivs',  units='indiv / m2',            &
          long='total PFT level number of individuals', use_default='active',       &

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -191,6 +191,7 @@ module FatesHistoryInterfaceMod
   integer :: ih_canopy_biomass_si
   integer :: ih_understory_biomass_si
 
+  integer :: ih_primaryland_fusion_error_si
   integer :: ih_disturbance_rate_p2p_si
   integer :: ih_disturbance_rate_p2s_si
   integer :: ih_disturbance_rate_s2s_si
@@ -1786,6 +1787,7 @@ end subroutine flush_hvars
                hio_agb_si              => this%hvars(ih_agb_si)%r81d, &
                hio_canopy_biomass_si   => this%hvars(ih_canopy_biomass_si)%r81d, &
                hio_understory_biomass_si   => this%hvars(ih_understory_biomass_si)%r81d, &
+               hio_primaryland_fusion_error_si    => this%hvars(ih_primaryland_fusion_error_si)%r81d, &
                hio_disturbance_rate_p2p_si       => this%hvars(ih_disturbance_rate_p2p_si)%r81d, &
                hio_disturbance_rate_p2s_si       => this%hvars(ih_disturbance_rate_p2s_si)%r81d, &
                hio_disturbance_rate_s2s_si       => this%hvars(ih_disturbance_rate_s2s_si)%r81d, &
@@ -2055,6 +2057,9 @@ end subroutine flush_hvars
             this%hvars(ih_h2oveg_growturn_err_si)%r81d(io_si) = sites(s)%si_hydr%h2oveg_growturn_err
             this%hvars(ih_h2oveg_pheno_err_si)%r81d(io_si)    = sites(s)%si_hydr%h2oveg_pheno_err
          end if
+
+         ! error in primary lands from patch fusion
+         hio_primaryland_fusion_error_si = sites(s)%primary_land_patchfusion_error
 
          ! output site-level disturbance rates
          hio_disturbance_rate_p2p_si = sum(sites(s)%disturbance_rates_primary_to_primary(1:N_DIST_TYPES))
@@ -4239,6 +4244,11 @@ end subroutine flush_hvars
          ivar=ivar, initialize=initialize_variables, index = ih_understory_biomass_si )
 
     ! disturbance rates
+    call this%set_history_var(vname='PRIMARYLAND_PATCHFUSION_ERROR', units='m2 m-2 d-1',                   &
+         long='Error in total primary lands associated with patch fusion',  use_default='active',     &
+         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
+         ivar=ivar, initialize=initialize_variables, index = ih_primaryland_fusion_error_si )
+
     call this%set_history_var(vname='DISTURBANCE_RATE_P2P', units='m2 m-2 d-1',                   &
          long='Disturbance rate from primary to primary lands',  use_default='active',     &
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -4290,7 +4290,7 @@ end subroutine flush_hvars
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
          ivar=ivar, initialize=initialize_variables, index = ih_logging_disturbance_rate_si )
 
-    call this%set_history_var(vname='DISTURBANCE_RATE_FALL', units='m2 m-2 d-1',                   &
+    call this%set_history_var(vname='DISTURBANCE_RATE_TREEFALL', units='m2 m-2 d-1',                   &
          long='Disturbance rate from treefall',  use_default='active',     &
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
          ivar=ivar, initialize=initialize_variables, index = ih_fall_disturbance_rate_si )

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -199,6 +199,7 @@ module FatesHistoryInterfaceMod
   integer :: ih_logging_disturbance_rate_si
   integer :: ih_fall_disturbance_rate_si
   integer :: ih_potential_disturbance_rate_si
+  integer :: ih_harvest_primary_bcin_si
 
   ! Indices to site by size-class by age variables
   integer :: ih_nplant_si_scag
@@ -1638,7 +1639,7 @@ end subroutine flush_hvars
 
   ! ====================================================================================
   
-  subroutine update_history_dyn(this,nc,nsites,sites)
+  subroutine update_history_dyn(this,nc,nsites,sites,bc_in)
     
     ! ---------------------------------------------------------------------------------
     ! This is the call to update the history IO arrays that are expected to only change
@@ -1665,6 +1666,7 @@ end subroutine flush_hvars
     integer                 , intent(in)            :: nc   ! clump index
     integer                 , intent(in)            :: nsites
     type(ed_site_type)      , intent(inout), target :: sites(nsites)
+    type(bc_in_type)        , intent(in)            :: bc_in(nsites)
     
     ! Locals
     type(litter_type), pointer         :: litt_c   ! Pointer to the carbon12 litter pool
@@ -1795,6 +1797,7 @@ end subroutine flush_hvars
                hio_logging_disturbance_rate_si   => this%hvars(ih_logging_disturbance_rate_si)%r81d, &
                hio_fall_disturbance_rate_si      => this%hvars(ih_fall_disturbance_rate_si)%r81d, &
                hio_potential_disturbance_rate_si => this%hvars(ih_potential_disturbance_rate_si)%r81d, &
+               hio_harvest_primary_bcin_si => this%hvars(ih_harvest_primary_bcin_si)%r81d, &
                hio_gpp_si_scpf         => this%hvars(ih_gpp_si_scpf)%r82d, &
                hio_npp_totl_si_scpf    => this%hvars(ih_npp_totl_si_scpf)%r82d, &
                hio_npp_leaf_si_scpf    => this%hvars(ih_npp_leaf_si_scpf)%r82d, &
@@ -2079,6 +2082,8 @@ end subroutine flush_hvars
               sites(s)%disturbance_rates_secondary_to_secondary(dtype_ifall)
 
          hio_potential_disturbance_rate_si = sum(sites(s)%potential_disturbance_rates(1:N_DIST_TYPES))
+
+         hio_harvest_primary_bcin_si = sum(bc_in(s)%hlm_harvest(1:2))
 
          ipa = 0
          cpatch => sites(s)%oldest_patch
@@ -4283,6 +4288,11 @@ end subroutine flush_hvars
          long='Potential (i.e., including unresolved) disturbance rate',  use_default='active',     &
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
          ivar=ivar, initialize=initialize_variables, index = ih_potential_disturbance_rate_si )
+
+    call this%set_history_var(vname='HARVEST_PRIMARY_RATE_BCIN', units='m2 m-2 d-1',                   &
+         long='harvest disturbance rate input from HLM',  use_default='active',     &
+         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
+         ivar=ivar, initialize=initialize_variables, index = ih_harvest_primary_bcin_si )
 
     ! Canopy Resistance 
 

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -2062,28 +2062,28 @@ end subroutine flush_hvars
          end if
 
          ! error in primary lands from patch fusion
-         hio_primaryland_fusion_error_si = sites(s)%primary_land_patchfusion_error
+         hio_primaryland_fusion_error_si(io_si) = sites(s)%primary_land_patchfusion_error
 
          ! output site-level disturbance rates
-         hio_disturbance_rate_p2p_si = sum(sites(s)%disturbance_rates_primary_to_primary(1:N_DIST_TYPES))
-         hio_disturbance_rate_p2s_si = sum(sites(s)%disturbance_rates_primary_to_secondary(1:N_DIST_TYPES))
-         hio_disturbance_rate_s2s_si = sum(sites(s)%disturbance_rates_secondary_to_secondary(1:N_DIST_TYPES))
+         hio_disturbance_rate_p2p_si(io_si) = sum(sites(s)%disturbance_rates_primary_to_primary(1:N_DIST_TYPES))
+         hio_disturbance_rate_p2s_si(io_si) = sum(sites(s)%disturbance_rates_primary_to_secondary(1:N_DIST_TYPES))
+         hio_disturbance_rate_s2s_si(io_si) = sum(sites(s)%disturbance_rates_secondary_to_secondary(1:N_DIST_TYPES))
 
-         hio_fire_disturbance_rate_si = sites(s)%disturbance_rates_primary_to_primary(dtype_ifire) + &
+         hio_fire_disturbance_rate_si(io_si) = sites(s)%disturbance_rates_primary_to_primary(dtype_ifire) + &
               sites(s)%disturbance_rates_primary_to_secondary(dtype_ifire) + &
               sites(s)%disturbance_rates_secondary_to_secondary(dtype_ifire)
 
-         hio_logging_disturbance_rate_si = sites(s)%disturbance_rates_primary_to_primary(dtype_ilog) + &
+         hio_logging_disturbance_rate_si(io_si) = sites(s)%disturbance_rates_primary_to_primary(dtype_ilog) + &
               sites(s)%disturbance_rates_primary_to_secondary(dtype_ilog) + &
               sites(s)%disturbance_rates_secondary_to_secondary(dtype_ilog)
 
-         hio_fall_disturbance_rate_si = sites(s)%disturbance_rates_primary_to_primary(dtype_ifall) + &
+         hio_fall_disturbance_rate_si(io_si) = sites(s)%disturbance_rates_primary_to_primary(dtype_ifall) + &
               sites(s)%disturbance_rates_primary_to_secondary(dtype_ifall) + &
               sites(s)%disturbance_rates_secondary_to_secondary(dtype_ifall)
 
-         hio_potential_disturbance_rate_si = sum(sites(s)%potential_disturbance_rates(1:N_DIST_TYPES))
+         hio_potential_disturbance_rate_si(io_si) = sum(sites(s)%potential_disturbance_rates(1:N_DIST_TYPES))
 
-         hio_harvest_carbonflux_si = sites(s)%harvest_carbon_flux
+         hio_harvest_carbonflux_si(io_si) = sites(s)%harvest_carbon_flux
 
          ipa = 0
          cpatch => sites(s)%oldest_patch

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -199,6 +199,7 @@ module FatesHistoryInterfaceMod
   integer :: ih_logging_disturbance_rate_si
   integer :: ih_fall_disturbance_rate_si
   integer :: ih_potential_disturbance_rate_si
+  integer :: ih_harvest_carbonflux_si
 
   ! Indices to site by size-class by age variables
   integer :: ih_nplant_si_scag
@@ -1795,6 +1796,7 @@ end subroutine flush_hvars
                hio_logging_disturbance_rate_si   => this%hvars(ih_logging_disturbance_rate_si)%r81d, &
                hio_fall_disturbance_rate_si      => this%hvars(ih_fall_disturbance_rate_si)%r81d, &
                hio_potential_disturbance_rate_si => this%hvars(ih_potential_disturbance_rate_si)%r81d, &
+               hio_harvest_carbonflux_si => this%hvars(ih_harvest_carbonflux_si)%r81d, &
                hio_gpp_si_scpf         => this%hvars(ih_gpp_si_scpf)%r82d, &
                hio_npp_totl_si_scpf    => this%hvars(ih_npp_totl_si_scpf)%r82d, &
                hio_npp_leaf_si_scpf    => this%hvars(ih_npp_leaf_si_scpf)%r82d, &
@@ -2079,6 +2081,8 @@ end subroutine flush_hvars
               sites(s)%disturbance_rates_secondary_to_secondary(dtype_ifall)
 
          hio_potential_disturbance_rate_si = sum(sites(s)%potential_disturbance_rates(1:N_DIST_TYPES))
+
+         hio_harvest_carbonflux_si = sites(s)%harvest_carbon_flux
 
          ipa = 0
          cpatch => sites(s)%oldest_patch
@@ -4283,6 +4287,11 @@ end subroutine flush_hvars
          long='Potential (i.e., including unresolved) disturbance rate',  use_default='active',     &
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
          ivar=ivar, initialize=initialize_variables, index = ih_potential_disturbance_rate_si )
+
+    call this%set_history_var(vname='HARVEST_CARBON_FLUX', units='kg C m-2 d-1',                   &
+         long='Harvest carbon flux',  use_default='active',     &
+         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
+         ivar=ivar, initialize=initialize_variables, index = ih_harvest_carbonflux_si )
 
     ! Canopy Resistance 
 

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -191,7 +191,6 @@ module FatesHistoryInterfaceMod
   integer :: ih_canopy_biomass_si
   integer :: ih_understory_biomass_si
 
-  integer :: ih_patch_area_conservation_error_si
   integer :: ih_primaryland_fusion_error_si
   integer :: ih_disturbance_rate_p2p_si
   integer :: ih_disturbance_rate_p2s_si
@@ -1790,7 +1789,6 @@ end subroutine flush_hvars
                hio_agb_si              => this%hvars(ih_agb_si)%r81d, &
                hio_canopy_biomass_si   => this%hvars(ih_canopy_biomass_si)%r81d, &
                hio_understory_biomass_si   => this%hvars(ih_understory_biomass_si)%r81d, &
-               hio_patch_area_conservation_error_si => this%hvars(ih_patch_area_conservation_error_si)%r81d, &
                hio_primaryland_fusion_error_si    => this%hvars(ih_primaryland_fusion_error_si)%r81d, &
                hio_disturbance_rate_p2p_si       => this%hvars(ih_disturbance_rate_p2p_si)%r81d, &
                hio_disturbance_rate_p2s_si       => this%hvars(ih_disturbance_rate_p2s_si)%r81d, &
@@ -2065,9 +2063,6 @@ end subroutine flush_hvars
 
          ! error in primary lands from patch fusion
          hio_primaryland_fusion_error_si = sites(s)%primary_land_patchfusion_error
-
-         ! total error in patch area fixed during conservation check
-         hio_patch_area_conservation_error_si = sites(s)%patch_area_conservation_error
 
          ! output site-level disturbance rates
          hio_disturbance_rate_p2p_si = sum(sites(s)%disturbance_rates_primary_to_primary(1:N_DIST_TYPES))
@@ -4254,11 +4249,6 @@ end subroutine flush_hvars
          ivar=ivar, initialize=initialize_variables, index = ih_understory_biomass_si )
 
     ! disturbance rates
-    call this%set_history_var(vname='PATCH_AREA_CONSERVATION_ERROR', units='m2 m-2 d-1',                   &
-         long='Error in total patch area fixed to ensure conservation',  use_default='active',     &
-         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
-         ivar=ivar, initialize=initialize_variables, index = ih_patch_area_conservation_error_si )
-
     call this%set_history_var(vname='PRIMARYLAND_PATCHFUSION_ERROR', units='m2 m-2 d-1',                   &
          long='Error in total primary lands associated with patch fusion',  use_default='active',     &
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -191,6 +191,7 @@ module FatesHistoryInterfaceMod
   integer :: ih_canopy_biomass_si
   integer :: ih_understory_biomass_si
 
+  integer :: ih_patch_area_conservation_error_si
   integer :: ih_primaryland_fusion_error_si
   integer :: ih_disturbance_rate_p2p_si
   integer :: ih_disturbance_rate_p2s_si
@@ -1789,6 +1790,7 @@ end subroutine flush_hvars
                hio_agb_si              => this%hvars(ih_agb_si)%r81d, &
                hio_canopy_biomass_si   => this%hvars(ih_canopy_biomass_si)%r81d, &
                hio_understory_biomass_si   => this%hvars(ih_understory_biomass_si)%r81d, &
+               hio_patch_area_conservation_error_si => this%hvars(ih_patch_area_conservation_error_si)%r81d, &
                hio_primaryland_fusion_error_si    => this%hvars(ih_primaryland_fusion_error_si)%r81d, &
                hio_disturbance_rate_p2p_si       => this%hvars(ih_disturbance_rate_p2p_si)%r81d, &
                hio_disturbance_rate_p2s_si       => this%hvars(ih_disturbance_rate_p2s_si)%r81d, &
@@ -2063,6 +2065,9 @@ end subroutine flush_hvars
 
          ! error in primary lands from patch fusion
          hio_primaryland_fusion_error_si = sites(s)%primary_land_patchfusion_error
+
+         ! total error in patch area fixed during conservation check
+         hio_patch_area_conservation_error_si = sites(s)%patch_area_conservation_error
 
          ! output site-level disturbance rates
          hio_disturbance_rate_p2p_si = sum(sites(s)%disturbance_rates_primary_to_primary(1:N_DIST_TYPES))
@@ -4249,6 +4254,11 @@ end subroutine flush_hvars
          ivar=ivar, initialize=initialize_variables, index = ih_understory_biomass_si )
 
     ! disturbance rates
+    call this%set_history_var(vname='PATCH_AREA_CONSERVATION_ERROR', units='m2 m-2 d-1',                   &
+         long='Error in total patch area fixed to ensure conservation',  use_default='active',     &
+         avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
+         ivar=ivar, initialize=initialize_variables, index = ih_patch_area_conservation_error_si )
+
     call this%set_history_var(vname='PRIMARYLAND_PATCHFUSION_ERROR', units='m2 m-2 d-1',                   &
          long='Error in total primary lands associated with patch fusion',  use_default='active',     &
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -130,32 +130,30 @@ module FatesInterfaceMod
                                                    ! 1 = TRUE, 0 = FALSE
 
 
-   integer, public, protected :: hlm_use_harvest_area    ! This flag signals whether or not to use
+   integer, public, protected :: hlm_use_lu_harvest      ! This flag signals whether or not to use
                                                          ! harvest area data from the hlm
-                                                         ! If TRUE, it automatically sets
-                                                         ! hlm_use_logging to TRUE
-                                                         ! Only one of hlm_use_harvest_area
-                                                         ! or hlm_use_harvest_c can be TRUE
+                                                         ! 0 = do not use lu harvest from hlm
+                                                         ! 1 = use area fraction of vegetated land
+                                                         ! from from hlm
+                                                         ! 2 = use carbon from hlm
+                                                         ! If 1 or 2, it automatically sets
+                                                         ! hlm_use_logging to 1
 
-   integer, public, protected :: hlm_use_harvest_c       ! This flag signals whether or not to use
-                                                         ! harvest carbon data from the hlm
-                                                         ! If TRUE, it automatically sets
-                                                         ! hlm_use_logging to TRUE
-                                                         ! Only one of hlm_use_harvest_area
-                                                         ! or hlm_use_harvest_c can be TRUE
-                                                         ! These data are not available yet
+   integer, public, protected :: hlm_num_lu_harvest_cats    ! number of hlm harvest categories
+                                                         ! this is the first dimension of:
+                                                         ! harvest_rates in dynHarvestMod
+                                                         ! bc_in%hlm_harvest and bc_in%hlm_harvest_catnames
+
 
    integer, public, protected :: hlm_use_logging       ! This flag signals whether or not to use
                                                        ! the logging module
-                                                         ! If hlm_use_harvest_area or
-                                                         ! hlm_use_harvest_c are NOT true,
+                                                         ! If hlm_use_lu_harvest is zero,
                                                          ! then logging is determined by
                                                          ! the fates parameter file
-                                                         ! If hlm_use_harvest_area or
-                                                         ! hlm_use_harvest_c are TRUE,
+                                                         ! If hlm_use_lu_harvest is non-zero,
                                                          ! then this flag is automatically
-                                                         ! set and logging is determined
-                                                         ! by the harvest input from the hlm
+                                                         ! set to 1 and logging is determined
+                                                         ! by the lu harvest input from the hlm
 
    integer, public, protected :: hlm_use_planthydro    ! This flag signals whether or not to use
                                                        ! plant hydraulics (bchristo/xu methods)
@@ -491,7 +489,9 @@ module FatesInterfaceMod
 
       logical :: hlm_do_harvest_today           ! denotes whether hlm harvest data
                                                 ! are available for today
-      real(r8),allocatable :: hlm_harvest(:)    ! harvest data from hlm
+      real(r8),allocatable :: hlm_harvest(:)    ! annual harvest rate per cat from hlm for a site
+      character(len=64), allocatable :: hlm_harvest_catnames(:)  ! names of hlm_harvest d1
+
 
    end type bc_in_type
 
@@ -693,7 +693,7 @@ contains
    ! ====================================================================================
    
 
-   subroutine allocate_bcin(bc_in, nlevsoil_in, nlevdecomp_in, harvest_bounds)
+   subroutine allocate_bcin(bc_in, nlevsoil_in, nlevdecomp_in, num_lu_harvest_cats)
       
       ! ---------------------------------------------------------------------------------
       ! Allocate and Initialze the FATES boundary condition vectors
@@ -703,7 +703,7 @@ contains
       type(bc_in_type), intent(inout) :: bc_in
       integer,intent(in)              :: nlevsoil_in
       integer,intent(in)              :: nlevdecomp_in
-      type(bounds_type),intent(in)    :: harvest_bounds
+      integer,intent(in)              :: num_lu_harvest_cats
       
       ! Allocate input boundaries
 
@@ -818,11 +818,10 @@ contains
 
       ! Land use
 
-      ! harvest flags denote data from hlm,
-      ! while the logging flag signifies only that logging is occurring,
-      ! which could also just be FATES logging
-      if (hlm_use_harvest_area .or. hlm_use_harvest_c) then
-         allocate(bc_in%harvest(harvest_bounds%begg:harvest_bounds%endg))
+      ! harvest flag denote data from hlm,
+      ! while the logging flag signifies only that logging is occurring (which could just be FATES logging)
+      if (hlm_use_lu_harvest .gt. 0) then
+         allocate(bc_in%hlm_harvest(num_lu_harvest_cats))
       end if
 
       return
@@ -1469,8 +1468,8 @@ contains
          hlm_parteh_mode   = unset_int
          hlm_use_spitfire  = unset_int
          hlm_use_planthydro = unset_int
-         hlm_use_harvest_area   = unset_int
-         hlm_use_harvest_c   = unset_int
+         hlm_use_lu_harvest   = unset_int
+         hlm_use_num_lu_harvest_cats   = unset_int
          hlm_use_logging   = unset_int
          hlm_use_ed_st3    = unset_int
          hlm_use_ed_prescribed_phys = unset_int
@@ -1521,16 +1520,16 @@ contains
                write(fates_log(), *) '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
          end if
 
-         if ( .not.((hlm_use_harvest_area .eq.1).or.(hlm_use_harvest_area.eq.0))    ) then
+         if ( (hlm_use_lu_harvest .lt. 0).or.(hlm_use_lu_harvest .gt. 2) ) then
             if (fates_global_verbose()) then
-               write(fates_log(), *) 'The FATES namelist do_harvest flag must be 0 or 1, exiting'
+               write(fates_log(), *) 'The FATES lu_harvest flag must be 0 or 1 or 2, exiting'
             end if
             call endrun(msg=errMsg(sourcefile, __LINE__))
          end if
 
-         if ( .not.((hlm_use_harvest_c .eq.1).or.(hlm_use_harvest_c.eq.0))    ) then
+         if ( (hlm_use_num_lu_harvest_cats .lt. 0) ) then
             if (fates_global_verbose()) then
-               write(fates_log(), *) 'The FATES namelist do_harvest flag must be 0 or 1, exiting'
+               write(fates_log(), *) 'The FATES number of hlm harvest cats must be >= 0, exiting'
             end if
             call endrun(msg=errMsg(sourcefile, __LINE__))
          end if
@@ -1747,16 +1746,16 @@ contains
                   write(fates_log(),*) 'Transfering hlm_use_planthydro= ',ival,' to FATES'
                end if
 
-            case('use_harvest_area')
-               hlm_use_harvest_area = ival
+            case('use_lu_harvest')
+               hlm_use_lu_harvest = ival
                if (fates_global_verbose()) then
-                  write(fates_log(),*) 'Transfering hlm_use_harvest_area= ',ival,' to FATES'
+                  write(fates_log(),*) 'Transfering hlm_use_lu_harvest= ',ival,' to FATES'
                end if
 
-            case('use_harvest_c')
-               hlm_use_harvest_c = ival
+            case('use_num_lu_harvest_cats')
+               hlm_use_num_lu_harvest_cats = ival
                if (fates_global_verbose()) then
-                  write(fates_log(),*) 'Transfering hlm_use_harvest_c= ',ival,' to FATES'
+                  write(fates_log(),*) 'Transfering hlm_use_num_lu_harvest_cats= ',ival,' to FATES'
                end if
 
             case('use_logging')

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -1469,7 +1469,7 @@ contains
          hlm_use_spitfire  = unset_int
          hlm_use_planthydro = unset_int
          hlm_use_lu_harvest   = unset_int
-         hlm_use_num_lu_harvest_cats   = unset_int
+         hlm_num_lu_harvest_cats   = unset_int
          hlm_use_logging   = unset_int
          hlm_use_ed_st3    = unset_int
          hlm_use_ed_prescribed_phys = unset_int
@@ -1527,7 +1527,7 @@ contains
             call endrun(msg=errMsg(sourcefile, __LINE__))
          end if
 
-         if ( (hlm_use_num_lu_harvest_cats .lt. 0) ) then
+         if ( (hlm_num_lu_harvest_cats .lt. 0) ) then
             if (fates_global_verbose()) then
                write(fates_log(), *) 'The FATES number of hlm harvest cats must be >= 0, exiting'
             end if
@@ -1752,10 +1752,10 @@ contains
                   write(fates_log(),*) 'Transfering hlm_use_lu_harvest= ',ival,' to FATES'
                end if
 
-            case('use_num_lu_harvest_cats')
-               hlm_use_num_lu_harvest_cats = ival
+            case('num_lu_harvest_cats')
+               hlm_num_lu_harvest_cats = ival
                if (fates_global_verbose()) then
-                  write(fates_log(),*) 'Transfering hlm_use_num_lu_harvest_cats= ',ival,' to FATES'
+                  write(fates_log(),*) 'Transfering hlm_num_lu_harvest_cats= ',ival,' to FATES'
                end if
 
             case('use_logging')

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -363,7 +363,7 @@ contains
       ! harvest flag denote data from hlm,
       ! while the logging flag signifies only that logging is occurring (which could just be FATES logging)
       if (hlm_use_lu_harvest .gt. 0) then
-         allocate(bc_in%hlm_harvest(num_lu_harvest_cats))
+         allocate(bc_in%hlm_harvest_rates(num_lu_harvest_cats))
          allocate(bc_in%hlm_harvest_catnames(num_lu_harvest_cats))
       end if
 

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -363,6 +363,7 @@ contains
       ! while the logging flag signifies only that logging is occurring (which could just be FATES logging)
       if (hlm_use_lu_harvest .gt. 0) then
          allocate(bc_in%hlm_harvest(num_lu_harvest_cats))
+         allocate(bc_in%hlm_harvest_catnames(num_lu_harvest_cats))
       end if
 
       return

--- a/main/FatesInterfaceTypesMod.F90
+++ b/main/FatesInterfaceTypesMod.F90
@@ -100,7 +100,7 @@ module FatesInterfaceTypesMod
    integer, public :: hlm_num_lu_harvest_cats    ! number of hlm harvest categories (e.g. primary forest harvest, secondary young forest harvest, etc.)
                                                          ! this is the first dimension of:
                                                          ! harvest_rates in dynHarvestMod
-                                                         ! bc_in%hlm_harvest and bc_in%hlm_harvest_catnames
+                                                         ! bc_in%hlm_harvest_rates and bc_in%hlm_harvest_catnames
 
    integer, public :: hlm_use_logging       ! This flag signals whether or not to use
                                                        ! the logging module
@@ -449,9 +449,7 @@ module FatesInterfaceTypesMod
       
       ! Land use
       ! ---------------------------------------------------------------------------------
-      logical :: hlm_do_harvest_today           ! denotes whether hlm harvest data
-                                                ! are available for today
-      real(r8),allocatable :: hlm_harvest(:)    ! annual harvest rate per cat from hlm for a site
+      real(r8),allocatable :: hlm_harvest_rates(:)    ! annual harvest rate per cat from hlm for a site
       character(len=64), allocatable :: hlm_harvest_catnames(:)  ! names of hlm_harvest d1
 
       ! Fixed biogeography mode 

--- a/main/FatesInterfaceTypesMod.F90
+++ b/main/FatesInterfaceTypesMod.F90
@@ -97,7 +97,7 @@ module FatesInterfaceTypesMod
                                                          ! If 1 or 2, it automatically sets
                                                          ! hlm_use_logging to 1
 
-   integer, public :: hlm_num_lu_harvest_cats    ! number of hlm harvest categories
+   integer, public :: hlm_num_lu_harvest_cats    ! number of hlm harvest categories (e.g. primary forest harvest, secondary young forest harvest, etc.)
                                                          ! this is the first dimension of:
                                                          ! harvest_rates in dynHarvestMod
                                                          ! bc_in%hlm_harvest and bc_in%hlm_harvest_catnames

--- a/main/FatesInterfaceTypesMod.F90
+++ b/main/FatesInterfaceTypesMod.F90
@@ -450,7 +450,10 @@ module FatesInterfaceTypesMod
       ! Land use
       ! ---------------------------------------------------------------------------------
       real(r8),allocatable :: hlm_harvest_rates(:)    ! annual harvest rate per cat from hlm for a site
+
       character(len=64), allocatable :: hlm_harvest_catnames(:)  ! names of hlm_harvest d1
+
+      integer :: hlm_harvest_units  ! what units are the harvest rates specified in? [area vs carbon]
 
       ! Fixed biogeography mode 
       real(r8), allocatable :: pft_areafrac(:)     ! Fractional area of the FATES column occupied by each PFT  

--- a/main/FatesInterfaceTypesMod.F90
+++ b/main/FatesInterfaceTypesMod.F90
@@ -88,7 +88,7 @@ module FatesInterfaceTypesMod
    integer, public :: hlm_use_spitfire  ! This flag signals whether or not to use SPITFIRE
                                                    ! 1 = TRUE, 0 = FALSE
 
-   integer, public, protected :: hlm_use_lu_harvest      ! This flag signals whether or not to use
+   integer, public :: hlm_use_lu_harvest      ! This flag signals whether or not to use
                                                          ! harvest area data from the hlm
                                                          ! 0 = do not use lu harvest from hlm
                                                          ! 1 = use area fraction of vegetated land
@@ -97,7 +97,7 @@ module FatesInterfaceTypesMod
                                                          ! If 1 or 2, it automatically sets
                                                          ! hlm_use_logging to 1
 
-   integer, public, protected :: hlm_num_lu_harvest_cats    ! number of hlm harvest categories
+   integer, public :: hlm_num_lu_harvest_cats    ! number of hlm harvest categories
                                                          ! this is the first dimension of:
                                                          ! harvest_rates in dynHarvestMod
                                                          ! bc_in%hlm_harvest and bc_in%hlm_harvest_catnames

--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -1008,7 +1008,7 @@ contains
 
     call this%set_restart_var(vname='fates_use_this_pft', vtype=cohort_int, & !should this be cohort_int as above?
          long_name='in fixed biogeog mode, is pft in gridcell?', &
-         units='0/1', flushval = flushzero, &
+         units='0/1', flushval = flushone, &
          hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_use_this_pft_sift)
 
     call this%set_restart_var(vname='fates_area_pft', vtype=cohort_r8, &


### PR DESCRIPTION
These changes provide a first version of land use change, as driven by the CLM & ELM landuse.timeseries files that currently drive the big-leaf versions of the models, and should allow global transient simulations with land use.

The idea is that the HLMs read a series of land-use driving datasets (as they already do), which they'll now then pass through the HLM-FATES interface via the interface variable `bc_in%hlm_harvest(num_lu_harvest_cats)`.  Currently the default is that the HLM reads and passes five area-based logging streams, for harvest from various categories of land (primary forest, primary nonforest, secondary young forest, secondary young nonforest, secondary old forest).  FATES uses this data to harvest from three separate types: primary lands, secondary young lands, and secondary old lands.  FATES does not distinguish between forest and no-forest lands, though possibly a future step could be to infer that either from the composition of a given patch or as specified if prescribed biogeography is turned on.  Mass-based harvest and associated disturbance is not yet implemented here, that is also a next step.

The harvest parameters are kept from before, though their usage and meaning are slightly different.
The event code triggers when within the year to apply the harvest rates, the direct_frac determines what fraction of trees within the harvested area are removed (so `fates_logging_direct_frac=1` means clearcut), etc.  Plants within the logged area that are not harvested, whether because they are not trees, are not within the dbhmin threshold, or because `(fates_logging_direct_frac + fates_logging_mechanical_frac  + fates_logging_collateral_frac ) < 1` are all moved to a newly-disturbed secondary patch, along with an equivalent fraction of bare ground of each harvested patch if the canopy is not closed.  So the definition of secondary lands includes everything from full clearcut disturbance to potentially relatively low-intensity forest degradation.  But for consistency with the intention of the land-use datasets, we should probably set the default values to be closer to clear-cut type of conditions.  Future steps may include making these arguments harvest-type-dependent. Also we still need to wire the `max_dbh` parameter introduced in #659 to this logic, once that code is merged into this.

We added a bunch of diagnostics to serve as either sanity checks or other trackers of things that might be useful, including tracking various disturbance rates, as well as 'potential disturbace' rates (i.e. the disturbance rates before the part of the code where it says only resolve a given patch's most dominant disturbance type on a given day).  Also changed the newly-disturbed patch insertion to fix a bug as described in #660.

This isn't really ready to be merged just yet, in particular the merging with the prescribed biogeography (#632 and follow-on) will most likely be a bit tricky.  But putting up for interested parties to start reviewing.

fixes: #660, #491, #276, and the first batch of changes described in #450.


### Collaborators:
co-written by @aldivi and me.  @aldivi also wrote the E3SM-side changes of these (PR to come later) and I wrote the CTSM-side changes (PR https://github.com/ESCOMP/CTSM/pull/1040).

### Expectation of Answer Changes:
This should only change answers when logging is operational.  But this hasn't been formally tested yet and probably requires some new tests that use the land-use timeseries data.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 