### PR TITLE
Add initialization of th_sat

### DIFF
--- a/biogeophys/FatesHydroWTFMod.F90
+++ b/biogeophys/FatesHydroWTFMod.F90
@@ -304,6 +304,7 @@ contains
   function get_thsat_base(this) result(th_sat)
     class(wrf_type)     :: this
     real(r8)            :: th_sat
+    th_sat = 0._r8
     write(fates_log(),*) 'The base thsat call'
     write(fates_log(),*) 'should never be actualized'
     write(fates_log(),*) 'check how the class pointer was setup'


### PR DESCRIPTION
Add initialization of th_sat (function return value) to avoid errors with Summit IBM XL compiler.

[BFB]

Test: SMS.ne4_ne4.FC5AV1C-L

E3SM hash: [9c9f3d532e495c274f10e6bcd1d7c06277a58ab5](https://github.com/E3SM-Project/E3SM/commit/9c9f3d532e495c274f10e6bcd1d7c06277a58ab5)

FATES hash: [5534a9405bbc5d9b825bf37bd0d65147bc0fda41](https://github.com/NGEET/fates/tree/5534a9405bbc5d9b825bf37bd0d65147bc0fda41)