### PR TITLE
Some fire-related fixes and clarifications

### DIFF
--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -2034,6 +2034,23 @@ contains
     new_patch%fabi_sha_z(:,:,:)  = 0._r8  
     new_patch%scorch_ht(:)       = 0._r8  
     new_patch%frac_burnt         = 0._r8  
+    new_patch%litter_moisture(:) = 0._r8
+    new_patch%fuel_eff_moist     = 0._r8
+    new_patch%livegrass          = 0._r8
+    new_patch%sum_fuel           = 0._r8
+    new_patch%fuel_bulkd         = 0._r8
+    new_patch%fuel_sav           = 0._r8
+    new_patch%fuel_mef           = 0._r8
+    new_patch%ros_front          = 0._r8
+    new_patch%effect_wspeed      = 0._r8
+    new_patch%tau_l              = 0._r8
+    new_patch%fuel_frac(:)       = 0._r8
+    new_patch%tfc_ros            = 0._r8
+    new_patch%fi                 = 0._r8
+    new_patch%fd                 = 0._r8
+    new_patch%ros_back           = 0._r8
+    new_patch%scorch_ht(:)       = 0._r8
+    new_patch%burnt_frac_litter(:) = 0._r8
     new_patch%total_tree_area    = 0.0_r8  
     new_patch%NCL_p              = 1
 

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -2108,31 +2108,31 @@ contains
 
 
     ! FIRE
-   currentPatch%litter_moisture(:)         = 0.0_r8 ! litter moisture
-    currentPatch%fuel_eff_moist             = 0.0_r8 ! average fuel moisture content of the ground fuel 
+    currentPatch%litter_moisture(:)         = nan    ! litter moisture
+    currentPatch%fuel_eff_moist             = nan    ! average fuel moisture content of the ground fuel 
     ! (incl. live grasses. omits 1000hr fuels)
-    currentPatch%livegrass                  = 0.0_r8 ! total ag grass biomass in patch. 1=c3 grass, 2=c4 grass. gc/m2
-    currentPatch%sum_fuel                   = 0.0_r8 ! total ground fuel related to ros (omits 1000hr fuels). gc/m2
-    currentPatch%fuel_bulkd                 = 0.0_r8 ! average fuel bulk density of the ground fuel 
+    currentPatch%livegrass                  = nan    ! total ag grass biomass in patch. 1=c3 grass, 2=c4 grass. gc/m2
+    currentPatch%sum_fuel                   = nan    ! total ground fuel related to ros (omits 1000hr fuels). gc/m2
+    currentPatch%fuel_bulkd                 = nan    ! average fuel bulk density of the ground fuel 
     ! (incl. live grasses. omits 1000hr fuels). kgc/m3
-    currentPatch%fuel_sav                   = 0.0_r8 ! average surface area to volume ratio of the ground fuel 
+    currentPatch%fuel_sav                   = nan    ! average surface area to volume ratio of the ground fuel 
     ! (incl. live grasses. omits 1000hr fuels).
-    currentPatch%fuel_mef                   = 0.0_r8 ! average moisture of extinction factor of the ground fuel
+    currentPatch%fuel_mef                   = nan    ! average moisture of extinction factor of the ground fuel
     ! (incl. live grasses. omits 1000hr fuels).
-    currentPatch%ros_front                  = 0.0_r8 ! average rate of forward spread of each fire in the patch. m/min.
-    currentPatch%effect_wspeed              = 0.0_r8 ! dailywind modified by fraction of relative grass and tree cover. m/min.
-    currentPatch%tau_l                      = 0.0_r8 ! mins p&r(1986)
-    currentPatch%fuel_frac(:)               = 0.0_r8 ! fraction of each litter class in the sum_fuel 
+    currentPatch%ros_front                  = nan    ! average rate of forward spread of each fire in the patch. m/min.
+    currentPatch%effect_wspeed              = nan    ! dailywind modified by fraction of relative grass and tree cover. m/min.
+    currentPatch%tau_l                      = nan    ! mins p&r(1986)
+    currentPatch%fuel_frac(:)               = nan    ! fraction of each litter class in the sum_fuel 
     !- for purposes of calculating weighted averages. 
-    currentPatch%tfc_ros                    = 0.0_r8 ! used in fi calc
-    currentPatch%fi                         = 0._r8  ! average fire intensity of flaming front during day.  
+    currentPatch%tfc_ros                    = nan    ! used in fi calc
+    currentPatch%fi                         = nan    ! average fire intensity of flaming front during day.  
     ! backward ros plays no role. kj/m/s or kw/m.
     currentPatch%fire                       = 999    ! sr decide_fire.1=fire hot enough to proceed. 0=stop everything- no fires today
-    currentPatch%fd                         = 0.0_r8 ! fire duration (mins)
-    currentPatch%ros_back                   = 0.0_r8 ! backward ros (m/min)
-    currentPatch%scorch_ht(:)               = 0.0_r8 ! scorch height of flames on a given PFT
-    currentPatch%frac_burnt                 = 0.0_r8 ! fraction burnt daily  
-    currentPatch%burnt_frac_litter(:)       = 0.0_r8 
+    currentPatch%fd                         = nan    ! fire duration (mins)
+    currentPatch%ros_back                   = nan    ! backward ros (m/min)
+    currentPatch%scorch_ht(:)               = nan    ! scorch height of flames on a given PFT
+    currentPatch%frac_burnt                 = nan    ! fraction burnt daily  
+    currentPatch%burnt_frac_litter(:)       = nan    
     currentPatch%btran_ft(:)                = 0.0_r8
 
     currentPatch%canopy_layer_tlai(:)       = 0.0_r8

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -2249,7 +2249,7 @@ contains
     !
     ! !LOCAL VARIABLES:
     logical  :: use_century_tfunc = .false.
-    logical  :: use_hlm_soil_scalar = .false. ! Use hlm input decomp fraction scalars
+    logical  :: use_hlm_soil_scalar = .true. ! Use hlm input decomp fraction scalars
     integer  :: j
     integer  :: ifp                          ! Index of a FATES Patch "ifp"
     real(r8) :: t_scalar                     ! temperature scalar

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -2248,7 +2248,7 @@ contains
     !
     ! !LOCAL VARIABLES:
     logical  :: use_century_tfunc = .false.
-    logical  :: use_hlm_soil_scalar = .true. ! Use hlm input decomp fraction scalars
+    logical  :: use_hlm_soil_scalar = .false. ! Use hlm input decomp fraction scalars
     integer  :: j
     integer  :: ifp                          ! Index of a FATES Patch "ifp"
     real(r8) :: t_scalar                     ! temperature scalar

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -227,10 +227,6 @@ contains
        ! Calculate loss rate of viable seeds to litter
        call SeedDecay(litt)
        
-       ! Send those decaying seeds in the previous call 
-       ! to the litter input flux
-       call SeedDecayToFines(litt)
-       
        ! Calculate seed germination rate, the status flags prevent
        ! germination from occuring when the site is in a drought 
        ! (for drought deciduous) or too cold (for cold deciduous)
@@ -254,7 +250,8 @@ contains
        ! Fragmentation flux to soil decomposition model [kg/site/day]
        site_mass%frag_out = site_mass%frag_out + currentPatch%area * &
             ( sum(litt%ag_cwd_frag) + sum(litt%bg_cwd_frag) + &
-            sum(litt%leaf_fines_frag) + sum(litt%root_fines_frag))
+            sum(litt%leaf_fines_frag) + sum(litt%root_fines_frag) + &
+            sum(litt%seed_decay) + sum(litt%seed_germ_decay))
        
     end do
      
@@ -2195,39 +2192,6 @@ contains
 
   ! =====================================================================================
 
-  subroutine SeedDecayToFines(litt)
-
-    type(litter_type) :: litt
-    !
-    ! !LOCAL VARIABLES:
-    integer  ::  pft
-    integer, parameter :: seedlev = 2
-
-    ! Add decaying seeds to a single level of root litter
-    ! -----------------------------------------------------------------------------------
-
-    do pft = 1,numpft
-
-        litt%root_fines_in(ilabile,seedlev) = litt%root_fines_in(ilabile,seedlev) + & 
-              (litt%seed_decay(pft) + litt%seed_germ_decay(pft)) * EDPftvarcon_inst%lf_flab(pft)
-        
-        litt%root_fines_in(icellulose,seedlev) = litt%root_fines_in(icellulose,seedlev) + & 
-              (litt%seed_decay(pft) + litt%seed_germ_decay(pft)) * EDPftvarcon_inst%lf_fcel(pft)
-        
-        litt%root_fines_in(ilignin,seedlev) = litt%root_fines_in(ilignin,seedlev) + & 
-              (litt%seed_decay(pft) + litt%seed_germ_decay(pft)) * EDPftvarcon_inst%lf_flig(pft)
-
-    enddo
-    
-    
-    return
-  end subroutine SeedDecayToFines
-  
-  
-
-
-
-  ! =====================================================================================
 
   subroutine fragmentation_scaler( currentPatch, bc_in) 
     !

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -2201,19 +2201,20 @@ contains
     !
     ! !LOCAL VARIABLES:
     integer  ::  pft
+    integer, parameter :: seedlev = 2
 
-    ! Add decaying seeds to the leaf litter
+    ! Add decaying seeds to a single level of root litter
     ! -----------------------------------------------------------------------------------
 
     do pft = 1,numpft
 
-        litt%leaf_fines_in(ilabile) = litt%leaf_fines_in(ilabile) + & 
+        litt%root_fines_in(ilabile,seedlev) = litt%root_fines_in(ilabile,seedlev) + & 
               (litt%seed_decay(pft) + litt%seed_germ_decay(pft)) * EDPftvarcon_inst%lf_flab(pft)
         
-        litt%leaf_fines_in(icellulose) = litt%leaf_fines_in(icellulose) + & 
+        litt%root_fines_in(icellulose,seedlev) = litt%root_fines_in(icellulose,seedlev) + & 
               (litt%seed_decay(pft) + litt%seed_germ_decay(pft)) * EDPftvarcon_inst%lf_fcel(pft)
         
-        litt%leaf_fines_in(ilignin) = litt%leaf_fines_in(ilignin) + & 
+        litt%root_fines_in(ilignin,seedlev) = litt%root_fines_in(ilignin,seedlev) + & 
               (litt%seed_decay(pft) + litt%seed_germ_decay(pft)) * EDPftvarcon_inst%lf_flig(pft)
 
     enddo

--- a/biogeochem/FatesSoilBGCFluxMod.F90
+++ b/biogeochem/FatesSoilBGCFluxMod.F90
@@ -772,7 +772,6 @@ contains
                                                ! into the soil/decomposition
                                                ! layers. It exponentially decays
     real(r8) :: surface_prof_tot ! normalizes the surface_prof array
-    integer  :: ft               ! PFT number
     integer  :: nlev_eff_soil    ! number of effective soil layers
     integer  :: nlev_eff_decomp  ! number of effective decomp layers
     real(r8) :: area_frac        ! fraction of site's area of current patch
@@ -782,6 +781,7 @@ contains
     integer  :: j                ! Soil layer index
     integer  :: id               ! Decomposition layer index
     integer  :: ic               ! CWD type index
+    integer  :: ipft             ! PFT index
 
     ! NOTE(rgk, 201705) this parameter was brought over from SoilBiogeochemVerticalProfile
     ! how steep profile is for surface components (1/ e_folding depth) (1/m) 
@@ -929,6 +929,26 @@ contains
                   litt%leaf_fines_frag(ilignin) * area_frac* surface_prof(id)
 
           end do
+
+
+          ! decaying seeds from the litter pool
+          do ipft = 1,numpft
+             do id = 1,nlev_eff_decomp
+
+                flux_lab_si(id) = flux_lab_si(id) + &
+                     (litt%seed_decay(ipft) + litt%seed_germ_decay(ipft)) * &
+                     EDPftvarcon_inst%lf_flab(ipft) * area_frac* surface_prof(id)
+
+                flux_cel_si(id) = flux_cel_si(id) + &
+                     (litt%seed_decay(ipft) + litt%seed_germ_decay(ipft)) * &
+                     EDPftvarcon_inst%lf_fcel(ipft) * area_frac* surface_prof(id)
+
+                flux_lig_si(id) = flux_lig_si(id) + &
+                     (litt%seed_decay(ipft) + litt%seed_germ_decay(ipft)) * &
+                     EDPftvarcon_inst%lf_flig(ipft) * area_frac* surface_prof(id)
+             end do
+          end do
+
 
           do j = 1, nlev_eff_soil
 

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -694,7 +694,7 @@ contains
     integer :: iofp  ! index of oldest fates patch
     real(r8), parameter :: pot_hmn_ign_counts_alpha = 0.0035_r8  ! Potential human ignition counts (alpha in Li et al. 2012) (#/person/month)
     real(r8), parameter :: km2_to_m2 = 1000000.0_r8 !area conversion for square km to square m
-    real(r8), parameter :: wind_convert = 0.06_r8  ! convert wind speed from m/min to km/hr
+    real(r8), parameter :: m_per_min__to__km_per_hour = 0.06_r8  ! convert wind speed from m/min to km/hr
 
     !  ---initialize site parameters to zero--- 
     currentSite%frac_burnt(:) = 0.0_r8  
@@ -763,15 +763,15 @@ contains
              write(fates_log(),*) 'SF  AREA ',AREA
           endif         
  
-          if (currentPatch%effect_wspeed < 16.67_r8) then !16.67m/min = 1km/hr 
+          if ((currentPatch%effect_wspeed*m_per_min__to__km_per_hour) < 1._r8) then !16.67m/min = 1km/hr 
              lb = 1.0_r8
           else
              if (tree_fraction_patch > 0.55_r8) then      !benchmark forest cover, Staver 2010
                  ! EQ 79 forest fuels (Canadian Forest Fire Behavior Prediction System Ont.Inf.Rep. ST-X-3, 1992)
                  lb = (1.0_r8 + (8.729_r8 * &
-                      ((1.0_r8 -(exp(-0.03_r8 * wind_convert * currentPatch%effect_wspeed)))**2.155_r8)))
-             else ! EQ 80 grass fuels (CFFBPS Ont.Inf.Rep. ST-X-3, 1992)
-                 lb = (1.1_r8+((wind_convert * currentPatch%effect_wspeed)**0.0464))
+                      ((1.0_r8 -(exp(-0.03_r8 * m_per_min__to__km_per_hour * currentPatch%effect_wspeed)))**2.155_r8)))
+             else ! EQ 80 grass fuels (CFFBPS Ont.Inf.Rep. ST-X-3, 1992, but with a correction in Information Report GLC-X-10 by Bottom et al., 2009)
+                 lb = (1.1_r8*((m_per_min__to__km_per_hour * currentPatch%effect_wspeed)**0.464_r8))
              endif
           endif
 

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -708,6 +708,7 @@ contains
     real(r8), parameter :: pot_hmn_ign_counts_alpha = 0.0035_r8  ! Potential human ignition counts (alpha in Li et al. 2012) (#/person/month)
     real(r8), parameter :: km2_to_m2 = 1000000.0_r8 !area conversion for square km to square m
     real(r8), parameter :: m_per_min__to__km_per_hour = 0.06_r8  ! convert wind speed from m/min to km/hr
+    real(r8), parameter :: forest_grassland_lengthtobreadth_threshold = 0.55_r8 ! tree canopy cover below which to use grassland length-to-breadth eqn
 
     !  ---initialize site parameters to zero--- 
     currentSite%frac_burnt(:) = 0.0_r8  
@@ -779,11 +780,12 @@ contains
           if ((currentPatch%effect_wspeed*m_per_min__to__km_per_hour) < 1._r8) then !16.67m/min = 1km/hr 
              lb = 1.0_r8
           else
-             if (tree_fraction_patch > 0.55_r8) then      !benchmark forest cover, Staver 2010
+             if (tree_fraction_patch > forest_grassland_lengthtobreadth_threshold) then      !benchmark forest cover, Staver 2010
                  ! EQ 79 forest fuels (Canadian Forest Fire Behavior Prediction System Ont.Inf.Rep. ST-X-3, 1992)
                  lb = (1.0_r8 + (8.729_r8 * &
                       ((1.0_r8 -(exp(-0.03_r8 * m_per_min__to__km_per_hour * currentPatch%effect_wspeed)))**2.155_r8)))
-             else ! EQ 80 grass fuels (CFFBPS Ont.Inf.Rep. ST-X-3, 1992, but with a correction in Information Report GLC-X-10 by Bottom et al., 2009)
+             else ! EQ 80 grass fuels (CFFBPS Ont.Inf.Rep. ST-X-3, 1992, but with a correction from an errata published within 
+                  ! Information Report GLC-X-10 by Bottom et al., 2009 because there is a typo in CFFBPS Ont.Inf.Rep. ST-X-3, 1992)
                  lb = (1.1_r8*((m_per_min__to__km_per_hour * currentPatch%effect_wspeed)**0.464_r8))
              endif
           endif

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -719,7 +719,6 @@ contains
     real(r8), parameter :: forest_grassland_lengthtobreadth_threshold = 0.55_r8 ! tree canopy cover below which to use grassland length-to-breadth eqn
 
     !  ---initialize site parameters to zero--- 
-    currentSite%frac_burnt(:) = 0.0_r8  
     currentSite%NF_successful = 0._r8
     
     ! Equation 7 from Venevsky et al GCB 2002 (modification of equation 8 in Thonicke et al. 2010) 
@@ -854,15 +853,9 @@ contains
             currentSite%NF_successful = currentSite%NF_successful + &
                  currentSite%NF * currentSite%FDI * currentPatch%area / area
             !
-            ! accumulate frac_burnt % at site level. this is purely being tracked as a diagnostic 
-            ! since patch%frac_burnt * patch%area changes due to the fire before history output
-            currentSite%frac_burnt(currentPatch%age_class) = currentSite%frac_burnt(currentPatch%age_class) + &
-                 currentPatch%frac_burnt * currentPatch%area / area
-            !
          else     
             currentPatch%fire       = 0 ! No fire... :-/
             currentPatch%FD         = 0.0_r8
-            currentPatch%frac_burnt = 0.0_r8
          endif         
           
        endif! NF ignitions check

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -815,7 +815,8 @@ contains
                  currentSite%NF * currentSite%FDI * currentPatch%area / area
             !
             ! accumulate frac_burnt % at site level
-            currentSite%frac_burnt(cpatch%age_class) = currentSite%frac_burnt(cpatch%age_class) + currentPatch%frac_burnt    
+            currentSite%frac_burnt(currentPatch%age_class) = currentSite%frac_burnt(currentPatch%age_class) + &
+                 currentPatch%frac_burnt    
             !
          else     
             currentPatch%fire       = 0 ! No fire... :-/

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -695,7 +695,7 @@ contains
     real(r8),parameter :: km2_to_m2 = 1000000.0_r8 !area conversion for square km to square m
 
     !  ---initialize site parameters to zero--- 
-    currentSite%frac_burnt = 0.0_r8  
+    currentSite%frac_burnt(:) = 0.0_r8  
     currentSite%NF_successful = 0._r8
     
     ! Equation 7 from Venevsky et al GCB 2002 (modification of equation 8 in Thonicke et al. 2010) 
@@ -788,7 +788,7 @@ contains
              AB = size_of_fire * currentSite%NF * currentSite%FDI
 
              !frac_burnt 
-             currentPatch%frac_burnt = (min(0.99_r8, AB / km2_to_m2)) * currentPatch%area/area 
+             currentPatch%frac_burnt = (min(0.99_r8, AB / km2_to_m2))
              
              if(write_SF == itrue)then
                 if ( hlm_masterproc == itrue ) write(fates_log(),*) 'frac_burnt',currentPatch%frac_burnt
@@ -813,6 +813,10 @@ contains
             !
             currentSite%NF_successful = currentSite%NF_successful + &
                  currentSite%NF * currentSite%FDI * currentPatch%area / area
+            !
+            ! accumulate frac_burnt % at site level
+            currentSite%frac_burnt(cpatch%age_class) = currentSite%frac_burnt(cpatch%age_class) + currentPatch%frac_burnt    
+            !
          else     
             currentPatch%fire       = 0 ! No fire... :-/
             currentPatch%FD         = 0.0_r8
@@ -820,11 +824,7 @@ contains
          endif         
           
        endif! NF ignitions check
-
        
-       ! accumulate frac_burnt % at site level
-       currentSite%frac_burnt = currentSite%frac_burnt + currentPatch%frac_burnt    
-
        currentPatch => currentPatch%younger
 
     enddo !end patch loop

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -823,6 +823,7 @@ contains
          else     
             currentPatch%fire       = 0 ! No fire... :-/
             currentPatch%FD         = 0.0_r8
+            currentPatch%frac_burnt = 0.0_r8
          endif         
           
        endif! NF ignitions check

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -247,13 +247,14 @@ contains
           currentPatch%fuel_frac(lg_sf)       = currentPatch%livegrass       / currentPatch%sum_fuel
           
           ! MEF (moisure of extinction) depends on compactness of fuel, depth, particle size, wind, slope
+          ! Eqn here is eqn 27 from Peterson and Ryan (1986) "Modeling Postfire Conifer Mortality for Long-Range Planning"
+          ! but lots of other approaches in use out there...
           ! MEF: pine needles=0.30 (text near EQ 28 Rothermal 1972)
           ! Table II-1 NFFL mixed fuels models from Rothermal 1983 Gen. Tech. Rep. INT-143 
           ! MEF: short grass=0.12,tall grass=0.25,chaparral=0.20,closed timber litter=0.30,hardwood litter=0.25
-          ! Thonicke 2010 SAV give MEF:tw=0.45, sb=0.4874, lb=0.5245, tr=0.57, dg=0.404, lg=0.404
-          ! no reference for MEF eqn. in Thonicke 2010
+          ! Thonicke 2010 SAV values propagated thru P&R86 eqn below gives MEF:tw=0.355, sb=0.44, lb=0.525, tr=0.63, dg=0.248, lg=0.248
           ! Lasslop 2014 Table 1 MEF PFT level:grass=0.2,shrubs=0.3,TropEverGrnTree=0.2,TropDecid Tree=0.3, Extra-trop Tree=0.3
-          MEF(1:nfsc)                         = 0.524_r8 - 0.066_r8 * log10(SF_val_SAV(1:nfsc)) 
+          MEF(1:nfsc)                         = 0.524_r8 - 0.066_r8 * log(SF_val_SAV(1:nfsc)) 
 
           !--- weighted average of relative moisture content---
           ! Equation 6 in Thonicke et al. 2010. across twig, small branch, large branch, and dead leaves

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -696,7 +696,7 @@ contains
 
     !  ---initialize site parameters to zero--- 
     currentSite%frac_burnt = 0.0_r8  
-
+    currentSite%NF_successful = 0._r8
     
     ! Equation 7 from Venevsky et al GCB 2002 (modification of equation 8 in Thonicke et al. 2010) 
     ! FDI 0.1 = low, 0.3 moderate, 0.75 high, and 1 = extreme ignition potential for alpha 0.000337
@@ -810,7 +810,9 @@ contains
          !'decide_fire' subroutine 
          if (currentPatch%FI > SF_val_fire_threshold) then !track fires greater than kW/m energy threshold
             currentPatch%fire = 1 ! Fire...    :D
-          
+            !
+            currentSite%NF_successful = currentSite%NF_successful + &
+                 currentSite%NF * currentSite%FDI * currentPatch%area / area
          else     
             currentPatch%fire       = 0 ! No fire... :-/
             currentPatch%FD         = 0.0_r8

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -816,7 +816,7 @@ contains
             !
             ! accumulate frac_burnt % at site level
             currentSite%frac_burnt(currentPatch%age_class) = currentSite%frac_burnt(currentPatch%age_class) + &
-                 currentPatch%frac_burnt    
+                 currentPatch%frac_burnt * currentPatch%area / area
             !
          else     
             currentPatch%fire       = 0 ! No fire... :-/

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -7,6 +7,7 @@
 
   use FatesConstantsMod     , only : r8 => fates_r8
   use FatesConstantsMod     , only : itrue, ifalse
+  use FatesConstantsMod     , only : pi_const
   use FatesInterfaceTypesMod     , only : hlm_masterproc ! 1= master process, 0=not master process
   use EDTypesMod            , only : numWaterMem
   use FatesGlobals          , only : fates_log
@@ -791,7 +792,7 @@ contains
              ! AB = AB *3.0_r8
 
              !size of fire = equation 14 Arora and Boer JGR 2005
-             size_of_fire = ((3.1416_r8/(4.0_r8*lb))*((df+db)**2.0_r8))
+             size_of_fire = ((pi_const/(4.0_r8*lb))*((df+db)**2.0_r8))
 
              !AB = daily area burnt = size fires in m2 * num ignitions per day per km2 * prob ignition starts fire
              !AB = m2 per km2 per day

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -800,8 +800,8 @@ contains
          W     = currentPatch%TFC_ROS / 0.45_r8 !kgC/m2 to kgbiomass/m2          
 
          ! EQ 15 Thonicke et al 2010
-         !units of fire intensity = (kJ/kg)*(kgBiomass/m2)*(m/min)*unitless_fraction
-         currentPatch%FI = SF_val_fuel_energy * W * ROS * currentPatch%frac_burnt !kj/m/s, or kW/m
+         !units of fire intensity = (kJ/kg)*(kgBiomass/m2)*(m/min)
+         currentPatch%FI = SF_val_fuel_energy * W * ROS !kj/m/s, or kW/m
        
          if(write_sf == itrue)then
              if( hlm_masterproc == itrue ) write(fates_log(),*) 'fire_intensity',currentPatch%fi,W,currentPatch%ROS_front

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -120,8 +120,6 @@ contains
     allocate(site_in%mass_balance(1:num_elements))
     allocate(site_in%flux_diags(1:num_elements))
    
-    allocate(site_in%frac_burnt(1:nlevage))
-
     site_in%nlevsoil   = bc_in%nlevsoil
     allocate(site_in%rootfrac_scr(site_in%nlevsoil))
     allocate(site_in%zi_soil(0:site_in%nlevsoil))
@@ -190,7 +188,6 @@ contains
     site_in%acc_ni           = 0.0_r8     ! daily nesterov index accumulating over time. time unlimited theoretically.
     site_in%NF               = 0.0_r8     ! daily lightning strikes per km2 
     site_in%NF_successful    = 0.0_r8     ! daily successful iginitions per km2
-    site_in%frac_burnt(:)    = 0.0_r8     ! burn area
 
     do el=1,num_elements
        ! Zero the state variables used for checking mass conservation
@@ -301,7 +298,6 @@ contains
           sites(s)%acc_NI     = acc_NI
           sites(s)%NF         = 0.0_r8         
           sites(s)%NF_successful  = 0.0_r8
-          sites(s)%frac_burnt(:)  = 0.0_r8
          
          ! PLACEHOLDER FOR PFT AREA DATA MOVED ACROSS INTERFACE                                                                                   
           if(hlm_use_fixed_biogeog.eq.itrue)then

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -301,7 +301,7 @@ contains
           sites(s)%acc_NI     = acc_NI
           sites(s)%NF         = 0.0_r8         
           sites(s)%NF_successful  = 0.0_r8
-          sites(s)%frac_burnt = 0.0_r8
+          sites(s)%frac_burnt(:)  = 0.0_r8
          
          ! PLACEHOLDER FOR PFT AREA DATA MOVED ACROSS INTERFACE                                                                                   
           if(hlm_use_fixed_biogeog.eq.itrue)then

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -44,6 +44,7 @@ module EDInitMod
   use FatesInterfaceTypesMod         , only : nleafage
   use FatesInterfaceTypesMod         , only : nlevsclass
   use FatesInterfaceTypesMod         , only : nlevcoage
+  use FatesInterfaceTypesMod         , only : nlevage
   use FatesAllometryMod         , only : h2d_allom
   use FatesAllometryMod         , only : bagw_allom
   use FatesAllometryMod         , only : bbgw_allom
@@ -119,6 +120,8 @@ contains
     allocate(site_in%mass_balance(1:num_elements))
     allocate(site_in%flux_diags(1:num_elements))
    
+    allocate(site_in%frac_burnt(1:nlevage))
+
     site_in%nlevsoil   = bc_in%nlevsoil
     allocate(site_in%rootfrac_scr(site_in%nlevsoil))
     allocate(site_in%zi_soil(0:site_in%nlevsoil))
@@ -187,7 +190,7 @@ contains
     site_in%acc_ni           = 0.0_r8     ! daily nesterov index accumulating over time. time unlimited theoretically.
     site_in%NF               = 0.0_r8     ! daily lightning strikes per km2 
     site_in%NF_successful    = 0.0_r8     ! daily successful iginitions per km2
-    site_in%frac_burnt       = 0.0_r8     ! burn area read in from external file
+    site_in%frac_burnt(:)    = 0.0_r8     ! burn area
 
     do el=1,num_elements
        ! Zero the state variables used for checking mass conservation

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -357,6 +357,7 @@ contains
      
      type(ed_site_type),  pointer :: sitep
      type(ed_patch_type), pointer :: newp
+     type(ed_patch_type), pointer :: currentPatch
 
      ! List out some nominal patch values that are used for Near Bear Ground initializations
      ! as well as initializing inventory
@@ -437,6 +438,35 @@ contains
 
      end if
 
+     ! zero all the patch fire variables for the first timestep
+     do s = 1, nsites
+        currentPatch => sites(s)%youngest_patch
+        do while(associated(currentPatch))
+
+           currentPatch%litter_moisture(:)         = 0._r8
+           currentPatch%fuel_eff_moist             = 0._r8
+           currentPatch%livegrass                  = 0._r8
+           currentPatch%sum_fuel                   = 0._r8
+           currentPatch%fuel_bulkd                 = 0._r8
+           currentPatch%fuel_sav                   = 0._r8
+           currentPatch%fuel_mef                   = 0._r8
+           currentPatch%ros_front                  = 0._r8
+           currentPatch%effect_wspeed              = 0._r8
+           currentPatch%tau_l                      = 0._r8
+           currentPatch%fuel_frac(:)               = 0._r8
+           currentPatch%tfc_ros                    = 0._r8
+           currentPatch%fi                         = 0._r8
+           currentPatch%fire                       = 0
+           currentPatch%fd                         = 0._r8
+           currentPatch%ros_back                   = 0._r8
+           currentPatch%scorch_ht(:)               = 0._r8
+           currentPatch%frac_burnt                 = 0._r8
+           currentPatch%burnt_frac_litter(:)       = 0._r8
+
+           currentPatch => currentPatch%older
+        enddo
+     enddo
+     
      ! This sets the rhizosphere shells based on the plant initialization
      ! The initialization of the plant-relevant hydraulics variables
      ! were set from a call inside of the init_cohorts()->create_cohort() subroutine

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -186,6 +186,7 @@ contains
     ! FIRE 
     site_in%acc_ni           = 0.0_r8     ! daily nesterov index accumulating over time. time unlimited theoretically.
     site_in%NF               = 0.0_r8     ! daily lightning strikes per km2 
+    site_in%NF_successful    = 0.0_r8     ! daily successful iginitions per km2
     site_in%frac_burnt       = 0.0_r8     ! burn area read in from external file
 
     do el=1,num_elements
@@ -296,6 +297,7 @@ contains
           
           sites(s)%acc_NI     = acc_NI
           sites(s)%NF         = 0.0_r8         
+          sites(s)%NF_successful  = 0.0_r8
           sites(s)%frac_burnt = 0.0_r8
          
          ! PLACEHOLDER FOR PFT AREA DATA MOVED ACROSS INTERFACE                                                                                   

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -534,9 +534,9 @@ module EDTypesMod
      real(r8) ::  sum_fuel                                         ! total ground fuel related to ros (omits 1000hr fuels): KgC/m2
      real(r8) ::  fuel_frac(nfsc)                                  ! fraction of each litter class in the ros_fuel:-.  
      real(r8) ::  livegrass                                        ! total aboveground grass biomass in patch.  KgC/m2
-     real(r8) ::  fuel_bulkd                                       ! average fuel bulk density of the ground fuel 
+     real(r8) ::  fuel_bulkd                                       ! average fuel bulk density of the ground fuel. kgBiomass/m3
                                                                    ! (incl. live grasses. omits 1000hr fuels). KgC/m3
-     real(r8) ::  fuel_sav                                         ! average surface area to volume ratio of the ground fuel 
+     real(r8) ::  fuel_sav                                         ! average surface area to volume ratio of the ground fuel. cm-1
                                                                    ! (incl. live grasses. omits 1000hr fuels).
      real(r8) ::  fuel_mef                                         ! average moisture of extinction factor 
                                                                    ! of the ground fuel (incl. live grasses. omits 1000hr fuels).

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -730,6 +730,7 @@ module EDTypesMod
      real(r8) ::  acc_ni                                       ! daily nesterov index accumulating over time.
      real(r8) ::  fdi                                          ! daily probability an ignition event will start a fire
      real(r8) ::  NF                                           ! daily ignitions in km2
+     real(r8) ::  NF_successful                                ! daily ignitions in km2 that actually lead to fire
      real(r8) ::  frac_burnt                                   ! fraction of area burnt in this day.
 
      ! PLANT HYDRAULICS

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -731,7 +731,6 @@ module EDTypesMod
      real(r8) ::  fdi                                          ! daily probability an ignition event will start a fire
      real(r8) ::  NF                                           ! daily ignitions in km2
      real(r8) ::  NF_successful                                ! daily ignitions in km2 that actually lead to fire
-     real(r8), allocatable ::  frac_burnt(:)                   ! fraction of gridcell area burnt in this day. indexed by patch age bins
 
      ! PLANT HYDRAULICS
      type(ed_site_hydr_type), pointer :: si_hydr

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -555,7 +555,7 @@ module EDTypesMod
 
      ! FIRE EFFECTS     
      real(r8) ::  scorch_ht(maxpft)                                ! scorch height: m 
-     real(r8) ::  frac_burnt                                       ! fraction burnt: frac gridcell/day  
+     real(r8) ::  frac_burnt                                       ! fraction burnt: frac patch/day  
      real(r8) ::  tfc_ros                                          ! total fuel consumed - no trunks.  KgC/m2/day
      real(r8) ::  burnt_frac_litter(nfsc)                          ! fraction of each litter pool burned:-
 
@@ -731,7 +731,7 @@ module EDTypesMod
      real(r8) ::  fdi                                          ! daily probability an ignition event will start a fire
      real(r8) ::  NF                                           ! daily ignitions in km2
      real(r8) ::  NF_successful                                ! daily ignitions in km2 that actually lead to fire
-     real(r8) ::  frac_burnt                                   ! fraction of area burnt in this day.
+     real(r8), allocatable ::  frac_burnt(:)                   ! fraction of gridcell area burnt in this day. indexed by patch age bins
 
      ! PLANT HYDRAULICS
      type(ed_site_hydr_type), pointer :: si_hydr

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -556,8 +556,8 @@ module EDTypesMod
      ! FIRE EFFECTS     
      real(r8) ::  scorch_ht(maxpft)                                ! scorch height: m 
      real(r8) ::  frac_burnt                                       ! fraction burnt: frac patch/day  
-     real(r8) ::  tfc_ros                                          ! total fuel consumed - no trunks.  KgC/m2/day
-     real(r8) ::  burnt_frac_litter(nfsc)                          ! fraction of each litter pool burned:-
+     real(r8) ::  tfc_ros                                          ! total intensity-relevant fuel consumed - no trunks.  KgC/m2 of burned ground/day
+     real(r8) ::  burnt_frac_litter(nfsc)                          ! fraction of each litter pool burned, conditional on it being burned
 
 
      ! PLANT HYDRAULICS   (not currently used in hydraulics RGK 03-2018)  

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -2071,7 +2071,7 @@ end subroutine flush_hvars
          
          ! site-level fire variables
          hio_nesterov_fire_danger_si(io_si) = sites(s)%acc_NI
-         hio_fire_nignitions_si(io_si) = sites(s)%NF
+         hio_fire_nignitions_si(io_si) = sites(s)%NF_successful
          hio_fire_fdi_si(io_si) = sites(s)%FDI
 
          ! If hydraulics are turned on, track the error terms
@@ -4362,7 +4362,7 @@ end subroutine update_history_hifrq
          ivar=ivar, initialize=initialize_variables, index = ih_nesterov_fire_danger_si)
 
     call this%set_history_var(vname='FIRE_IGNITIONS', units='number/km2/day',       &
-         long='number of ignitions', use_default='active',               &
+         long='number of successful ignitions', use_default='active',               &
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
          ivar=ivar, initialize=initialize_variables, index = ih_fire_nignitions_si)
 

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -506,6 +506,8 @@ module FatesHistoryInterfaceMod
   integer :: ih_mortality_si_pft
   integer :: ih_crownarea_si_pft
   integer :: ih_canopycrownarea_si_pft
+  integer :: ih_gpp_si_pft
+  integer :: ih_npp_si_pft
 
   ! indices to (site x patch-age) variables
   integer :: ih_area_si_age
@@ -1810,6 +1812,8 @@ end subroutine flush_hvars
                hio_mortality_si_pft    => this%hvars(ih_mortality_si_pft)%r82d, &
                hio_crownarea_si_pft    => this%hvars(ih_crownarea_si_pft)%r82d, &
                hio_canopycrownarea_si_pft  => this%hvars(ih_canopycrownarea_si_pft)%r82d, &
+               hio_gpp_si_pft  => this%hvars(ih_gpp_si_pft)%r82d, &
+               hio_npp_si_pft  => this%hvars(ih_npp_si_pft)%r82d, &
                hio_nesterov_fire_danger_si => this%hvars(ih_nesterov_fire_danger_si)%r81d, &
                hio_fire_nignitions_si => this%hvars(ih_fire_nignitions_si)%r81d, &
                hio_fire_fdi_si => this%hvars(ih_fire_fdi_si)%r81d, &
@@ -2375,14 +2379,20 @@ end subroutine flush_hvars
 
                ! Update PFT crown area
                hio_crownarea_si_pft(io_si, ft) = hio_crownarea_si_pft(io_si, ft) + &
-                    ccohort%c_area 
+                    ccohort%c_area * AREA_INV
 
                if (ccohort%canopy_layer .eq. 1) then
                   ! Update PFT canopy crown area
                   hio_canopycrownarea_si_pft(io_si, ft) = hio_canopycrownarea_si_pft(io_si, ft) + &
-                       ccohort%c_area 
+                       ccohort%c_area * AREA_INV
                end if
 
+               ! update pft-resolved NPP and GPP fluxes
+               hio_gpp_si_pft(io_si, ft) = hio_gpp_si_pft(io_si, ft) + &
+                    ccohort%gpp_acc_hold * n_perm2
+
+               hio_npp_si_pft(io_si, ft) = hio_npp_si_pft(io_si, ft) + &
+                    ccohort%npp_acc_hold * n_perm2
                
 
                ! Site by Size-Class x PFT (SCPF) 
@@ -4202,12 +4212,12 @@ end subroutine update_history_hifrq
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,    &
          ivar=ivar, initialize=initialize_variables, index = ih_trimming_si)
     
-    call this%set_history_var(vname='AREA_PLANT', units='m2',                   &
+    call this%set_history_var(vname='AREA_PLANT', units='m2/m2',                   &
          long='area occupied by all plants', use_default='active',              &
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,    &
          ivar=ivar, initialize=initialize_variables, index = ih_area_plant_si)
     
-    call this%set_history_var(vname='AREA_TREES', units='m2',                   &
+    call this%set_history_var(vname='AREA_TREES', units='m2/m2',                   &
          long='area occupied by woody plants', use_default='active',            &
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,    &
          ivar=ivar, initialize=initialize_variables, index = ih_area_trees_si)
@@ -4293,15 +4303,25 @@ end subroutine update_history_hifrq
          avgflag='A', vtype=site_pft_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1, &
          ivar=ivar, initialize=initialize_variables, index = ih_storebiomass_si_pft )
 
-    call this%set_history_var(vname='PFTcrownarea',  units='m2/ha',            &
+    call this%set_history_var(vname='PFTcrownarea',  units='m2/m2',            &
          long='total PFT level crown area', use_default='inactive',              &
          avgflag='A', vtype=site_pft_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1, &
          ivar=ivar, initialize=initialize_variables, index = ih_crownarea_si_pft )
     
-    call this%set_history_var(vname='PFTcanopycrownarea',  units='m2/ha',            &
+    call this%set_history_var(vname='PFTcanopycrownarea',  units='m2/m2',            &
          long='total PFT-level canopy-layer crown area', use_default='inactive',     &
          avgflag='A', vtype=site_pft_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1, &
          ivar=ivar, initialize=initialize_variables, index = ih_canopycrownarea_si_pft )
+    
+    call this%set_history_var(vname='PFTgpp',  units='kg C m-2 y-1',            &
+         long='total PFT-level GPP', use_default='active',     &
+         avgflag='A', vtype=site_pft_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1, &
+         ivar=ivar, initialize=initialize_variables, index = ih_gpp_si_pft )
+    
+    call this%set_history_var(vname='PFTnpp',  units='kg C m-2 y-1',            &
+         long='total PFT-level NPP', use_default='active',     &
+         avgflag='A', vtype=site_pft_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1, &
+         ivar=ivar, initialize=initialize_variables, index = ih_npp_si_pft )
     
     call this%set_history_var(vname='PFTnindivs',  units='indiv / m2',            &
          long='total PFT level number of individuals', use_default='active',       &

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -522,6 +522,7 @@ module FatesHistoryInterfaceMod
   integer :: ih_agesince_anthrodist_si_age
   integer :: ih_secondaryforest_area_si_age
   integer :: ih_area_burnt_si_age
+  integer :: ih_area_burnt2_si_age
   ! integer :: ih_fire_rate_of_spread_front_si_age
   integer :: ih_fire_intensity_si_age
   integer :: ih_fire_sum_fuel_si_age
@@ -2001,6 +2002,7 @@ end subroutine flush_hvars
                hio_agesince_anthrodist_si_age     => this%hvars(ih_agesince_anthrodist_si_age)%r82d, &
                hio_secondaryforest_area_si_age    => this%hvars(ih_secondaryforest_area_si_age)%r82d, &
                hio_area_burnt_si_age              => this%hvars(ih_area_burnt_si_age)%r82d, &
+               hio_area_burnt2_si_age             => this%hvars(ih_area_burnt2_si_age)%r82d, &
                ! hio_fire_rate_of_spread_front_si_age  => this%hvars(ih_fire_rate_of_spread_front_si_age)%r82d, &
                hio_fire_intensity_si_age          => this%hvars(ih_fire_intensity_si_age)%r82d, &
                hio_fire_sum_fuel_si_age           => this%hvars(ih_fire_sum_fuel_si_age)%r82d, &
@@ -2873,6 +2875,9 @@ end subroutine flush_hvars
                hio_lai_si_age(io_si, ipa2) = 0._r8
                hio_ncl_si_age(io_si, ipa2) = 0._r8
             endif
+
+            hio_area_burnt2_si_age(io_si,ipa2) =  sites(s)%frac_burnt(ipa2)
+
          end do
 
          ! pass the cohort termination mortality as a flux to the history, and then reset the termination mortality buffer
@@ -4508,6 +4513,12 @@ end subroutine update_history_hifrq
          use_default='active', &
          avgflag='A', vtype=site_age_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1, &
          ivar=ivar, initialize=initialize_variables, index = ih_area_burnt_si_age )
+
+    call this%set_history_var(vname='AREA_BURNT2_BY_PATCH_AGE', units='m2/m2', &
+         long='spitfire area burnt by patch age (divide by patch_area_by_age to get burnt fraction by age)', &
+         use_default='active', &
+         avgflag='A', vtype=site_age_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1, &
+         ivar=ivar, initialize=initialize_variables, index = ih_area_burnt2_si_age )
 
     call this%set_history_var(vname='FIRE_INTENSITY_BY_PATCH_AGE', units='kJ/m/2', &
          long='product of fire intensity and burned area, resolved by patch age (so divide by AREA_BURNT_BY_PATCH_AGE to get burned-area-weighted-average intensity', &

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -524,7 +524,6 @@ module FatesHistoryInterfaceMod
   integer :: ih_agesince_anthrodist_si_age
   integer :: ih_secondaryforest_area_si_age
   integer :: ih_area_burnt_si_age
-  integer :: ih_area_burnt2_si_age
   ! integer :: ih_fire_rate_of_spread_front_si_age
   integer :: ih_fire_intensity_si_age
   integer :: ih_fire_sum_fuel_si_age
@@ -2006,7 +2005,6 @@ end subroutine flush_hvars
                hio_agesince_anthrodist_si_age     => this%hvars(ih_agesince_anthrodist_si_age)%r82d, &
                hio_secondaryforest_area_si_age    => this%hvars(ih_secondaryforest_area_si_age)%r82d, &
                hio_area_burnt_si_age              => this%hvars(ih_area_burnt_si_age)%r82d, &
-               hio_area_burnt2_si_age             => this%hvars(ih_area_burnt2_si_age)%r82d, &
                ! hio_fire_rate_of_spread_front_si_age  => this%hvars(ih_fire_rate_of_spread_front_si_age)%r82d, &
                hio_fire_intensity_si_age          => this%hvars(ih_fire_intensity_si_age)%r82d, &
                hio_fire_sum_fuel_si_age           => this%hvars(ih_fire_sum_fuel_si_age)%r82d, &
@@ -2885,8 +2883,6 @@ end subroutine flush_hvars
                hio_lai_si_age(io_si, ipa2) = 0._r8
                hio_ncl_si_age(io_si, ipa2) = 0._r8
             endif
-
-            hio_area_burnt2_si_age(io_si,ipa2) =  sites(s)%frac_burnt(ipa2)
 
          end do
 
@@ -4533,12 +4529,6 @@ end subroutine update_history_hifrq
          use_default='active', &
          avgflag='A', vtype=site_age_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1, &
          ivar=ivar, initialize=initialize_variables, index = ih_area_burnt_si_age )
-
-    call this%set_history_var(vname='AREA_BURNT2_BY_PATCH_AGE', units='m2/m2', &
-         long='spitfire area burnt by patch age (divide by patch_area_by_age to get burnt fraction by age)', &
-         use_default='active', &
-         avgflag='A', vtype=site_age_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1, &
-         ivar=ivar, initialize=initialize_variables, index = ih_area_burnt2_si_age )
 
     call this%set_history_var(vname='FIRE_INTENSITY_BY_PATCH_AGE', units='kJ/m/2', &
          long='product of fire intensity and burned area, resolved by patch age (so divide by AREA_BURNT_BY_PATCH_AGE to get burned-area-weighted-average intensity', &

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -4472,7 +4472,7 @@ end subroutine update_history_hifrq
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
          ivar=ivar, initialize=initialize_variables, index = ih_fire_intensity_area_product_si )
 
-    call this%set_history_var(vname='FIRE_AREA', units='fraction',             &
+    call this%set_history_var(vname='FIRE_AREA', units='fraction/day',             &
          long='spitfire fire area burn fraction', use_default='active',                    &
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
          ivar=ivar, initialize=initialize_variables, index = ih_fire_area_si )
@@ -4524,7 +4524,7 @@ end subroutine update_history_hifrq
          avgflag='A', vtype=site_agefuel_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1,   &
          ivar=ivar, initialize=initialize_variables, index = ih_fuel_amount_age_fuel )
 
-    call this%set_history_var(vname='AREA_BURNT_BY_PATCH_AGE', units='m2/m2', &
+    call this%set_history_var(vname='AREA_BURNT_BY_PATCH_AGE', units='m2/m2/day', &
          long='spitfire area burnt by patch age (divide by patch_area_by_age to get burnt fraction by age)', &
          use_default='active', &
          avgflag='A', vtype=site_age_r8, hlms='CLM:ALM', flushval=0.0_r8, upfreq=1, &

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -164,7 +164,7 @@ variables:
 		fates_eca_vmax_ptase:units = "gP/m2/s" ;
 		fates_eca_vmax_ptase:long_name = "maximum production rate for biochemical P (per m2) (ECA)" ;
 	double fates_fire_alpha_SH(fates_pft) ;
-		fates_fire_alpha_SH:units = "NA" ;
+		fates_fire_alpha_SH:units = "m / (kw/m)**(2/3)" ;
 		fates_fire_alpha_SH:long_name = "spitfire parameter, alpha scorch height, Equation 16 Thonicke et al 2010" ;
 	double fates_fire_bark_scaler(fates_pft) ;
 		fates_fire_bark_scaler:units = "fraction" ;
@@ -501,8 +501,8 @@ variables:
 		fates_z0mr:units = "unitless" ;
 		fates_z0mr:long_name = "Ratio of momentum roughness length to canopy top height" ;
 	double fates_fire_FBD(fates_litterclass) ;
-		fates_fire_FBD:units = "NA" ;
-		fates_fire_FBD:long_name = "spitfire parameter related to fuel bulk density, see SFMain.F90" ;
+		fates_fire_FBD:units = "kg Biomass/m3" ;
+		fates_fire_FBD:long_name = "fuel bulk density" ;
 	double fates_fire_low_moisture_Coeff(fates_litterclass) ;
 		fates_fire_low_moisture_Coeff:units = "NA" ;
 		fates_fire_low_moisture_Coeff:long_name = "spitfire parameter, equation B1 Thonicke et al 2010" ;
@@ -522,8 +522,8 @@ variables:
 		fates_fire_min_moisture:units = "NA" ;
 		fates_fire_min_moisture:long_name = "spitfire litter moisture threshold to be considered very dry" ;
 	double fates_fire_SAV(fates_litterclass) ;
-		fates_fire_SAV:units = "NA" ;
-		fates_fire_SAV:long_name = "spitfire parameter related to surface area to volume ratio, see SFMain.F90" ;
+		fates_fire_SAV:units = "cm-1" ;
+		fates_fire_SAV:long_name = "fuel surface area to volume ratio" ;
 	double fates_max_decomp(fates_litterclass) ;
 		fates_max_decomp:units = "yr-1" ;
 		fates_max_decomp:long_name = "maximum rate of litter & CWD transfer from non-decomposing class into decomposing class" ;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
there were a bunch of issues with the fire code, which this PR fixes.

### Description:
There were a bunch of fire-related issues, which include:

1. fire area was wrongly using the patch%frac_burnt to modify the fire intensity, which because intensity is used via a threshold to determine whether or not a fire actually occurs, was leading to too-low burned area
2. the decay flux from the seed pool was being routed to the FATES leaf litter pool, where it could act as a fuel source.  this meant we were both double-counting the seed C stocks in the scheme and also meant that under the special cases where a plant allocates a large fraction of its NPP to seeds (this can particularly happen with grasses right now) it would build up huge amounts of fuel and thus fire area.  I've changed this to reroute the seed decay fluxes straight to the HLM decomposition cascade rather than the intermediate step of the FATES leaf litter pool.  some day we may want to directly couple the seed pool to the fire behavior and effects but for now this should make the model behavior more as expected.
3. re-added the fire ellipse length-to-breadth calculation in the fire code.  This had been hard-coded to one (thus all fires are circular rather than elliptical), which was making the fire areas too big.  also there were typos in the equations for the length-to-breadth code. One of the typos goes back to the original 1992 Canadian fire behavior model (which noted in a 2009 errata that there had been a typo) and thus possibly exists in all extant versions of SPITFIRE (not just FATES-SPITFIRE).  In addition to the typos, we reverted the length-to-breadth logic to be categorically distinct—rather than a continuous transition—between grasslands and forests.  we can revisit this later, as well as what value of tree cover should switch between them, but for changed it to the separate equation approach.
4. added some more comment tracing the provenance of various equations and more info on the units where helpful.
5. added a couple more history variables that are helpful (e.g. PFT-level NPP and GPP) for investigating things.  also fixed and simplified some unit descriptions.
6. the MEF (moisture extinction factor) equation didn't have a clear provenance; once that was sorted out we realized there was a typo there as well (log10->log).
7. nan (rather than zero) the fire-relevant patch variables when initializing them.

Fixes #713 
Fixes #473 
Fixes #575

### Collaborators:
Lots of discussion and code from @jkshuman and also discussion with @lmkueppers @pollybuotte @rosiealice @rgknox @glemieux @JunyanDing 

### Expectation of Answer Changes:
highly answer changing if fire on.  also answer-changing litter and belowground BGC dynamics for case where fire is off.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided

still need to update the tech note to be consistent with the changes here.  will do so before merging this PR.

### Test Results:
not yet tested

<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

