### PR TITLE
fixes to logging: dbhmax logic and hlm_use_lu_harvest checking

### DIFF
--- a/biogeochem/EDLoggingMortalityMod.F90
+++ b/biogeochem/EDLoggingMortalityMod.F90
@@ -259,7 +259,10 @@ contains
             
             ! direct logging rates, based on dbh min and max criteria
             if (dbh >= logging_dbhmin .and. .not. &
-                 ((logging_dbhmax < fates_check_param_set) .and. (dbh < logging_dbhmax )) ) then
+                 ((logging_dbhmax < fates_check_param_set) .and. (dbh >= logging_dbhmax )) ) then
+               ! the logic of the above line is a bit unintuitive but allows turning off the dbhmax comparison entirely.
+               ! since there is an .and. .not. after the first conditional, the dbh:dbhmax comparison needs to be 
+               ! the opposite of what would otherwise be expected...
                lmort_direct = harvest_rate * logging_direct_frac
 
             else

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -1063,9 +1063,9 @@ contains
                write(fates_log(), *) '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
          end if
 
-         if ( (hlm_use_lu_harvest .lt. 0).or.(hlm_use_lu_harvest .gt. 2) ) then
+         if ( (hlm_use_lu_harvest .lt. 0).or.(hlm_use_lu_harvest .gt. 1) ) then
             if (fates_global_verbose()) then
-               write(fates_log(), *) 'The FATES lu_harvest flag must be 0 or 1 or 2, exiting'
+               write(fates_log(), *) 'The FATES lu_harvest flag must be 0 or 1,  exiting'
             end if
             call endrun(msg=errMsg(sourcefile, __LINE__))
          end if

--- a/main/FatesInterfaceTypesMod.F90
+++ b/main/FatesInterfaceTypesMod.F90
@@ -90,12 +90,10 @@ module FatesInterfaceTypesMod
                                          ! ignitions: 1=constant, >1=external data sources (lightning and/or anthropogenic)
 
    integer, public :: hlm_use_lu_harvest      ! This flag signals whether or not to use
-                                                         ! harvest area data from the hlm
+                                                         ! harvest data from the hlm
                                                          ! 0 = do not use lu harvest from hlm
-                                                         ! 1 = use area fraction of vegetated land
-                                                         ! from from hlm
-                                                         ! 2 = use carbon from hlm
-                                                         ! If 1 or 2, it automatically sets
+                                                         ! 1 = use lu harvest from hlm  
+                                                         ! If 1, it automatically sets
                                                          ! hlm_use_logging to 1
 
    integer, public :: hlm_num_lu_harvest_cats    ! number of hlm harvest categories (e.g. primary forest harvest, secondary young forest harvest, etc.)


### PR DESCRIPTION
Fixes two things: the logic on logging_dbhmax was reversed, and the ok-values checking on hlm_use_lu_harvest wasn't right.

### Description:
1. Basically because of the .and. .not. in the dbh logic, the comparison to logging_dbhmax was reversed.
2. Since the area-based vs mass-based logic is now handled by a separate variable (hlm_harvest_units), hlm_use_lu_harvest is only a true/false switch so updated the error checking and documentation to reflect that.

I worked through all the combinations of possible logic on the dbh checking to make sure it is right this time...

          [dbh > dbhmin] .and. not. ([dbhmax invoked] .and. [dbh >= dbhmax]) =>  [do we log this tree?]
          T                                  F                      T            T
          T                                  F                      F            T
          T                                  T                      T            F
          T                                  T                      F            T
          F                                  F                      T            F
          F                                  F                      F            F
          F                                  T                      T            F
          F                                  T                      F            F


### Collaborators:
Both of these were caught by @aldivi.  

### Expectation of Answer Changes:
not unless logging_dbhmax is set as other than missing value in the parameter file.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
not tested yet.

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

