### PR TITLE
Facilitate crops in SP mode. 

### DIFF
--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -11,7 +11,7 @@ dimensions:
 	fates_pft = 12 ;
 	fates_prt_organs = 4 ;
 	fates_string_length = 60 ;
-	fates_hlm_pftno = 14 ;
+	fates_hlm_pftno = 16 ;
 variables:
 	double fates_history_ageclass_bin_edges(fates_history_age_bins) ;
 		fates_history_ageclass_bin_edges:units = "yr" ;
@@ -1345,6 +1345,8 @@ data:
  0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0,
  0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0,
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
+ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0,
  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 ;
 
  fates_fire_FBD = 15.4, 16.8, 19.6, 999, 4, 4 ;
@@ -1352,6 +1354,7 @@ data:
  fates_fire_low_moisture_Coeff = 1.12, 1.09, 0.98, 0.8, 1.15, 1.15 ;
 
  fates_fire_low_moisture_Slope = 0.62, 0.72, 0.85, 0.8, 0.62, 0.62 ;
+
 
  fates_fire_mid_moisture = 0.72, 0.51, 0.38, 1, 0.8, 0.8 ;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
To allow FATES-SP mode to generate crop areas, this PR updates the default PFT file to extend the map to HLM_PFTs 15 and 16. This means that for grid cells with crops, area is allocated.  In SP mode, the HLM actually shifts the crops onto the natural vegetation land unit, hence the previous solution (running over crop land units as well as soil land units) does not in itself solve the problem. 

Further, this PR also changes the order of operations logic related to the precision checking of the total patch area. Previously, this happened AFTER the call to init_cohorts, which appeared to result in cohorts that were larger than the patch area with an error the same size and that later trimmed off by the precision checking in EDInit (see changes).  This PR makes the call to init_cohorts occur after the change in patch areas to account for precision-level errors in the inputs.

Adding the crop PFTs appeared to trigger this error. It is possible that this change will fix  #782 which threw a similar error. 

This PR addresses issue #760


 



### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
yes, this will change answers in SP and NOCOMP modes. 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

