### PR TITLE
Nutrient controls on leaf level photosynthetic processes 

### DIFF
--- a/biogeochem/FatesSoilBGCFluxMod.F90
+++ b/biogeochem/FatesSoilBGCFluxMod.F90
@@ -1182,7 +1182,7 @@ contains
     integer, parameter :: downreg_logi   = 2
     integer, parameter :: downreg_CN_logi = 3
     
-    integer, parameter :: downreg_type = downreg_linear
+    integer, parameter :: downreg_type = downreg_CN_logi
 
     
     real(r8), parameter :: logi_k   = 25.0_r8         ! logistic function k

--- a/biogeophys/FatesPlantRespPhotosynthMod.F90
+++ b/biogeophys/FatesPlantRespPhotosynthMod.F90
@@ -40,6 +40,7 @@ module FATESPlantRespPhotosynthMod
    use PRTGenericMod,     only : prt_cnp_flex_allom_hyp 
    use PRTGenericMod,     only : all_carbon_elements
    use PRTGenericMod,     only : nitrogen_element
+   use PRTGenericMod,     only : phosphorus_element
    use PRTGenericMod,     only : leaf_organ
    use PRTGenericMod,     only : fnrt_organ
    use PRTGenericMod,     only : sapw_organ
@@ -161,6 +162,10 @@ contains
                                    ! (umol electrons/m**2/s)
     real(r8) :: kp_z               ! leaf layer initial slope of CO2 response 
                                    ! curve (C4 plants)
+    real(r8) :: vcmax25top_prt     ! canopy top: variable maximum rate of carboxylation at 25C for parteh
+                                   ! (umol CO2/m**2/s)
+    real(r8) :: jmax25top_prt      ! canopy top: variable maximum electron transport rate at 25C for parteh
+                                   ! (umol electrons/m**2/s)
     real(r8) :: c13disc_z(nclmax,maxpft,nlevleaf) ! carbon 13 in newly assimilated carbon at leaf level
    
     real(r8) :: mm_kco2            ! Michaelis-Menten constant for CO2 (Pa)
@@ -169,10 +174,12 @@ contains
     real(r8) :: btran_eff          ! effective transpiration wetness factor (0 to 1)
     real(r8) :: stomatal_intercept_btran   ! water-stressed minimum stomatal conductance (umol H2O/m**2/s)
     real(r8) :: kn                 ! leaf nitrogen decay coefficient
+    real(r8) :: kn_prt             ! leaf nitrogen decay coefficient based on variable vcmax25top_prt
     real(r8) :: cf                 ! s m**2/umol -> s/m (ideal gas conversion) [umol/m3]
     real(r8) :: gb_mol             ! leaf boundary layer conductance (molar form: [umol /m**2/s])
     real(r8) :: ceair              ! vapor pressure of air, constrained (Pa)
     real(r8) :: nscaler            ! leaf nitrogen scaling coefficient
+    real(r8) :: nscaler_prt        ! leaf nitrogen scaling coefficient based on variable vcmax25top_prt
     real(r8) :: leaf_frac          ! ratio of to leaf biomass to total alive biomass
     real(r8) :: tcsoi              ! Temperature response function for root respiration. 
     real(r8) :: tcwood             ! Temperature response function for wood
@@ -188,6 +195,7 @@ contains
     real(r8) :: fnrt_n             ! Fine root nitrogen content (kgN/plant)
     real(r8) :: leaf_c             ! Leaf carbon (kgC/plant)
     real(r8) :: leaf_n             ! leaf nitrogen content (kgN/plant)
+    real(r8) :: leaf_p             ! leaf phosphorus (kgP/plant)
     real(r8) :: g_sb_leaves        ! Mean combined (stomata+boundary layer) leaf conductance [m/s]
                                    ! over all of the patch's leaves.  The "sb" refers to the combined
                                    ! "s"tomatal and "b"oundary layer.
@@ -206,6 +214,10 @@ contains
                                    ! over each cohort x layer.
     real(r8) :: cohort_eleaf_area  ! This is the effective leaf area [m2] reported by each cohort
     real(r8) :: lnc_top            ! Leaf nitrogen content per unit area at canopy top [gN/m2]
+    real(r8) :: lpc_top            ! Leaf phosphorus content per unit area at canopy top [gP/m2]
+    real(r8) :: jmax_np1           ! jmax~np relationship coefficient
+    real(r8) :: jmax_np2           ! jmax~np relationship coefficient
+    real(r8) :: jmax_np3           ! jmax~np relationship coefficient
     real(r8) :: lmr25top           ! canopy top leaf maint resp rate at 25C 
                                    ! for this plant or pft (umol CO2/m**2/s)
     real(r8) :: leaf_inc           ! LAI-only portion of the vegetation increment of dinc_ed
@@ -251,8 +263,17 @@ contains
          slatop    => prt_params%slatop , &  ! specific leaf area at top of canopy, 
                                              ! projected area basis [m^2/gC]
          woody     => prt_params%woody,   &  ! Is vegetation woody or not? 
-         stomatal_intercept   => EDPftvarcon_inst%stomatal_intercept ) !Unstressed minimum stomatal conductance
+         stomatal_intercept   => EDPftvarcon_inst%stomatal_intercept, &  !Unstressed minimum stomatal conductance
+         vcmax_np1   => EDPftvarcon_inst%vcmax_np1, &  !vcmax~np relationship coefficient
+         vcmax_np2   => EDPftvarcon_inst%vcmax_np2, &  !vcmax~np relationship coefficient
+         vcmax_np3   => EDPftvarcon_inst%vcmax_np3, &  !vcmax~np relationship coefficient
+         vcmax_np4   => EDPftvarcon_inst%vcmax_np4 )   !vcmax~np relationship coefficient
 
+         ! jmax~np relationship coefficients needed in the parteh calculation of
+         ! variable jmax25top_prt
+         jmax_np1 = 1.246_r8     
+         jmax_np2 = 0.886_r8        
+         jmax_np3 = 0.089_r8        
 
       do s = 1,nsites
 
@@ -434,24 +455,8 @@ contains
                                 btran_eff = btran_eff*currentPatch%bstress_sal_ft(ft)
                               endif 
                               
-                              
-                              ! Bonan et al (2011) JGR, 116, doi:10.1029/2010JG001593 used
-                              ! kn = 0.11. Here, derive kn from vcmax25 as in Lloyd et al 
-                              ! (2010) Biogeosciences, 7, 1833-1859
-                              
-                              kn = decay_coeff_kn(ft,currentCohort%vcmax25top)
-
-                              ! Scale for leaf nitrogen profile
-                              nscaler = exp(-kn * cumulative_lai)
-                              
-                              ! Leaf maintenance respiration to match the base rate used in CN
-                              ! but with the new temperature functions for C3 and C4 plants.
-
-                              ! CN respiration has units:  g C / g N [leaf] / s. This needs to be
-                              ! converted from g C / g N [leaf] / s to umol CO2 / m**2 [leaf] / s
-                              
-                              ! Then scale this value at the top of the canopy for canopy depth
-                              ! Leaf nitrogen concentration at the top of the canopy (g N leaf / m**2 leaf)
+                             
+                              ! Leaf nutrient concentrations at the top of the canopy (g N leaf / m**2 leaf)
                               select case(hlm_parteh_mode)
                               case (prt_carbon_allom_hyp)
 
@@ -462,20 +467,52 @@ contains
                                  leaf_c  = currentCohort%prt%GetState(leaf_organ, all_carbon_elements)
                                  if( (leaf_c*slatop(ft)) > nearzero) then
                                     leaf_n  = currentCohort%prt%GetState(leaf_organ, nitrogen_element)
+                                    leaf_p  = currentCohort%prt%GetState(leaf_organ, phosphorus_element)
                                     lnc_top = leaf_n / (slatop(ft) * leaf_c )
+                                    lpc_top = leaf_p / (slatop(ft) * leaf_c )
+                                    ! lnc_top = leaf_n / currentPatch%tlai_profile(cl,ft,iv)
+                                    ! lpc_top = leaf_p / currentPatch%tlai_profile(cl,ft,iv)
+                                    lnc_top = min(max(lnc_top,0.25_r8),3.0_r8) !based on doi: 10.1002/ece3.1173
+                                    lpc_top = min(max(lpc_top,0.014_r8),0.85_r8) !based on doi: 10.1002/ece3.1173
                                  else
-                                    lnc_top  = prt_params%nitr_stoich_p1(ft,prt_params%organ_param_id(leaf_organ))/slatop(ft)
+                                    lnc_top = prt_params%nitr_stoich_p1(ft,prt_params%organ_param_id(leaf_organ))/slatop(ft)
+                                    lpc_top = prt_params%phos_stoich_p1(ft,prt_params%organ_param_id(leaf_organ))/slatop(ft)
                                  end if
                                     
                                  ! If one wants to break coupling with dynamic N conentrations,
                                  ! use the stoichiometry parameter
                                  ! lnc_top  = prt_params%nitr_stoich_p1(ft,prt_params%organ_param_id(leaf_organ))/slatop(ft)
                                  
+                                 vcmax25top_prt = exp(vcmax_np1(ft) + vcmax_np2(ft)*log(lnc_top) + &
+                                          vcmax_np3(ft)*log(lpc_top) + vcmax_np4(ft)*log(lnc_top)*log(lpc_top))
+                                 jmax25top_prt = exp(jmax_np1 + jmax_np2*log(vcmax25top_prt) + jmax_np3*log(lpc_top))
+                                 vcmax25top_prt = min(max(vcmax25top_prt, 10.0_r8), 150.0_r8)
+                                 jmax25top_prt  = min(max(jmax25top_prt, 10.0_r8), 250.0_r8)
+
+                                 kn_prt = decay_coeff_kn(ft,vcmax25top_prt)
+                                 nscaler_prt = exp(-kn_prt * cumulative_lai) 
+
                               end select
 
                               lmr25top = 2.525e-6_r8 * (1.5_r8 ** ((25._r8 - 20._r8)/10._r8))
                               lmr25top = lmr25top * lnc_top / (umolC_to_kgC * g_per_kg)
                               
+                              ! Bonan et al (2011) JGR, 116, doi:10.1029/2010JG001593 used
+                              ! kn = 0.11. Here, derive kn from vcmax25 as in Lloyd et al 
+                              ! (2010) Biogeosciences, 7, 1833-1859
+
+                              kn = decay_coeff_kn(ft,currentCohort%vcmax25top)
+
+                              ! Scale for leaf nitrogen profile
+                              nscaler = exp(-kn * cumulative_lai)
+
+                              ! Leaf maintenance respiration to match the base rate used in CN
+                              ! but with the new temperature functions for C3 and C4 plants.
+
+                              ! CN respiration has units:  g C / g N [leaf] / s. This needs to be
+                              ! converted from g C / g N [leaf] / s to umol CO2 / m**2 [leaf] / s
+
+                              ! Then scale this value at the top of the canopy for canopy depth
 
                               ! Part VII: Calculate dark respiration (leaf maintenance) for this layer
                               call LeafLayerMaintenanceRespiration( lmr25top,                 &  ! in
@@ -501,8 +538,12 @@ contains
                                                              currentCohort%vcmax25top,           &  ! in
                                                              currentCohort%jmax25top,            &  ! in
                                                              currentCohort%kp25top,              &  ! in
+                                                             vcmax25top_prt,                     &  ! in
+                                                             jmax25top_prt,                      &  ! in
                                                              nscaler,                            &  ! in
+                                                             nscaler_prt,                        &  ! in
                                                              bc_in(s)%t_veg_pa(ifp),             &  ! in
+                                                             bc_in(s)%dayl_factor_pa(ifp),       &  ! in
                                                              btran_eff,                          &  ! in
                                                              vcmax_z,                            &  ! out
                                                              jmax_z,                             &  ! out
@@ -542,7 +583,7 @@ contains
 
                               rate_mask_z(iv,ft,cl) = .true.
                            end if
-                        end do
+                        end do  !leaf-layer loop
 
                         ! Zero cohort flux accumulators.
                         currentCohort%npp_tstep  = 0.0_r8
@@ -815,7 +856,7 @@ contains
             
             currentPatch => currentPatch%younger
             
-        end do
+        end do  !patch loop
         
         deallocate(rootfr_ft)
  
@@ -1813,8 +1854,12 @@ contains
                                          vcmax25top_ft, &
                                          jmax25top_ft, &
                                          co2_rcurve_islope25top_ft, &
+                                         vcmax25top_prt_ft, &
+                                         jmax25top_prt_ft, &
                                          nscaler,    &
+                                         nscaler_prt, & 
                                          veg_tempk,      &
+                                         dayl_factor, &
                                          btran, &
                                          vcmax, &
                                          jmax, &
@@ -1842,14 +1887,20 @@ contains
       real(r8), intent(in) :: parsun_lsl      ! PAR absorbed in sunlit leaves for this layer
       integer,  intent(in) :: ft              ! (plant) Functional Type Index
       real(r8), intent(in) :: nscaler         ! Scale for leaf nitrogen profile
+      real(r8), intent(in) :: nscaler_prt     ! Scale for leaf nitrogen profile based on variable vcmax25top_prt
       real(r8), intent(in) :: vcmax25top_ft   ! canopy top maximum rate of carboxylation at 25C 
                                               ! for this pft (umol CO2/m**2/s)
       real(r8), intent(in) :: jmax25top_ft    ! canopy top maximum electron transport rate at 25C 
                                               ! for this pft (umol electrons/m**2/s)
       real(r8), intent(in) :: co2_rcurve_islope25top_ft ! initial slope of CO2 response curve
                                               ! (C4 plants) at 25C, canopy top, this pft
-      real(r8), intent(in) :: veg_tempk           ! vegetation temperature
-      real(r8), intent(in) :: btran           ! transpiration wetness factor (0 to 1) 
+      real(r8), intent(in) :: vcmax25top_prt_ft  ! canopy top maximum rate of carboxylation at 25C for parteh
+                                                 ! for this pft (umol CO2/m**2/s)
+      real(r8), intent(in) :: jmax25top_prt_ft   ! canopy top maximum electron transport rate at 25C for parteh
+                                                 ! for this pft (umol CO2/m**2/s) 
+      real(r8), intent(in) :: veg_tempk          ! vegetation temperature
+      real(r8), intent(in) :: dayl_factor        ! daylength scaling factor (0-1)
+      real(r8), intent(in) :: btran              ! transpiration wetness factor (0 to 1) 
                                                     
       real(r8), intent(out) :: vcmax             ! maximum rate of carboxylation (umol co2/m**2/s)
       real(r8), intent(out) :: jmax              ! maximum electron transport rate 
@@ -1885,6 +1936,8 @@ contains
       
       vcmaxse = EDPftvarcon_inst%vcmaxse(FT)
       jmaxse  = EDPftvarcon_inst%jmaxse(FT)
+      !vcmaxse = 668.39_r8 - 1.07_r8 * min(max((temp_a10-tfrz),11._r8),35._r8) !Kattge & Knorr 2007
+      !jmaxse  = 659.70_r8 - 0.75_r8 * min(max((temp_a10-tfrz),11._r8),35._r8) !Kattge & Knorr 2007
 
       vcmaxc = fth25_f(vcmaxhd, vcmaxse)
       jmaxc  = fth25_f(jmaxhd, jmaxse)
@@ -1895,11 +1948,29 @@ contains
          co2_rcurve_islope = 0._r8
       else                                     ! day time
 
+         select case(hlm_parteh_mode)
+         case (prt_carbon_allom_hyp)
+              !vcmax25top_ft = lnc_top * flnr * fnr * act25 * dayl_factor
+              !jmax25top_ft = (2.59_r8 - 0.035_r8*min(max((temp_a10-tfrz),11._r8),35._r8)) * vcmax25top_ft
+
+         case (prt_cnp_flex_allom_hyp)
+
+              ! Using the newly calculated top of the canopy vcmax and jmax, not the parameter file values
+              vcmax25 = vcmax25top_prt_ft * dayl_factor * nscaler_prt
+              jmax25  = jmax25top_prt_ft * dayl_factor * nscaler_prt
+         
+         end select
+
+
          ! Vcmax25top was already calculated to derive the nscaler function
          vcmax25 = vcmax25top_ft * nscaler
          jmax25  = jmax25top_ft * nscaler
          co2_rcurve_islope25 = co2_rcurve_islope25top_ft * nscaler
          
+         print*,"vcmax25top, vcmax25top_prt, vcmax25: ",vcmax25top_ft,vcmax25top_prt_ft,vcmax25
+         print*,"nscaler, nscaler_prt, day_length : ",nscaler,nscaler_prt,dayl_factor
+         print*,"jmax25top, jmax25top_prt, jmax25: ",jmax25top_ft,jmax25top_prt_ft,jmax25
+
          ! Adjust for temperature
          vcmax = vcmax25 * ft1_f(veg_tempk, vcmaxha) * fth_f(veg_tempk, vcmaxhd, vcmaxse, vcmaxc)
          jmax  = jmax25 * ft1_f(veg_tempk, jmaxha) * fth_f(veg_tempk, jmaxhd, jmaxse, jmaxc)

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -72,7 +72,7 @@ module EDPftvarcon
                                                      ! decreases light interception
      real(r8), allocatable :: c3psn(:)               ! index defining the photosynthetic 
                                                      ! pathway C4 = 0,  C3 = 1
-    
+     real(r8), allocatable :: flnr(:)                ! fraction of leaf N in Rubisco 
      real(r8), allocatable :: smpso(:)               ! Soil water potential at full stomatal opening 
                                                      ! (non-HYDRO mode only) [mm]
      real(r8), allocatable :: smpsc(:)               ! Soil water potential at full stomatal closure 
@@ -378,6 +378,10 @@ contains
          dimension_names=dim_names, lower_bounds=dim_lower_bound)
 
     name = 'fates_leaf_c3psn'
+    call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
+         dimension_names=dim_names, lower_bounds=dim_lower_bound)
+
+    name = 'fates_leaf_flnr'
     call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
          dimension_names=dim_names, lower_bounds=dim_lower_bound)
 
@@ -713,6 +717,10 @@ contains
     name = 'fates_leaf_clumping_index'
     call fates_params%RetreiveParameterAllocate(name=name, &
          data=this%clumping_index)
+
+    name = 'fates_leaf_flnr'
+    call fates_params%RetreiveParameterAllocate(name=name, &
+         data=this%flnr)
 
     name = 'fates_leaf_c3psn'
     call fates_params%RetreiveParameterAllocate(name=name, &
@@ -1345,6 +1353,7 @@ contains
         write(fates_log(),fmt0) 'xl = ',EDPftvarcon_inst%xl
         write(fates_log(),fmt0) 'clumping_index = ',EDPftvarcon_inst%clumping_index
         write(fates_log(),fmt0) 'c3psn = ',EDPftvarcon_inst%c3psn
+        write(fates_log(),fmt0) 'flnr = ',EDPftvarcon_inst%flnr
         write(fates_log(),fmt0) 'vcmax25top = ',EDPftvarcon_inst%vcmax25top
         write(fates_log(),fmt0) 'smpso = ',EDPftvarcon_inst%smpso
         write(fates_log(),fmt0) 'smpsc = ',EDPftvarcon_inst%smpsc

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -99,6 +99,10 @@ module EDPftvarcon
      real(r8), allocatable :: jmaxhd(:)
      real(r8), allocatable :: vcmaxse(:)
      real(r8), allocatable :: jmaxse(:)
+     real(r8), allocatable :: vcmax_np1(:) 
+     real(r8), allocatable :: vcmax_np2(:)
+     real(r8), allocatable :: vcmax_np3(:)
+     real(r8), allocatable :: vcmax_np4(:)
      real(r8), allocatable :: germination_rate(:)        ! Fraction of seed mass germinating per year (yr-1)
      real(r8), allocatable :: seed_decay_rate(:)         ! Fraction of seed mass (both germinated and 
                                                          ! ungerminated), decaying per year    (yr-1)
@@ -509,6 +513,22 @@ contains
     call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
          dimension_names=dim_names, lower_bounds=dim_lower_bound)
 
+    name = 'fates_eca_vcmax_np1'
+    call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
+         dimension_names=dim_names, lower_bounds=dim_lower_bound)
+
+    name = 'fates_eca_vcmax_np2'
+    call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
+         dimension_names=dim_names, lower_bounds=dim_lower_bound)
+    
+    name = 'fates_eca_vcmax_np3'
+    call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
+         dimension_names=dim_names, lower_bounds=dim_lower_bound)
+
+    name = 'fates_eca_vcmax_np4'
+    call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
+         dimension_names=dim_names, lower_bounds=dim_lower_bound)
+
     name = 'fates_seed_germination_rate'
     call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
          dimension_names=dim_names, lower_bounds=dim_lower_bound)
@@ -839,6 +859,22 @@ contains
     name = 'fates_leaf_jmaxse'
     call fates_params%RetreiveParameterAllocate(name=name, &
          data=this%jmaxse)
+
+    name = 'fates_eca_vcmax_np1'
+    call fates_params%RetreiveParameterAllocate(name=name, &
+         data=this%vcmax_np1)
+
+    name = 'fates_eca_vcmax_np2'
+    call fates_params%RetreiveParameterAllocate(name=name, &
+         data=this%vcmax_np2)
+
+    name = 'fates_eca_vcmax_np3'
+    call fates_params%RetreiveParameterAllocate(name=name, &
+         data=this%vcmax_np3)
+
+    name = 'fates_eca_vcmax_np4'
+    call fates_params%RetreiveParameterAllocate(name=name, &
+         data=this%vcmax_np4)
 
     name = 'fates_seed_germination_rate'
     call fates_params%RetreiveParameterAllocate(name=name, &
@@ -1328,6 +1364,10 @@ contains
         write(fates_log(),fmt0) 'jmaxhd = ',EDPftvarcon_inst%jmaxhd
         write(fates_log(),fmt0) 'vcmaxse = ',EDPftvarcon_inst%vcmaxse
         write(fates_log(),fmt0) 'jmaxse = ',EDPftvarcon_inst%jmaxse
+        write(fates_log(),fmt0) 'vcmax_np1 = ',EDPftvarcon_inst%vcmax_np1
+        write(fates_log(),fmt0) 'vcmax_np1 = ',EDPftvarcon_inst%vcmax_np2
+        write(fates_log(),fmt0) 'vcmax_np1 = ',EDPftvarcon_inst%vcmax_np3
+        write(fates_log(),fmt0) 'vcmax_np1 = ',EDPftvarcon_inst%vcmax_np4
         write(fates_log(),fmt0) 'germination_timescale = ',EDPftvarcon_inst%germination_rate
         write(fates_log(),fmt0) 'seed_decay_turnover = ',EDPftvarcon_inst%seed_decay_rate
         write(fates_log(),fmt0) 'trim_limit = ',EDPftvarcon_inst%trim_limit

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -238,7 +238,7 @@ contains
     fates%bc_in(s)%precip24_pa(:) = 0.0_r8
     fates%bc_in(s)%relhumid24_pa(:) = 0.0_r8
     fates%bc_in(s)%wind24_pa(:)     = 0.0_r8
-
+    fates%bc_in(s)%t_a10_pa(:)      = 0.0_r8
     fates%bc_in(s)%lightning24(:)      = 0.0_r8
     fates%bc_in(s)%pop_density(:)      = 0.0_r8
     fates%bc_in(s)%solad_parb(:,:)     = 0.0_r8
@@ -473,6 +473,7 @@ contains
 
       ! Photosynthesis
       allocate(bc_in%filter_photo_pa(maxPatchesPerSite))
+      allocate(bc_in%t_a10_pa(maxPatchesPerSite))
       allocate(bc_in%dayl_factor_pa(maxPatchesPerSite))
       allocate(bc_in%esat_tv_pa(maxPatchesPerSite))
       allocate(bc_in%eair_pa(maxPatchesPerSite))

--- a/main/FatesInterfaceTypesMod.F90
+++ b/main/FatesInterfaceTypesMod.F90
@@ -405,7 +405,10 @@ module FatesInterfaceTypesMod
 
       ! daylength scaling factor (0-1)
       real(r8), allocatable :: dayl_factor_pa(:)
-      
+     
+      ! 10-day running mean of 2m temperature (K)
+      real(r8), allocatable :: t_a10_pa(:)
+ 
       ! saturation vapor pressure at t_veg (Pa)
       real(r8), allocatable :: esat_tv_pa(:)
 

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -166,6 +166,18 @@ variables:
 	double fates_eca_vmax_ptase(fates_pft) ;
 		fates_eca_vmax_ptase:units = "gP/m2/s" ;
 		fates_eca_vmax_ptase:long_name = "maximum production rate for biochemical P (per m2) (ECA)" ;
+        double fates_eca_vcmax_np1(fates_pft) ;
+                fates_eca_vcmax_np1:long_name = "vcmax~np relationship coefficient" ;
+                fates_eca_vcmax_np1:unit = "" ;
+        double fates_eca_vcmax_np2(fates_pft) ;
+                fates_eca_vcmax_np2:long_name = "vcmax~np relationship coefficient" ;
+                fates_eca_vcmax_np2:unit = "" ;
+        double fates_eca_vcmax_np3(fates_pft) ;
+                fates_eca_vcmax_np3:long_name = "vcmax~np relationship coefficient" ;
+                fates_eca_vcmax_np3:unit = "" ;
+        double fates_eca_vcmax_np4(fates_pft) ;
+                fates_eca_vcmax_np4:long_name = "vcmax~np relationship coefficient" ;
+                fates_eca_vcmax_np4:unit = "" ;
 	double fates_fire_alpha_SH(fates_pft) ;
 		fates_fire_alpha_SH:units = "m / (kw/m)**(2/3)" ;
 		fates_fire_alpha_SH:long_name = "spitfire parameter, alpha scorch height, Equation 16 Thonicke et al 2010" ;
@@ -383,10 +395,10 @@ variables:
 		fates_prescribed_npp_understory:units = "kgC / m^2 / yr" ;
 		fates_prescribed_npp_understory:long_name = "NPP per unit crown area of understory trees for prescribed physiology mode" ;
 	double fates_prescribed_nuptake(fates_pft) ;
-	   fates_prescribed_nuptake:units = "fraction" ;
+	        fates_prescribed_nuptake:units = "fraction" ;
 		fates_prescribed_nuptake:long_name = "Prescribed N uptake flux. 0=fully coupled simulation >0=prescribed (experimental)" ;
 	double fates_prescribed_puptake(fates_pft) ;
-    	fates_prescribed_puptake:units = "fraction" ;
+    	        fates_prescribed_puptake:units = "fraction" ;
 		fates_prescribed_puptake:long_name = "Prescribed P uptake flux. 0=fully coupled simulation, >0=prescribed (experimental)" ;
 	double fates_prescribed_recruitment(fates_pft) ;
 		fates_prescribed_recruitment:units = "n/yr" ;
@@ -833,6 +845,18 @@ data:
 
  fates_eca_vmax_ptase = 5e-09, 5e-09, 5e-09, 5e-09, 5e-09, 5e-09, 5e-09, 
     5e-09, 5e-09, 5e-09, 5e-09, 5e-09 ;
+
+ fates_eca_vcmax_np1 = 4.02421875, 3.2345, 4.800, 3.878125, 4.800, 4.7175,
+    3.9421875, 3.700, 3.7859375, 3.86757, 3.7859375, 4.43859375 ;
+
+ fates_eca_vcmax_np2 = 0.7640625, 0.7828125, 0.7453125, 0.9140625, 0.8015625,
+    0.91875, 1.096875, 0.6, 1.134375, 0.742968, 1.134375, 0.6703125 ;
+
+ fates_eca_vcmax_np3 = 0.07125, 0.08375, 0.08625, 0.19125, 0.12125, 0.185,
+    0.1225, 0.04, 0.1725, 0.126875, 0.1725, 0.14625 ;
+
+ fates_eca_vcmax_np4 = 0.282, 0.282, 0.282, 0.282, 0.282, 0.282, 0.282, 0.282,
+    0.282, 0.282, 0.282, 0.282 ;
 
  fates_fire_alpha_SH = 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 
     0.2 ;

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -259,6 +259,9 @@ variables:
 	double fates_leaf_c3psn(fates_pft) ;
 		fates_leaf_c3psn:units = "flag" ;
 		fates_leaf_c3psn:long_name = "Photosynthetic pathway (1=c3, 0=c4)" ;
+        double fates_leaf_flnr(fates_pft) ;
+		fates_leaf_flnr:units = "gN Rubisco / gN leaf" ;
+		fates_leaf_flnr:long_name = "fraction of leaf N in the Rubisco enzyme" ;
 	double fates_leaf_clumping_index(fates_pft) ;
 		fates_leaf_clumping_index:units = "fraction (0-1)" ;
 		fates_leaf_clumping_index:long_name = "factor describing how much self-occlusion of leaf scattering elements decreases light interception" ;
@@ -968,6 +971,9 @@ data:
   0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75, 0.75 ;
 
  fates_leaf_c3psn = 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0 ;
+ 
+ fates_leaf_flnr = 0.0461, 0.04875, 0.0546, 0.0515, 0.0716, 0.1007, 0.0517, 
+    0.0943, 0.0943, 0.1365, 0.1365, 0.09 ;
 
  fates_leaf_clumping_index = 0.85, 0.85, 0.8, 0.85, 0.85, 0.9, 0.85, 0.9, 
     0.9, 0.75, 0.75, 0.75 ;

--- a/parteh/PRTAllometricCNPMod.F90
+++ b/parteh/PRTAllometricCNPMod.F90
@@ -1601,11 +1601,11 @@ contains
 
     ! If any N or P is still hanging around, put it in storage
 
-    state_n(store_id)%ptr = state_n(store_id)%ptr + n_gain
-    state_p(store_id)%ptr = state_p(store_id)%ptr + p_gain
+    !state_n(store_id)%ptr = state_n(store_id)%ptr + n_gain
+    !state_p(store_id)%ptr = state_p(store_id)%ptr + p_gain
 
-    n_gain = 0._r8
-    p_gain = 0._r8
+    !n_gain = 0._r8
+    !p_gain = 0._r8
     
     
     ! -----------------------------------------------------------------------------------
@@ -1638,13 +1638,13 @@ contains
     ! -----------------------------------------------------------------------------------
 
     c_efflux = max(0.0_r8,c_gain)
-!    n_efflux = max(0.0_r8,n_gain)
-!    p_efflux = max(0.0_r8,p_gain)
+    n_efflux = max(0.0_r8,n_gain)
+    p_efflux = max(0.0_r8,p_gain)
 
 
     c_gain = 0.0_r8
-!    n_gain = 0.0_r8
-!    p_gain = 0.0_r8
+    n_gain = 0.0_r8
+    p_gain = 0.0_r8
 
     return
   end subroutine CNPAllocateRemainder


### PR DESCRIPTION
This code takes into account leaf-level nutrient effects on photosynthesis when PARTEH is used, particularly updating how the vcmax25 and jmax25 terms are calculated. These new relationships between leaf N, leaf P, and regression coefficients estimated from a photosynthesis data set will allow for a dynamic approach to represent nutrient constraints on photosynthesis.

Connected to the issue discussion at #597 , #443 , and could later be important for the acclimation work being done by others. 

### Description:
Following the work that was implemented in ELMv1 by Qing Zhu 2019 (https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2018MS001571), the code has been updated so that "photosynthesis is a function of leaf N (lnc: gN/m2 leaf area) and leaf P (lpc: gP/m2 leaf area) contents, which are commonly measured leaf properties, and their fundamental controls on plant photosynthesis rates are widely supported by observations (Kattge et al., 2009; Reich et al., 2009)." 

The equations for vcmax25top and jmax25top have now been updated to be a function of leaf N and leaf P, based on the results from (Walker et al., 2014), instead of the static values provided in the parameter file. 
These changes only occur when PARTEH is turned in (in c-only mode and CNP mode in PARTEH). The default, non-PARTEH mode, still uses the vcmax25top from the parameter file, and jmax25top being derived from the parameter file vcmax25top within "FatesParameterDerivedMod". 

Now that there is a varying vcmax25top term, additional changes need to be made where other terms are based on vcmax25top. For example, the "kn" term (the decay coefficient) is now based on the newly updated vcmax25top, which in turn produces a new "nscaler" term (leaf nitrogen scaling coefficient).  Two new variables were introduced to keep track of these new terms: kn_prt, and nscaler_prt (standing for PARTEH). For now a newly updated "kn_prt" term is only being implemented in the photosynthesis code when using PARTEH, not in other parts of the code where "kn" is used, such as in FatesAllometryMod when using kn to calculate things like LAI an SLA. The default, parameter value of vcmax25top is still being used. 

The "kp25top" term (initial slope of CO2 response curve) has also been updated to account for the varying vcmax25top, but only when using PARTEH. Otherwise kp25top is still being derived in "FatesParameterDerivedMod" using this%kp25top(ft,iage)   = 20000._r8 * vcmax25top(ft,iage).   
Note - I would appreciate any feedback on this change, and also make sure I'm not double charging kp25top * 20000 twice. In the LEAFN figure below the initial jump in leaf N in the "w/ photosyn. CO2 response" test is due to this sudden change in how kp25top is calculated, which wasn't used during the spinup procedure. 

### Collaborators:
@rgknox , @walkeranthonyp , @ckoven , @Qing Zhu, @rosiealice , @alistairrogers 

### Expectation of Answer Changes:
These code changes will definitely change answers. Below are some output examples from different scenarios testing the changes to different forest states and fluxes. 
All simulations began after running an AD spinup case (with supplemental N and P), a 200-year regular spinup (with AD turned off, and no supplemental N and P, until all carbon pools were stable in equilibrium). Then code changes to photosynthesis were turned on. 
Legend key for figures below:
"Regular Spinup" - continuing the regular spinup mode, with no leaf level photosynthesis changes (as a pseudo default case)
"w/ photosyn." = all leaf level photosynthesis code changes, including adding the multiplier of "day length factor", which allows for the consideration of light limitation. Testing at a boreal forest site, so large impacts. 
"w/ photosyn. no day-length" = removing the day length multiplying factor to test the impacts of only the leaf level nutrient additions. 
"w/ photosyn. CO2 response" = all leaf level photosynthesis code changes, including adding the multiplier of day length factor, and slope of CO2 response curve based on updated vcmax25top. 

"C-only PARTEH" = test of if case is (prt_carbon_allom_hyp), and using the new approach of vcmax25top_prt = lnc_top * flnr(ft) * fnr * act25. 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided

Yes, the code changes requires these checklist items and they still need to be done. 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

E3SM = Ryan's PARTEH branch = "rgknox/lnd/fates-cnp      cdbeea0 Made modifications to supplementation of NP during FATES-ECA."

FATES baseline hash-tag:

Test Output:
Single site test, in Alaska boreal forest - 

![image](https://user-images.githubusercontent.com/8737688/128381486-c6a80c1d-b001-497d-8e04-e69d8458aa14.png)

![image](https://user-images.githubusercontent.com/8737688/128381564-cb48125a-2f02-4aae-afff-60d1f5eeff54.png)


![image](https://user-images.githubusercontent.com/8737688/128381650-12358bd6-a54e-4678-9f59-52763418d1c6.png)


![image](https://user-images.githubusercontent.com/8737688/128381671-542cc731-a6fb-42b6-aaf9-1ff36299ed43.png)


![image](https://user-images.githubusercontent.com/8737688/128413670-adce0189-021c-4e05-9ce4-c94334b6fa4d.png)

![image](https://user-images.githubusercontent.com/8737688/128413694-b5b7de13-e1b7-48c8-87c8-ab53013f902d.png)




<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

