### PR TITLE
restart fix for efflux variables

### DIFF
--- a/biogeochem/FatesSoilBGCFluxMod.F90
+++ b/biogeochem/FatesSoilBGCFluxMod.F90
@@ -1022,34 +1022,18 @@ contains
           
        end select
 
+       
+       ! If there is any efflux (from stores overflowing)
+       ! than pass that to the labile litter pool
+       
+       do id = 1,nlev_eff_decomp
+          flux_lab_si(id) = flux_lab_si(id) + &
+               sum(csite%flux_diags(el)%nutrient_efflux_scpf(:)) * &
+               area_inv * surface_prof(id)
+       end do
+       
        currentPatch => csite%oldest_patch
        do while (associated(currentPatch))
-
-          ! If there is any efflux (from stores overflowing)
-          ! than pass that to the labile litter pool
-          
-          currentCohort => currentPatch%tallest
-          do while(associated(currentCohort))
-             if(.not.currentCohort%isnew)then
-                if(element_list(el).eq.carbon12_element) then
-                   efflux_ptr => currentCohort%daily_c_efflux
-                elseif(element_list(el).eq.nitrogen_element) then
-                   efflux_ptr => currentCohort%daily_n_efflux
-                elseif(element_list(el).eq.phosphorus_element) then
-                   efflux_ptr => currentCohort%daily_p_efflux
-                end if
-                
-                ! Unit conversion
-                ! kg/plant/day * plant/ha * ha/m2 -> kg/m2/day
-                
-                do id = 1,nlev_eff_decomp
-                   flux_lab_si(id) = flux_lab_si(id) + &
-                        efflux_ptr * currentCohort%n* AREA_INV * surface_prof(id)
-                end do
-             end if
-             currentCohort => currentCohort%shorter
-          end do
-
 
           ! Set a pointer to the litter object
           ! for the current element on the current

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -3377,12 +3377,6 @@ end subroutine flush_hvars
 
          end do
 
-         ! and reset the disturbance-related field buffers
-
-         do el = 1, num_elements
-             call sites(s)%flux_diags(el)%ZeroFluxDiags()
-         end do
-
       enddo ! site loop
       
     end associate

--- a/tools/FatesPFTIndexSwapper.py
+++ b/tools/FatesPFTIndexSwapper.py
@@ -25,7 +25,9 @@ from scipy.io import netcdf
 
 pft_dim_name = 'fates_pft'
 prt_dim_name = 'fates_prt_organs'
-
+hydro_dim_name = 'fates_hydr_organs'
+litt_dim_name = 'fates_litterclass'
+string_dim_name = 'fates_string_length'
 
 class timetype:
 
@@ -165,22 +167,31 @@ def main(argv):
         # Idenfity if this variable has pft dimension
         pft_dim_found = -1
         prt_dim_found = -1
+        hydro_dim_found = -1
+        litt_dim_found  = -1
+        string_dim_found = -1
         pft_dim_len   = len(fp_in.variables.get(key).dimensions)
 
         for idim, name in enumerate(fp_in.variables.get(key).dimensions):
+
             # Manipulate data
             if(name==pft_dim_name):
                 pft_dim_found = idim
             if(name==prt_dim_name):
                 prt_dim_found = idim
-
+            if(name==litt_dim_name):
+                litt_dim_found = idim
+            if(name==hydro_dim_name):
+                hydro_dim_found = idim
+            if(name==string_dim_name):
+                string_dim_found = idim
 
         # Copy over the input data
         # Tedious, but I have to permute through all combinations of dimension position
         if( pft_dim_len == 0 ):
             out_var = fp_out.createVariable(key,'d',(fp_in.variables.get(key).dimensions))
             out_var.assignValue(float(fp_in.variables.get(key).data))
-        elif( (pft_dim_found==-1) & (prt_dim_found==-1) ):
+        elif( (pft_dim_found==-1) & (prt_dim_found==-1) & (litt_dim_found==-1) & (hydro_dim_found==-1)  ):
             out_var = fp_out.createVariable(key,'d',(fp_in.variables.get(key).dimensions))
             out_var[:] = in_var[:]
         elif( (pft_dim_found==0) & (pft_dim_len==1) ):           # 1D fates_pft
@@ -208,14 +219,28 @@ def main(argv):
             for id,ipft in enumerate(donor_pft_indices):
                 out_var[id] = fp_in.variables.get(key).data[ipft-1]
                 
-        elif( (prt_dim_found==0) & (pft_dim_len==2) ):          # fates_prt_organs - string_length
+        elif( (prt_dim_found==0) & (pft_dim_len==2) ):         
             out_var = fp_out.createVariable(key,'c',(fp_in.variables.get(key).dimensions))
             out_var[:] = in_var[:]
 
-        elif( prt_dim_found==0 ):
+        elif( (hydro_dim_found==0) & (string_dim_found>=0) ):      
+            out_var = fp_out.createVariable(key,'c',(fp_in.variables.get(key).dimensions))
+            out_var[:] = in_var[:]
+        
+        elif( (litt_dim_found==0) & (string_dim_found>=0) ):       
+            out_var = fp_out.createVariable(key,'c',(fp_in.variables.get(key).dimensions))
+            out_var[:] = in_var[:]   
+
+        elif( prt_dim_found==0 ): # fates_prt_organs - indices
             out_var = fp_out.createVariable(key,'d',(fp_in.variables.get(key).dimensions))
             out_var[:] = in_var[:]
-            
+
+        elif( litt_dim_found==0 ):
+            out_var = fp_out.createVariable(key,'d',(fp_in.variables.get(key).dimensions))
+            out_var[:] = in_var[:]
+        elif( hydro_dim_found==0):
+            out_var = fp_out.createVariable(key,'d',(fp_in.variables.get(key).dimensions))
+            out_var[:] = in_var[:]
         else:
             print('This variable has a dimensioning that we have not considered yet.')
             print('Please add this condition to the logic above this statement.')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

Efflux is defined at the cohort scale. Efflux is passed from the cohort to the output flux to the HLMs litter pool before we perform disturbance and mortality. Thus, in order for restarts to work, this flux at the site level must be preserved prior to mortality and disturbance.   Luckily, we can use the flux_diags structure which already exists to generate the output flux, this same flux will be preserved after a restart read. 

Fixes: #763


### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:

This should not change results, because we don't yet generate efflux in any tests.

<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

TBD

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

