### PR TITLE
logic around test on hlm_pft_map test plus a couple other things

### DIFF
--- a/biogeochem/FatesAllometryMod.F90
+++ b/biogeochem/FatesAllometryMod.F90
@@ -1330,16 +1330,15 @@ contains
     
     ! ======================================================================
     ! This is a power function for leaf biomass from plant diameter.
-    !
-    ! log(bl) = a2 + b2*log(h)
-    ! bl = exp(a2) * h**b2
     ! ======================================================================
     
+    ! p1 and p2 represent the parameters that govern total beaf dry biomass, 
+    ! and the output argument blmax is the leaf carbon only
     
     real(r8),intent(in)  :: d         ! plant diameter [cm]
     real(r8),intent(in)  :: p1        ! parameter 1  (slope)
     real(r8),intent(in)  :: p2        ! parameter 2  (curvature, exponent)
-    real(r8),intent(in)  :: c2b       ! carbon to biomass multiplier
+    real(r8),intent(in)  :: c2b       ! carbon to biomass multiplier (~2)
     
     real(r8),intent(out) :: blmax     ! plant leaf biomass [kgC]
     real(r8),intent(out),optional :: dblmaxdd  ! change leaf bio per diameter [kgC/cm]
@@ -1674,7 +1673,7 @@ contains
     real(r8),intent(in)  :: p2  ! allometry parameter 2
     real(r8),intent(in)  :: wood_density
     real(r8),intent(in)  :: c2b
-    real(r8),intent(out) :: bagw     ! plant height [m]
+    real(r8),intent(out) :: bagw     ! plant aboveground biomass [kgC]
     real(r8),intent(out),optional :: dbagwdd  ! change in agb per diameter [kgC/cm]
     
     real(r8) :: dbagwdd1,dbagwdd2,dbagwdd3
@@ -1730,10 +1729,10 @@ contains
 
     
     real(r8),intent(in)  :: d       ! plant diameter [cm]
-    real(r8),intent(in)  :: p1  ! allometry parameter 1
-    real(r8),intent(in)  :: p2  ! allometry parameter 2
+    real(r8),intent(in)  :: p1      ! allometry parameter 1
+    real(r8),intent(in)  :: p2      ! allometry parameter 2
     real(r8),intent(in)  :: c2b     ! carbon to biomass multiplier ~2
-    real(r8),intent(out) :: bagw     ! plant height [m]
+    real(r8),intent(out) :: bagw    ! plant aboveground biomass [kg C]
     real(r8),intent(out),optional :: dbagwdd  ! change in agb per diameter [kgC/cm]
     
     bagw    = (p1 * d**p2)/c2b

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -1749,21 +1749,23 @@ contains
 
         end if
 
-        ! check that the host-fates PFT map adds to one along HLM dimension so that all the HLM area
-        ! goes to a FATES PFT.  Each FATES PFT can get < or > 1 of an HLM PFT.
-        do hlm_pft = 1,size( EDPftvarcon_inst%hlm_pft_map,2)
-          sumarea = sum(EDPftvarcon_inst%hlm_pft_map(1:npft,hlm_pft))
-          if(abs(sumarea-1.0_r8).gt.nearzero)then
-            write(fates_log(),*) 'The distribution of this host land model PFT :',hlm_pft
-            write(fates_log(),*) 'into FATES PFTs, does not add up to 1.0.'
-            write(fates_log(),*) 'Error is:',sumarea-1.0_r8
-            write(fates_log(),*) 'and the hlm_pft_map is:', EDPftvarcon_inst%hlm_pft_map(1:npft,hlm_pft)
-            write(fates_log(),*) 'Aborting'
-            call endrun(msg=errMsg(sourcefile, __LINE__))
-           end if
-         end do !hlm_pft
-       end do !ipft
-
+        if( hlm_use_fixed_biogeog .eq. itrue ) then
+           ! check that the host-fates PFT map adds to one along HLM dimension so that all the HLM area
+           ! goes to a FATES PFT.  Each FATES PFT can get < or > 1 of an HLM PFT.
+           do hlm_pft = 1,size( EDPftvarcon_inst%hlm_pft_map,2)
+              sumarea = sum(EDPftvarcon_inst%hlm_pft_map(1:npft,hlm_pft))
+              if(abs(sumarea-1.0_r8).gt.nearzero)then
+                 write(fates_log(),*) 'The distribution of this host land model PFT :',hlm_pft
+                 write(fates_log(),*) 'into FATES PFTs, does not add up to 1.0.'
+                 write(fates_log(),*) 'Error is:',sumarea-1.0_r8
+                 write(fates_log(),*) 'and the hlm_pft_map is:', EDPftvarcon_inst%hlm_pft_map(1:npft,hlm_pft)
+                 write(fates_log(),*) 'Aborting'
+                 call endrun(msg=errMsg(sourcefile, __LINE__))
+              end if
+           end do !hlm_pft
+        end if
+        
+     end do !ipft
 
 !!    ! Checks for HYDRO
 !!    if( hlm_use_planthydro == itrue ) then

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -529,8 +529,6 @@ module EDTypesMod
 
      real(r8),allocatable :: fragmentation_scaler(:)            ! Scale rate of litter fragmentation based on soil layer. 0 to 1.
 
-     real(r8) ::  repro(maxpft)                                 ! allocation to reproduction per PFT : KgC/m2
-
      !FUEL CHARECTERISTICS
      real(r8) ::  sum_fuel                                         ! total ground fuel related to ros (omits 1000hr fuels): KgC/m2
      real(r8) ::  fuel_frac(nfsc)                                  ! fraction of each litter class in the ros_fuel:-.  


### PR DESCRIPTION
this fixes the issue noted here: https://github.com/NGEET/fates/issues/782#issuecomment-946863749 where the hlm_pft_map test was happening even when fixed_biogeog was not true.

also some other tiny things that have been building up in a cleaning branch: there was an unused patch variable `repro` in EDTypesMod that I deleted, and there was some incorrect documentation in FatesAllometryMod that I fixed.

Should be b4b.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided

Not yet tested, except to confirm that it builds and runs.

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

