### PR TITLE
Fix decay restarts

### DIFF
--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -1396,7 +1396,6 @@ contains
                curr_litt%seed_germ_decay(pft)*patch_site_areadis/newPatch%area
           
        end do
-
        
        ! -----------------------------------------------------------------------------
        ! Distribute the existing litter that was already in place on the donor

--- a/biogeochem/FatesSoilBGCFluxMod.F90
+++ b/biogeochem/FatesSoilBGCFluxMod.F90
@@ -1022,15 +1022,34 @@ contains
           
        end select
 
-       ! Add efflux to the litter pool. kg/ha/day -> kg/m2/day                                                                             
-       do id = 1,nlev_eff_decomp
-          flux_lab_si(id) = flux_lab_si(id) + &
-               sum(csite%flux_diags(el)%nutrient_efflux_scpf)*surface_prof(id)*area_inv
-       end do
-
-       
        currentPatch => csite%oldest_patch
        do while (associated(currentPatch))
+
+          ! If there is any efflux (from stores overflowing)
+          ! than pass that to the labile litter pool
+          
+          currentCohort => currentPatch%tallest
+          do while(associated(currentCohort))
+             if(.not.currentCohort%isnew)then
+                if(element_list(el).eq.carbon12_element) then
+                   efflux_ptr => currentCohort%daily_c_efflux
+                elseif(element_list(el).eq.nitrogen_element) then
+                   efflux_ptr => currentCohort%daily_n_efflux
+                elseif(element_list(el).eq.phosphorus_element) then
+                   efflux_ptr => currentCohort%daily_p_efflux
+                end if
+                
+                ! Unit conversion
+                ! kg/plant/day * plant/ha * ha/m2 -> kg/m2/day
+                
+                do id = 1,nlev_eff_decomp
+                   flux_lab_si(id) = flux_lab_si(id) + &
+                        efflux_ptr * currentCohort%n* AREA_INV * surface_prof(id)
+                end do
+             end if
+             currentCohort => currentCohort%shorter
+          end do
+
 
           ! Set a pointer to the litter object
           ! for the current element on the current

--- a/biogeochem/FatesSoilBGCFluxMod.F90
+++ b/biogeochem/FatesSoilBGCFluxMod.F90
@@ -997,9 +997,9 @@ contains
        
        select case (element_list(el))
        case (carbon12_element)
-          bc_out%litt_flux_cel_c_si(:) = 0._r8
-          bc_out%litt_flux_lig_c_si(:) = 0._r8
-          bc_out%litt_flux_lab_c_si(:) = 0._r8
+          bc_out%litt_flux_cel_c_si(:) = 0.0_r8
+          bc_out%litt_flux_lig_c_si(:) = 0.0_r8
+          bc_out%litt_flux_lab_c_si(:) = 0.0_r8
           flux_cel_si => bc_out%litt_flux_cel_c_si(:)
           flux_lab_si => bc_out%litt_flux_lab_c_si(:)
           flux_lig_si => bc_out%litt_flux_lig_c_si(:)
@@ -1022,35 +1022,16 @@ contains
           
        end select
 
+       ! Add efflux to the litter pool. kg/ha/day -> kg/m2/day                                                                             
+       do id = 1,nlev_eff_decomp
+          flux_lab_si(id) = flux_lab_si(id) + &
+               sum(csite%flux_diags(el)%nutrient_efflux_scpf)*surface_prof(id)*area_inv
+       end do
+
        
        currentPatch => csite%oldest_patch
        do while (associated(currentPatch))
 
-          ! If there is any efflux (from stores overflowing)
-          ! than pass that to the labile litter pool
-
-          currentCohort => currentPatch%tallest
-          do while(associated(currentCohort))
-             if(.not.currentCohort%isnew)then
-                if(element_list(el).eq.carbon12_element) then
-                   efflux_ptr => currentCohort%daily_c_efflux
-                elseif(element_list(el).eq.nitrogen_element) then
-                   efflux_ptr => currentCohort%daily_n_efflux
-                elseif(element_list(el).eq.phosphorus_element) then
-                   efflux_ptr => currentCohort%daily_p_efflux
-                end if
-
-                ! Unit conversion
-                ! kg/plant/day * plant/ha * ha/m2 -> kg/m2/day
-                
-                do id = 1,nlev_eff_decomp
-                   flux_lab_si(id) = flux_lab_si(id) + &
-                        efflux_ptr * currentCohort%n* AREA_INV * surface_prof(id)
-                end do
-             end if
-             currentCohort => currentCohort%shorter
-          end do
-          
           ! Set a pointer to the litter object
           ! for the current element on the current
           ! patch

--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -947,13 +947,13 @@ contains
            hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_seedgerm_litt)
 
 
-    call this%RegisterCohortVector(symbol_base='fates_seed_decay', vtype=cohort_r8, &
-            long_name_base='seed bank (non-germinated)',  &
+    call this%RegisterCohortVector(symbol_base='fates_seed_frag', vtype=cohort_r8, &
+            long_name_base='seed bank fragmentation flux (non-germinated)',  &
             units='kg/m2', veclength=num_elements, flushval = flushzero, &
             hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_seed_decay_litt)
 
-    call this%RegisterCohortVector(symbol_base='fates_seedgerm_decay', vtype=cohort_r8, &
-           long_name_base='seed bank (germinated)',  &
+    call this%RegisterCohortVector(symbol_base='fates_seedgerm_frag', vtype=cohort_r8, &
+           long_name_base='seed bank fragmentation flux (germinated)',  &
            units='kg/m2', veclength=num_elements, flushval = flushzero, &
            hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_seedgerm_decay_litt)
     

--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -151,6 +151,8 @@ module FatesRestartInterfaceMod
   integer :: ir_fnrt_litt
   integer :: ir_seed_litt
   integer :: ir_seedgerm_litt
+  integer :: ir_seed_decay_litt
+  integer :: ir_seedgerm_decay_litt
   integer :: ir_seed_prod_co
   integer :: ir_livegrass_pa
   integer :: ir_age_pa
@@ -944,6 +946,17 @@ contains
            units='kg/m2', veclength=num_elements, flushval = flushzero, &
            hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_seedgerm_litt)
 
+
+    call this%RegisterCohortVector(symbol_base='fates_seed_decay', vtype=cohort_r8, &
+            long_name_base='seed bank (non-germinated)',  &
+            units='kg/m2', veclength=num_elements, flushval = flushzero, &
+            hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_seed_decay_litt)
+
+    call this%RegisterCohortVector(symbol_base='fates_seedgerm_decay', vtype=cohort_r8, &
+           long_name_base='seed bank (germinated)',  &
+           units='kg/m2', veclength=num_elements, flushval = flushzero, &
+           hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_seedgerm_decay_litt)
+    
     call this%RegisterCohortVector(symbol_base='fates_ag_cwd_frag', vtype=cohort_r8, &
             long_name_base='above ground CWD frag flux',  &
             units='kg/m2/day', veclength=num_elements, flushval = flushzero, &
@@ -1940,6 +1953,8 @@ contains
                  do i = 1,numpft
                     this%rvars(ir_seed_litt+el)%r81d(io_idx_pa_pft) = litt%seed(i)
                     this%rvars(ir_seedgerm_litt+el)%r81d(io_idx_pa_pft) = litt%seed_germ(i)
+                    this%rvars(ir_seed_decay_litt+el)%r81d(io_idx_pa_pft) = litt%seed_decay(i)
+                    this%rvars(ir_seedgerm_decay_litt+el)%r81d(io_idx_pa_pft) = litt%seed_germ_decay(i)
                     io_idx_pa_pft = io_idx_pa_pft + 1
                  end do
 
@@ -2705,6 +2720,8 @@ contains
                  do i = 1,numpft
                      litt%seed(i)       = this%rvars(ir_seed_litt+el)%r81d(io_idx_pa_pft)
                      litt%seed_germ(i)  = this%rvars(ir_seedgerm_litt+el)%r81d(io_idx_pa_pft)
+                     litt%seed_decay(i)       = this%rvars(ir_seed_decay_litt+el)%r81d(io_idx_pa_pft)
+                     litt%seed_germ_decay(i)  = this%rvars(ir_seedgerm_decay_litt+el)%r81d(io_idx_pa_pft)
                      io_idx_pa_pft      = io_idx_pa_pft + 1
                   end do
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

This is a bugfix. These changes are required to ensure b4b comparisons between a base and its restart.  This is due to a recent regression from a very recent tag.

### Expectation of Answer Changes:

This will change the answers following a restart, particularly those answers related to soil carbon, as this will modify the litter flux slightly.  

### Checklist:
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [x] FATES PASS/FAIL regression tests were run


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

TBD

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

