### PR TITLE
Manually reinstating `ai_min` after test failure

### DIFF
--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -2040,11 +2040,15 @@ contains
 
      integer :: cl,ft
      real(r8) :: ai
+     ! TODO: THIS MIN LAI IS AN ARTIFACT FROM TESTING LONG-AGO AND SHOULD BE REMOVED
+     ! THIS HAS BEEN KEPT THUS FAR TO MAINTAIN B4B IN TESTING OTHER COMMITS
+     real(r8),parameter :: ai_min = 0.1_r8
+
      real(r8),pointer   :: ai_profile
 
      ai = 0._r8
      if     (trim(ai_type) == 'elai') then
-        do cl = 1,cpatch%NCL_p
+        do cl = 1,cpatch%NCL_p 
            do ft = 1,numpft
               ai = ai + sum(cpatch%canopy_area_profile(cl,ft,1:cpatch%nrad(cl,ft)) * &
                     cpatch%elai_profile(cl,ft,1:cpatch%nrad(cl,ft)))
@@ -2076,6 +2080,8 @@ contains
         write(fates_log(),*) 'Unsupported area index sent to calc_areaindex'
         call endrun(msg=errMsg(sourcefile, __LINE__))
      end if
+
+     ai = max(ai_min,ai)
      
      return
 


### PR DESCRIPTION
Reinstating `ai_min` that was removed in PR #733 as it appears to be causing test failures.

### Description:
During testing of PR #734 and it's accompanying [CTSM PR #1324](https://github.com/ESCOMP/CTSM/pull/1324) it was discovered that merging in fates tag [sci.1.43.6_api.14.2.0](https://github.com/NGEET/fates/releases/tag/sci.1.43.6_api.14.2.0) into the snow occlusion fates PR branch was causing failures on the following `aux_clm` tests:

SMS_D_Lm6.f45_f45_mg37.I2000Clm45Fates.cheyenne_intel.clm-FatesColdDef
SMS_D_Lm6.f45_f45_mg37.I2000Clm50Fates.cheyenne_intel.clm-FatesColdDef
SMS_D_Lm6_P144x1.f45_f45_mg37.I2000Clm50Fates.cheyenne_intel.clm-FatesColdDef


### Collaborators: 
@rgknox @ekluzek @billsacks 

### Expectation of Answer Changes:
This will change answers relative to the last tag.

### Checklist:
- [ ] My change requires a change to the documentation.
- [x] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [x] If answers were expected to change, evaluation was performed and provided

### Test Results:
All the above tests pass now when merged into #734.

Testing of `fates` and `aux_clm` suite without #734 in progress.

CTSM (or) E3SM (specify which) test hash-tag:
See below for regression test details

CTSM (or) E3SM (specify which) baseline hash-tag:
See below for regression test details

FATES baseline hash-tag:
See below for regression test details

Test Output:
ctsm5.1.dev033 merged into pr branch and this pr branch merged onto #734: 
SMS_D_Lm6.f45_f45_mg37.I2000Clm50Fates.cheyenne_intel.clm-FatesColdDef: 
`/glade/u/home/glemieux/scratch/tests_0416-103437ch`

SMS_D_Lm6.f45_f45_mg37.I2000Clm50Fates.cheyenne_intel.clm-FatesColdDef: 
`/glade/u/home/glemieux/scratch/tests_0416-162804ch`

SMS_D_Lm6_P144x1.f45_f45_mg37.I2000Clm50Fates.cheyenne_intel.clm-FatesColdDef: 
`/glade/u/home/glemieux/scratch/tests_0416-162822ch`


See below for regression test details


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

