### PR TITLE
Allocate zero-size hlm_harvest variables for LoggingMortality_frac

### DIFF
--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -369,6 +369,9 @@ contains
       if (hlm_use_lu_harvest .gt. 0) then
          allocate(bc_in%hlm_harvest_rates(num_lu_harvest_cats))
          allocate(bc_in%hlm_harvest_catnames(num_lu_harvest_cats))
+      else ! LoggingMortality_frac needs these passed to it regardless of harvest
+         allocate(bc_in%hlm_harvest_rates(0))
+         allocate(bc_in%hlm_harvest_catnames(0))
       end if
 
       allocate(bc_in%pft_areafrac(maxpft))


### PR DESCRIPTION
### Description:
During regression testing of [fates_main_api](https://github.com/glemieux/ctsm/tree/fates_main_api) the following error was generated for a number of the tests:
```
Attempt to fetch from allocatable variable HLM_HARVEST_RATES when it is not allocated
286:cesm.exe           00000000014660C8  edpatchdynamicsmo         214  EDPatchDynamicsMod.F90
286:cesm.exe           000000000144CCBD  edmainmod_mp_ed_e         182  EDMainMod.F90
286:cesm.exe           000000000095750E  clmfatesinterface         817  clmfates_interfaceMod.F90
286:cesm.exe           00000000008EDD76  clm_driver_mp_clm        1011  clm_driver.F90
```
@ckoven determined that this was due to  `hlm_harvest_rates` and `hlm_harvest_catnames` not being allocated for the call to `LoggingMortality_frac` which requires the variables as inputs regardless of the harvest setting.  This PR simply allocates the arrays as zero-size when `hlm_use_lu_harvest` is not greater than zero.  

For future work: as a longer term effort we could probably refactor this to avoid the call to arrays that only need to be allocated during certain hlm settings.  This PR is meant to be a short term bug fix to facilitate the development of fates_main_api.

### Collaborators: @ckoven 

### Expectation of Answer Changes:
Not expected to change answers

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
In progress

CTSM (or) E3SM (specify which) test hash-tag: abcd5937

CTSM (or) E3SM (specify which) baseline hash-tag: d764dbad

FATES baseline hash-tag: 3248e63

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

