### PR TITLE
Some logic fixes to nocomp and nocomp + fixed_biogeog

### DIFF
--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -16,6 +16,7 @@ module EDPhysiologyMod
   use FatesInterfaceTypesMod, only    : hlm_use_planthydro
   use FatesInterfaceTypesMod, only    : hlm_parteh_mode
   use FatesInterfaceTypesMod, only    : hlm_use_fixed_biogeog
+  use FatesInterfaceTypesMod, only    : hlm_use_nocomp
   use FatesInterfaceTypesMod, only    : hlm_nitrogen_spec
   use FatesInterfaceTypesMod, only    : hlm_phosphorus_spec
   use FatesConstantsMod, only    : r8 => fates_r8
@@ -1853,8 +1854,10 @@ contains
 
 
     do ft = 1,numpft
-       if(currentSite%use_this_pft(ft).eq.itrue)then
-       temp_cohort%canopy_trim = init_recruit_trim
+       if(currentSite%use_this_pft(ft).eq.itrue &
+            .and. ((hlm_use_nocomp .eq. ifalse) .or. (ft .eq. currentPatch%nocomp_pft_label)))then
+
+          temp_cohort%canopy_trim = init_recruit_trim
           temp_cohort%pft         = ft
           temp_cohort%hite        = EDPftvarcon_inst%hgt_min(ft)
           temp_cohort%coage       = 0.0_r8

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -487,7 +487,7 @@ contains
           start_patch = 1   ! start at the first vegetated patch
           if(hlm_use_nocomp.eq.itrue)then
              num_new_patches = numpft
-             if(hlm_use_sp.eq.itrue)then
+             if( (hlm_use_sp.eq.itrue) .or. (hlm_use_fixed_biogeog .eq.itrue) )then
                 start_patch = 0 ! start at the bare ground patch
              endif
              !           allocate(newppft(numpft))


### PR DESCRIPTION
This fixes things so that nocomp + fixed_biogeog works properly (it was crashing before during init) and also a fix for nocomp (it was allowing recruits on supposedly-disallowed patches).

I think this is why nocomp was super-slow before, because it was actually allowing and PFT to recruit on any patch.  Now it doesn't.

In my head, I had previously thought that nocomp also implied fixed_biogeog.  I realize now that it doesn't necessarily, and that the logic differs slightly between nocomp versus nocomp + fixed_biogeog.  Anyway, all the various modes should work as intended now:

- fixed_biogeog: only lets a given PFT exist on a gridcell if the map says it can
- fixed_biogeog + nocomp: only lets a given PFT exist on a gridcell if the map says it can, and separates the gridcell into patch areas that each PFT can solely exist on based on the map areas
- nocomp: splits up the map to give every possible PFT the same amount of space on every gridcell in which that PFT can solely exist on.

I think, in general, fixed_biogeog + nocomp is what people will want to use, not nocomp on its own, so we should probably add a test for a fixed_biogeog + nocomp configuration.

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

This should be answer-changing in nocomp, and allow the model to pass a nocomp + fixed_biogeog test (it wouldn't have before).  All other modes should be identical.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

