### PR TITLE
Allow snow to occlude LAI

### DIFF
--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -1581,7 +1581,6 @@ contains
                       currentCohort%sai
                 
                 !snow burial
-                !write(fates_log(), *) 'calc snow'
                 snow_depth_avg = snow_depth_si * frac_sno_eff_si
                 if(snow_depth_avg  > maxh(iv))then
                    fraction_exposed = 0._r8
@@ -1592,9 +1591,6 @@ contains
                 if(snow_depth_avg>= minh(iv).and.snow_depth_avg <= maxh(iv))then !only partly hidden... 
                    fraction_exposed =  max(0._r8,(min(1.0_r8,(snow_depth_avg-minh(iv))/dh)))
                 endif
-                fraction_exposed = 1.0_r8
-                ! no m2 of leaf per m2 of ground in each height class
-                ! FIX(SPM,032414) these should be uncommented this and double check
                 
                 if ( debug ) write(fates_log(), *) 'leaf_area_profile()', currentPatch%elai_profile(1,ft,iv)
                 
@@ -1648,12 +1644,6 @@ contains
                    fleaf = 0._r8
                 endif
                 
-                ! XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-                ! SNOW BURIAL IS CURRENTLY TURNED OFF
-                ! WHEN IT IS TURNED ON, IT WILL HAVE TO BE COMPARED
-                ! WITH SNOW HEIGHTS CALCULATED BELOW.
-                ! XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-                
                 currentPatch%nrad(cl,ft) = currentPatch%ncan(cl,ft) 
 
                 if (currentPatch%nrad(cl,ft) > nlevleaf ) then
@@ -1700,10 +1690,6 @@ contains
                       fraction_exposed =  max(0._r8,(min(1.0_r8,(snow_depth_avg-layer_bottom_hite)/ &
                          (layer_top_hite-layer_bottom_hite ))))
                    endif
-                   
-                   ! =========== OVER-WRITE =================
-                   fraction_exposed= 1.0_r8
-                   ! =========== OVER-WRITE =================
                    
                    if(iv==currentCohort%NV) then
                       remainder = (currentCohort%treelai + currentCohort%treesai) - &

--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -1589,7 +1589,7 @@ contains
                    fraction_exposed = 1._r8
                 endif
                 if(snow_depth_avg>= minh(iv).and.snow_depth_avg <= maxh(iv))then !only partly hidden... 
-                   fraction_exposed =  max(0._r8,(min(1.0_r8,(snow_depth_avg-minh(iv))/dh)))
+                   fraction_exposed = 1._r8 - max(0._r8,(min(1.0_r8,(snow_depth_avg-minh(iv))/dh)))
                 endif
                 
                 if ( debug ) write(fates_log(), *) 'leaf_area_profile()', currentPatch%elai_profile(1,ft,iv)
@@ -1687,7 +1687,7 @@ contains
                    endif
                    if( snow_depth_avg>= layer_bottom_hite .and. &
                          snow_depth_avg <= layer_top_hite) then !only partly hidden...
-                      fraction_exposed =  max(0._r8,(min(1.0_r8,(snow_depth_avg-layer_bottom_hite)/ &
+                      fraction_exposed =  1._r8 - max(0._r8,(min(1.0_r8,(snow_depth_avg-layer_bottom_hite)/ &
                          (layer_top_hite-layer_bottom_hite ))))
                    endif
                    

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -174,6 +174,7 @@ contains
     site_in%cstatus          = fates_unset_int    ! are leaves in this pixel on or off?
     site_in%dstatus          = fates_unset_int
     site_in%grow_deg_days    = nan  ! growing degree days
+    site_in%snow_depth       = nan
     site_in%nchilldays       = fates_unset_int
     site_in%ncolddays        = fates_unset_int
     site_in%cleafondate      = fates_unset_int  ! doy of leaf on

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -703,6 +703,7 @@ module EDTypesMod
 
      ! PHENOLOGY 
      real(r8) ::  grow_deg_days                                ! Phenology growing degree days
+     real(r8) ::  snow_depth                                   ! site-level snow depth (used for ELAI/TLAI calcs)
 
      integer  ::  cstatus                                      ! are leaves in this pixel on or off for cold decid
                                                                ! 0 = this site has not experienced a cold period over at least

--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -624,7 +624,7 @@ contains
          hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_gdd_si )
 
     call this%set_restart_var(vname='fates_snow_depth_site', vtype=site_r8, &
-         long_name='growing degree days at each site', units='degC days', flushval = flushzero, &
+         long_name='average snow depth', units='m', flushval = flushzero, &
          hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_snow_depth_si )
 
     call this%set_restart_var(vname='fates_trunk_product_site', vtype=site_r8, &

--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -86,6 +86,7 @@ module FatesRestartInterfaceMod
   integer :: ir_dleafoffdate_si
   integer :: ir_acc_ni_si
   integer :: ir_gdd_si
+  integer :: ir_snow_depth_si
   integer :: ir_trunk_product_si
   integer :: ir_ncohort_pa
   integer :: ir_canopy_layer_co
@@ -621,6 +622,10 @@ contains
     call this%set_restart_var(vname='fates_gdd_site', vtype=site_r8, &
          long_name='growing degree days at each site', units='degC days', flushval = flushzero, &
          hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_gdd_si )
+
+    call this%set_restart_var(vname='fates_snow_depth_site', vtype=site_r8, &
+         long_name='growing degree days at each site', units='degC days', flushval = flushzero, &
+         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_snow_depth_si )
 
     call this%set_restart_var(vname='fates_trunk_product_site', vtype=site_r8, &
          long_name='Accumulate trunk product flux at site', &
@@ -1600,6 +1605,7 @@ contains
            rio_dleafoffdate_si         => this%rvars(ir_dleafoffdate_si)%int1d, &
            rio_acc_ni_si               => this%rvars(ir_acc_ni_si)%r81d, &
            rio_gdd_si                  => this%rvars(ir_gdd_si)%r81d, &
+           rio_snow_depth_si           => this%rvars(ir_snow_depth_si)%r81d, &
            rio_trunk_product_si        => this%rvars(ir_trunk_product_si)%r81d, &
            rio_ncohort_pa              => this%rvars(ir_ncohort_pa)%int1d, &
            rio_solar_zenith_flag_pa    => this%rvars(ir_solar_zenith_flag_pa)%int1d, &
@@ -2052,6 +2058,7 @@ contains
           rio_dleafoffdate_si(io_idx_si) = sites(s)%dleafoffdate
           rio_acc_ni_si(io_idx_si)       = sites(s)%acc_NI
           rio_gdd_si(io_idx_si)          = sites(s)%grow_deg_days 
+          rio_snow_depth_si(io_idx_si)   = sites(s)%snow_depth
           
           ! Accumulated trunk product
           rio_trunk_product_si(io_idx_si) = sites(s)%resources_management%trunk_product_site
@@ -2388,6 +2395,7 @@ contains
           rio_dleafoffdate_si         => this%rvars(ir_dleafoffdate_si)%int1d, &
           rio_acc_ni_si               => this%rvars(ir_acc_ni_si)%r81d, &
           rio_gdd_si                  => this%rvars(ir_gdd_si)%r81d, &
+          rio_snow_depth_si           => this%rvars(ir_snow_depth_si)%r81d, &
           rio_trunk_product_si        => this%rvars(ir_trunk_product_si)%r81d, &
           rio_ncohort_pa              => this%rvars(ir_ncohort_pa)%int1d, &
           rio_solar_zenith_flag_pa    => this%rvars(ir_solar_zenith_flag_pa)%int1d, &
@@ -2868,6 +2876,7 @@ contains
           sites(s)%dleafoffdate   = rio_dleafoffdate_si(io_idx_si)
           sites(s)%acc_NI         = rio_acc_ni_si(io_idx_si)
           sites(s)%grow_deg_days  = rio_gdd_si(io_idx_si)
+          sites(s)%snow_depth     = rio_snow_depth_si(io_idx_si)
 
           sites(s)%resources_management%trunk_product_site = rio_trunk_product_si(io_idx_si)
 


### PR DESCRIPTION
The snow burial logic in FATEs has been turned off for a long while because of a bug, this fixes the bug and turns it on.  This has been a known bug for a long time (#359), and was not a priority when the model was mainly being used in the tropics, but that that is no longer the case.


### Description:
There was an indexing issue in the snow occlusion logic, for partially-occluded LAI layers it was using the fraction buried rather than the fraction exposed. 

Fixes #359.
requires HLM-side changes.  
Accompanying CTSM PR is https://github.com/ESCOMP/CTSM/pull/1324.  
E3SM PR TBD.

### Collaborators:
@rgknox @rosiealice.  cc @huitang-earth @jenniferholm and anyone else using FATES in snowy ecosystems

### Expectation of Answer Changes:
expected answer-changing where there is snow, not answer changing where there is not.
tested for 60 years in three-PFT system (two trees+grass) over California.  First figure below shows the difference between total LAI and exposed LAI as a function of snow depth across the grid.  Results make sense in that more snow equals more occluded LAI.

<img width="755" alt="Screen Shot 2021-03-26 at 9 32 06 AM" src="https://user-images.githubusercontent.com/10852790/112664830-a0e9c900-8e17-11eb-9464-76b865085b71.png">

Second picture shows the difference in monthly-mean albedo between two runs(this branch minus master) as a function of snow depth.  Results are more scattered because full model dynamics are on, so ecosystem structures and everything else differs.  But I think this also roughly makes sense.  

<img width="747" alt="Screen Shot 2021-03-26 at 9 34 15 AM" src="https://user-images.githubusercontent.com/10852790/112665388-3d13d000-8e18-11eb-809f-57803140dd68.png">

We should probably do a test of a global FATES-SP configured comparison against master.

<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
Not yet run through test suite.
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

