### PR TITLE
minor fixes to ncvarsort and parameter file

### DIFF
--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -11,7 +11,6 @@ dimensions:
 	fates_pft = 12 ;
 	fates_prt_organs = 6 ;
 	fates_string_length = 60 ;
-	fates_variants = 2 ;
 variables:
 	double fates_history_ageclass_bin_edges(fates_history_age_bins) ;
 		fates_history_ageclass_bin_edges:units = "yr" ;

--- a/tools/ncvarsort.py
+++ b/tools/ncvarsort.py
@@ -41,7 +41,6 @@ def main():
     (u'fates_pft', u'fates_string_length'):4,
     (u'fates_prt_organs', u'fates_string_length'):5,
     (u'fates_pft',):6,
-    (u'fates_variants', u'fates_pft'):6,
     (u'fates_hydr_organs', u'fates_pft'):6,
     (u'fates_leafage_class', u'fates_pft'):6,
     (u'fates_prt_organs', u'fates_pft'):6,
@@ -50,7 +49,7 @@ def main():
     ():9}
     #
     # go through each of the variables and assign it to one of the sub-lists based on its dimensionality
-    for v_name, varin in dsin.variables.iteritems():
+    for v_name, varin in dsin.variables.items():
         sortorder = dimtype_sortorder_dict[varin.dimensions]
         # if a KeyError, it means that the parameter has a dimension which isn't in dimtype_sortorder_dict. need to add it.
         varnames_list[sortorder].append(v_name)
@@ -78,11 +77,11 @@ def main():
     dsout = nc.Dataset(args.fnameout,  "w")
     #
     #Copy dimensions
-    for dname, the_dim in dsin.dimensions.iteritems():
-        print dname, the_dim.size
+    for dname, the_dim in dsin.dimensions.items():
+        print(dname, the_dim.size)
         dsout.createDimension(dname, the_dim.size )
     #
-    print
+    print()
     #
     try:
         dsout.history = dsin.history
@@ -96,7 +95,7 @@ def main():
         v_name = varnames_list_sorted[i]
         varin = dsin.variables[v_name]
         outVar = dsout.createVariable(v_name, varin.datatype, varin.dimensions)
-        print v_name
+        print(v_name)
         #
         outVar.setncatts({k: varin.getncattr(k) for k in varin.ncattrs()})
         outVar[:] = varin[:]


### PR DESCRIPTION
This PR has two changes: (1) is to make ncvarsort.py python-3 compliant, and (2) is to get rid of the no-longer-used fates_variants dimension to both the param file and to ncvarsort.

### Description:
that's pretty much it.  the fates_variants was being used to handle the alternate specification of rooting profiles but isn't used anymore.  so we may as well get rid of it.

### Collaborators:
none

### Expectation of Answer Changes:
none

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
non tested, should be trivial though since no fortran or other code used during the testing was modified.

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

