### PR TITLE
Adding distubance rate tracking and radiation profile diagnostic to initialization

### DIFF
--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -2202,6 +2202,12 @@ contains
     currentPatch%c_lblayer                  = 0.0_r8
     currentPatch%fragmentation_scaler(:)    = 0.0_r8
 
+    ! diagnostic radiation profiles
+    currentPatch%nrmlzd_parprof_pft_dir_z(:,:,:,:) = 0._r8
+    currentPatch%nrmlzd_parprof_pft_dif_z(:,:,:,:) = 0._r8
+    currentPatch%nrmlzd_parprof_dir_z(:,:,:)       = 0._r8
+    currentPatch%nrmlzd_parprof_dif_z(:,:,:)       = 0._r8
+
     currentPatch%solar_zenith_flag          = .false.
     currentPatch%solar_zenith_angle         = nan
 

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -198,6 +198,13 @@ contains
     site_in%water_memory(:)  = nan
     site_in%vegtemp_memory(:) = nan              ! record of last 10 days temperature for senescence model.
 
+    ! Disturbance rates tracking
+    site_in%primary_land_patchfusion_error = 0.0_r8
+    site_in%harvest_carbon_flux = 0.0_r8
+    site_in%potential_disturbance_rates(:) = 0.0_r8
+    site_in%disturbance_rates_secondary_to_secondary(:) = 0.0_r8
+    site_in%disturbance_rates_primary_to_secondary(:) = 0.0_r8
+    site_in%disturbance_rates_primary_to_primary(:) = 0.0_r8
 
     ! FIRE
     site_in%acc_ni           = 0.0_r8     ! daily nesterov index accumulating over time. time unlimited theoretically.


### PR DESCRIPTION
### Description:
During the course of @ekluzek testing for upcoming [ctsm5.1.dev062](https://github.com/ESCOMP/CTSM/pull/1502) tag to make nuopc driver the default, three different gnu tests returned run time failures: https://github.com/ESCOMP/CTSM/pull/1502#issuecomment-964441131.  A ctsm issue with the `Vnuopc` version of these tests against the dev061 baseline is described here: https://github.com/ESCOMP/CTSM/issues/1545.  

There appear to be two issues here:

1. For the `amazon` and `brazil` tests, the run fails when trying to write uninitialized disturbance rate tracking variables to history output.
2. For the `f10` test, the `nrmlzd` versions of the diagnostic radiation profile variables (e.g. `parprof_pft_dir_z`) are being utilized in `ED_SunShadeFracs` prior to being zero'd in  `ED_Norman_Radiation`.

It should be noted that a fourth `gnu` debug regression test, in the `fates` suite, was failing using the dev062 PR branch for the same reason as detail in 1) above: https://github.com/ESCOMP/CTSM/pull/1502#issuecomment-964857066

Note that these variables were already set to zero at the top of the routines in which they are calculated.  Initializing these variables to zero at start up (i.e. in `zero_patch` and `zero_site`) alleviates the issue.

### Collaborators:
@ekluzek 

### Expectation of Answer Changes:
None expected

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [x] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:

CTSM (or) E3SM (specify which) test hash-tag: `ctsm5.1.dev061`

CTSM (or) E3SM (specify which) baseline hash-tag: `ctsm5.1.dev061`

FATES baseline hash-tag: `fates-sci.1.49.0_api.17.0.0-ctsm5.1.dev061`

Test Output:

All expected runs pass B4B:
`/glade/u/home/glemieux/scratch/ctsm-tests/tests_nuopc-init-fixes-dev061-rnd2`

