### PR TITLE
Added interface for spitfire definitions

### DIFF
--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -10,9 +10,13 @@
   use FatesInterfaceTypesMod     , only : hlm_masterproc ! 1= master process, 0=not master process
   use EDTypesMod            , only : numWaterMem
   use FatesGlobals          , only : fates_log
-
-  use FatesInterfaceTypesMod     , only : bc_in_type
-
+  use FatesInterfaceTypesMod, only : hlm_spitfire_mode
+  use FatesInterfaceTypesMod, only : hlm_sf_nofire_def
+  use FatesInterfaceTypesMod, only : hlm_sf_scalar_lightning_def
+  use FatesInterfaceTypesMod, only : hlm_sf_successful_ignitions_def
+  use FatesInterfaceTypesMod, only : hlm_sf_anthro_ignitions_def
+  use FatesInterfaceTypesMod, only : bc_in_type
+  
   use EDPftvarcon           , only : EDPftvarcon_inst
 
   use EDTypesMod            , only : element_pos
@@ -40,9 +44,6 @@
   use PRTGenericMod,          only : struct_organ
   use PRTGenericMod,          only : SetState
   use FatesInterfaceTypesMod     , only : numpft
-
-  use CNFireFactoryMod, only: no_fire, scalar_lightning, &
-          lightning_from_data, successful_ignitions, anthro_ignitions
 
   implicit none
   private
@@ -75,7 +76,7 @@ contains
   ! ============================================================================
   subroutine fire_model( currentSite, bc_in)
 
-    use FatesInterfaceTypesMod, only : hlm_spitfire_mode
+    
 
     type(ed_site_type)     , intent(inout), target :: currentSite
     type(bc_in_type)       , intent(in)            :: bc_in
@@ -95,7 +96,7 @@ contains
        write(fates_log(),*) 'spitfire_mode', hlm_spitfire_mode
     endif
 
-    if( hlm_spitfire_mode > no_fire )then
+    if( hlm_spitfire_mode > hlm_sf_nofire_def )then
        call fire_danger_index(currentSite, bc_in)
        call wind_effect(currentSite, bc_in) 
        call charecteristics_of_fuel(currentSite)
@@ -698,7 +699,7 @@ contains
     
     ! Equation 7 from Venevsky et al GCB 2002 (modification of equation 8 in Thonicke et al. 2010) 
     ! FDI 0.1 = low, 0.3 moderate, 0.75 high, and 1 = extreme ignition potential for alpha 0.000337
-    if (hlm_spitfire_mode == successful_ignitions) then
+    if (hlm_spitfire_mode == hlm_sf_successful_ignitions_def) then
        currentSite%FDI = 1.0_r8  ! READING "SUCCESSFUL IGNITION" DATA
                                   ! force ignition potential to be extreme
        cloud_to_ground_strikes = 1.0_r8   ! cloud_to_ground = 1 = use 100% incoming observed ignitions
@@ -709,7 +710,7 @@ contains
     
     !NF = number of lighting strikes per day per km2 scaled by cloud to ground strikes
     iofp = currentSite%oldest_patch%patchno
-    if (hlm_spitfire_mode == scalar_lightning) then
+    if (hlm_spitfire_mode == hlm_sf_scalar_lightning_def ) then
        currentSite%NF = ED_val_nignitions * years_per_day * cloud_to_ground_strikes
     else    ! use external daily lightning ignition data
        currentSite%NF = bc_in%lightning24(iofp) * cloud_to_ground_strikes
@@ -720,7 +721,7 @@ contains
  
     ! Calculate anthropogenic ignitions according to Li et al. (2012)
     ! Add to ignitions by lightning
-    if (hlm_spitfire_mode == anthro_ignitions) then
+    if (hlm_spitfire_mode == hlm_sf_anthro_ignitions_def) then
       ! anthropogenic ignitions (count/km2/day)
       !           =  ignitions/person/month * 6.8 * population_density **0.43 /approximate days per month
       anthro_ign_count = pot_hmn_ign_counts_alpha * 6.8_r8 * bc_in%pop_density(iofp)**0.43_r8 / 30._r8

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -990,6 +990,10 @@ contains
          hlm_use_vertsoilc = unset_int
          hlm_parteh_mode   = unset_int
          hlm_spitfire_mode = unset_int
+         hlm_sf_nofire_def = unset_int
+         hlm_sf_scalar_lightning_def = unset_int
+         hlm_sf_successful_ignitions_def = unset_int
+         hlm_sf_anthro_ignitions_def = unset_int
          hlm_use_planthydro = unset_int
          hlm_use_cohort_age_tracking = unset_int
          hlm_use_logging   = unset_int
@@ -1196,7 +1200,33 @@ contains
             end if
             call endrun(msg=errMsg(sourcefile, __LINE__))
          end if
+         if(hlm_sf_nofire_def .eq. unset_int) then
+            if (fates_global_verbose()) then
+               write(fates_log(), *) 'definition of no-fire mode unset: hlm_sf_nofire_def, exiting'
+            end if
+            call endrun(msg=errMsg(sourcefile, __LINE__))
+         end if
+         if(hlm_sf_scalar_lightning_def .eq. unset_int) then
+            if (fates_global_verbose()) then
+               write(fates_log(), *) 'definition of scalar lightning mode unset: hlm_sf_scalltng_def, exiting'
+            end if
+            call endrun(msg=errMsg(sourcefile, __LINE__))
+         end if
+         if(hlm_sf_successful_ignitions_def .eq. unset_int) then
+            if (fates_global_verbose()) then
+               write(fates_log(), *) 'definition of successful ignition mode unset: hlm_sf_successful, exiting'
+            end if
+            call endrun(msg=errMsg(sourcefile, __LINE__))
+         end if
+         if(hlm_sf_anthro_ignitions_def .eq. unset_int) then
+            if (fates_global_verbose()) then
+               write(fates_log(), *) 'definition of anthro-ignition mode unset: hlm_sf_anthig_def, exiting'
+            end if
+            call endrun(msg=errMsg(sourcefile, __LINE__))
+         end if
 
+ 
+         
         if(hlm_use_fixed_biogeog.eq.unset_int) then
            if(fates_global_verbose()) then
              write(fates_log(), *) 'switch for fixed biogeog unset: him_use_fixed_biogeog, exiting'
@@ -1294,8 +1324,33 @@ contains
                hlm_spitfire_mode = ival
                if (fates_global_verbose()) then
                   write(fates_log(),*) 'Transfering hlm_spitfire_mode =',ival,' to FATES'
+              end if
+              
+           case('sf_nofire_def')
+               hlm_sf_nofire_def = ival
+               if (fates_global_verbose()) then
+                  write(fates_log(),*) 'Transfering hlm_sf_nofire_def =',ival,' to FATES'
                end if
 
+           case('sf_scalar_lightning_def')
+               hlm_sf_scalar_lightning_def = ival
+               if (fates_global_verbose()) then
+                  write(fates_log(),*) 'Transfering hlm_sf_scalar_lightning_def =',ival,' to FATES'
+               end if
+
+           case('sf_successful_ignitions_def')
+               hlm_sf_successful_ignitions_def = ival
+               if (fates_global_verbose()) then
+                  write(fates_log(),*) 'Transfering hlm_sf_successful_ignition_def =',ival,' to FATES'
+               end if
+
+           case('sf_anthro_ignitions_def')
+               hlm_sf_anthro_ignitions_def = ival
+               if (fates_global_verbose()) then
+                  write(fates_log(),*) 'Transfering hlm_sf_anthro_ignition_def =',ival,' to FATES'
+               end if
+
+               
             case('use_fixed_biogeog')
                 hlm_use_fixed_biogeog = ival
                if (fates_global_verbose()) then

--- a/main/FatesInterfaceTypesMod.F90
+++ b/main/FatesInterfaceTypesMod.F90
@@ -90,6 +90,13 @@ module FatesInterfaceTypesMod
                                          ! ignitions: 1=constant, >1=external data sources (lightning and/or anthropogenic)
 
 
+
+   integer, public :: hlm_sf_nofire_def               ! Definition of a no-fire case for hlm_spitfire_mode
+   integer, public :: hlm_sf_scalar_lightning_def     ! Definition of a scalar-lightning case for hlm_spitfire_mode
+   integer, public :: hlm_sf_successful_ignitions_def ! Definition of a successful-ignition dataset case for hlm_spitfire_mode
+   integer, public :: hlm_sf_anthro_ignitions_def      ! Definition of an anthropogenic-ignition dataset case for hlm_spitfire_mode
+   
+
    integer, public :: hlm_use_logging       ! This flag signals whether or not to use
                                                        ! the logging module
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

This is a fix for issue #675 

This just adds the fire type definitions to the interface, and removes the call to the CNFireFactory module.

This should be synchronized with: https://github.com/ESCOMP/CTSM/pull/1088/files


### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->


### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->
no, should be b4b

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x]  I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

TBD

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

