### PR TITLE
FRAGMENTATION_SCALER history output fix

### DIFF
--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -2143,6 +2143,7 @@ contains
     currentPatch%zstar                      = 0.0_r8
     currentPatch%c_stomata                  = 0.0_r8 ! This is calculated immediately before use
     currentPatch%c_lblayer                  = 0.0_r8
+    currentPatch%fragmentation_scaler(:)    = 0.0_r8
 
     currentPatch%solar_zenith_flag          = .false.
     currentPatch%solar_zenith_angle         = nan

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -2248,7 +2248,7 @@ contains
     !
     ! !LOCAL VARIABLES:
     logical  :: use_century_tfunc = .false.
-    logical  :: use_hlm_soil_scalar = .false. ! Use hlm input decomp fraction scalars
+    logical  :: use_hlm_soil_scalar = .true. ! Use hlm input decomp fraction scalars
     integer  :: j
     integer  :: ifp                          ! Index of a FATES Patch "ifp"
     real(r8) :: t_scalar                     ! temperature scalar


### PR DESCRIPTION
Corrects new patch allocation error and history output for `fragmentation_scaler`.

### Description:
Due to parallel development of PR #705 and #694, the history output variable introduced in the latter needs to be updated to reflect the change of `fragmentation_scaler` to an array implemented in the former.  As such, the history output is indexed by soil layer. This PR also adds in `fragmentation_scaler` to the `zero_patch` subroutine, which was an oversight in the original PR.

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes: 
Output impacted by `fragmentation_scaler` is expected to change due to addition of the variable in `zero_patch`.
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [x] FATES PASS/FAIL regression tests were run
- [x] If answers were expected to change, evaluation was performed and provided


### Test Results: 
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag: https://github.com/ESCOMP/CTSM/commit/7138ab0d9decd01ffb7f72015a8240af2a284466

CTSM (or) E3SM (specify which) baseline hash-tag: https://github.com/glemieux/ctsm/commit/f6123355e318500f184eababbc62cbb20817f910

FATES baseline hash-tag: https://github.com/NGEET/fates/commit/19702e3712a47796961b0e854392372e06519d58

Test Output: 
```
/glade/u/home/glemieux/scratch/clmed-tests/basegen.fates-sci.1.43.1_api.14.1.0-fates_main_api_14.0.0-C7138ab0d-F9d26bb11
```

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

