### PR TITLE
Fix metadata on fates_mort_freezetol parameter.

### DIFF
--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -324,8 +324,8 @@ variables:
 		fates_mort_bmort:units = "1/yr" ;
 		fates_mort_bmort:long_name = "background mortality rate" ;
 	double fates_mort_freezetol(fates_pft) ;
-		fates_mort_freezetol:units = "NA" ;
-		fates_mort_freezetol:long_name = "minimum temperature tolerance (NOT USED)" ;
+		fates_mort_freezetol:units = "degrees C" ;
+		fates_mort_freezetol:long_name = "minimum temperature tolerance" ;
 	double fates_mort_hf_flc_threshold(fates_pft) ;
 		fates_mort_hf_flc_threshold:units = "fraction" ;
 		fates_mort_hf_flc_threshold:long_name = "plant fractional loss of conductivity at which drought mortality begins for hydraulic model" ;


### PR DESCRIPTION
fixes #556.  shouldn't require much testing, as it touches metadata only..

<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

