### PR TITLE
remove artificial minimum LAI value

### DIFF
--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -2040,9 +2040,6 @@ contains
 
      integer :: cl,ft
      real(r8) :: ai
-     ! TODO: THIS MIN LAI IS AN ARTIFACT FROM TESTING LONG-AGO AND SHOULD BE REMOVED
-     ! THIS HAS BEEN KEPT THUS FAR TO MAINTAIN B4B IN TESTING OTHER COMMITS
-     real(r8),parameter :: ai_min = 0.1_r8
      real(r8),pointer   :: ai_profile
 
      ai = 0._r8
@@ -2080,8 +2077,6 @@ contains
         call endrun(msg=errMsg(sourcefile, __LINE__))
      end if
      
-     ai = max(ai_min,ai)
-          
      return
 
   end function calc_areaindex


### PR DESCRIPTION
Removes the artificial minimum LAI of 0.1 that is being used in the canopy code, which was there at some point to provide stability.  Hopefully we can get rid of it.

fixes #261


### Expectation of Answer Changes:
expected to be answer changing.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:

Not yet tested. Expectation is that it will not be bit for bit.

<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

