### PR TITLE
instantiate prt_global as a class

### DIFF
--- a/parteh/PRTGenericMod.F90
+++ b/parteh/PRTGenericMod.F90
@@ -385,7 +385,7 @@ module PRTGenericMod
   end type prt_global_type
 
   
-  type(prt_global_type),pointer,public :: prt_global
+  class(prt_global_type),pointer,public :: prt_global
 
   ! Make necessary procedures public
   public :: GetCoordVal


### PR DESCRIPTION
This changes the definition of prt_global to a class. It points to classes, so, it should be a class.

fixes #725 


### Collaborators:
@billsacks  @ekluzek 

<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

This should not change answers, should be b4b

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [x] FATES PASS/FAIL regression tests were run


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

TBD

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

