### PR TITLE
Exact restart fix for satellite phenology mode

### DIFF
--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -1935,12 +1935,9 @@ contains
        total_patch_area = 0._r8
        total_canopy_area = 0._r8
        bc_out(s)%canopy_fraction_pa(:) = 0._r8
-       
-       if (hlm_use_sp.eq.ifalse) then
-          bc_out(s)%dleaf_pa(:) = 0._r8
-          bc_out(s)%z0m_pa(:) = 0._r8
-          bc_out(s)%displa_pa(:) = 0._r8
-       endif
+       bc_out(s)%dleaf_pa(:) = 0._r8
+       bc_out(s)%z0m_pa(:) = 0._r8
+       bc_out(s)%displa_pa(:) = 0._r8
        
        currentPatch => sites(s)%oldest_patch
        c = fcolumn(s)
@@ -1970,7 +1967,7 @@ contains
              ! Avoid this if running in satellite phenology mode
              ! ----------------------------------------------------------------------------
 
-             if (currentPatch%total_canopy_area > nearzero .and. hlm_use_sp.eq.ifalse) then
+             if (currentPatch%total_canopy_area > nearzero) then
                 currentCohort => currentPatch%shortest
                 do while(associated(currentCohort))
                    if (currentCohort%canopy_layer .eq. 1) then
@@ -1988,7 +1985,8 @@ contains
                 currentCohort => currentPatch%shortest
                 do while(associated(currentCohort))
 
-                   ! mkae sure that allometries are correct
+                   if (hlm_use_sp.eq.ifalse) then
+                   ! make sure that allometries are correct
                    call carea_allom(currentCohort%dbh,currentCohort%n,sites(s)%spread,&
                         currentCohort%pft,currentCohort%c_area)
 
@@ -2000,6 +1998,7 @@ contains
                         currentCohort%c_area, currentCohort%n, currentCohort%canopy_layer, &
                         currentPatch%canopy_layer_tlai, currentCohort%treelai , &
                         currentCohort%vcmax25top,4)
+                   endif
 
                    total_patch_leaf_stem_area = total_patch_leaf_stem_area + &
                         (currentCohort%treelai + currentCohort%treesai) * currentCohort%c_area

--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -1935,9 +1935,13 @@ contains
        total_patch_area = 0._r8
        total_canopy_area = 0._r8
        bc_out(s)%canopy_fraction_pa(:) = 0._r8
-       bc_out(s)%dleaf_pa(:) = 0._r8
-       bc_out(s)%z0m_pa(:) = 0._r8
-       bc_out(s)%displa_pa(:) = 0._r8
+       
+       if (hlm_use_sp.eq.ifalse) then
+          bc_out(s)%dleaf_pa(:) = 0._r8
+          bc_out(s)%z0m_pa(:) = 0._r8
+          bc_out(s)%displa_pa(:) = 0._r8
+       endif
+       
        currentPatch => sites(s)%oldest_patch
        c = fcolumn(s)
        do while(associated(currentPatch))
@@ -1963,9 +1967,10 @@ contains
              ! Use canopy-only crown area weighting for all cohorts in the patch to define the characteristic
              ! Roughness length and displacement height used by the HLM
              ! use total LAI + SAI to weight the leaft characteristic dimension
+             ! Avoid this if running in satellite phenology mode
              ! ----------------------------------------------------------------------------
 
-             if (currentPatch%total_canopy_area > nearzero) then
+             if (currentPatch%total_canopy_area > nearzero .and. hlm_use_sp.eq.ifalse) then
                 currentCohort => currentPatch%shortest
                 do while(associated(currentCohort))
                    if (currentCohort%canopy_layer .eq. 1) then

--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -1289,7 +1289,6 @@ contains
     integer  :: ft               ! plant functional type
     integer  :: ifp              ! the number of the vegetated patch (1,2,3). In SP mode bareground patch is 0
     integer  :: patchn           ! identification number for each patch.
-    real(r8) :: canopy_leaf_area ! total amount of leaf area in the vegetated area. m2.
     real(r8) :: leaf_c           ! leaf carbon [kg]
     real(r8) :: fnrt_c           ! fineroot carbon [kg]
     real(r8) :: sapw_c           ! sapwood carbon [kg]
@@ -1318,7 +1317,6 @@ contains
           !zero cohort-summed variables.
           currentPatch%total_canopy_area = 0.0_r8
           currentPatch%total_tree_area = 0.0_r8
-          canopy_leaf_area = 0.0_r8
 
           !update cohort quantitie s
           currentCohort => currentPatch%shortest
@@ -1347,11 +1345,6 @@ contains
                 call carea_allom(currentCohort%dbh,currentCohort%n,sites(s)%spread,&
                      currentCohort%pft,currentCohort%c_area)
              endif
-             currentCohort%treelai = tree_lai(leaf_c,             &
-                  currentCohort%pft, currentCohort%c_area, currentCohort%n, &
-                  currentCohort%canopy_layer, currentPatch%canopy_layer_tlai,currentCohort%vcmax25top )
-
-             canopy_leaf_area = canopy_leaf_area + currentCohort%treelai *currentCohort%c_area
 
              if(currentCohort%canopy_layer==1)then
                 currentPatch%total_canopy_area = currentPatch%total_canopy_area + currentCohort%c_area

--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -11,6 +11,7 @@ module EDCohortDynamicsMod
   use FatesInterfaceTypesMod     , only : hlm_use_planthydro
   use FatesInterfaceTypesMod     , only : hlm_use_sp
   use FatesInterfaceTypesMod     , only : hlm_use_cohort_age_tracking
+  use FatesInterfaceTypesMod     , only : hlm_is_restart
   use FatesConstantsMod     , only : r8 => fates_r8
   use FatesConstantsMod     , only : fates_unset_int
   use FatesConstantsMod     , only : itrue,ifalse
@@ -2011,6 +2012,13 @@ contains
           currentCohort%kp25top    = sum(param_derived%kp25top(ipft,1:nleafage) * &
                 frac_leaf_aclass(1:nleafage))
 
+       elseif (hlm_use_sp .eq. itrue .and. hlm_is_restart .eq. itrue) then
+         
+          currentCohort%vcmax25top = EDPftvarcon_inst%vcmax25top(ipft,1:nleafage)
+          currentCohort%jmax25top  = param_derived%jmax25top(ipft,1:nleafage)
+          currentCohort%tpu25top   = param_derived%tpu25top(ipft,1:nleafage)
+          currentCohort%kp25top    = param_derived%kp25top(ipft,1:nleafage)
+       
        else
 
           currentCohort%vcmax25top = 0._r8

--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -1993,9 +1993,10 @@ contains
        ! We assume that leaf age does not effect the specific leaf area, so the mass
        ! fractions are applicable to these rates
 
+       ipft = currentCohort%pft
+
        if(sum(frac_leaf_aclass(1:nleafage))>nearzero) then
 
-          ipft = currentCohort%pft
 
           frac_leaf_aclass(1:nleafage) =  frac_leaf_aclass(1:nleafage) / &
                 sum(frac_leaf_aclass(1:nleafage))
@@ -2014,10 +2015,10 @@ contains
 
        elseif (hlm_use_sp .eq. itrue .and. hlm_is_restart .eq. itrue) then
          
-          currentCohort%vcmax25top = EDPftvarcon_inst%vcmax25top(ipft,1:nleafage)
-          currentCohort%jmax25top  = param_derived%jmax25top(ipft,1:nleafage)
-          currentCohort%tpu25top   = param_derived%tpu25top(ipft,1:nleafage)
-          currentCohort%kp25top    = param_derived%kp25top(ipft,1:nleafage)
+          currentCohort%vcmax25top = EDPftvarcon_inst%vcmax25top(ipft,1)
+          currentCohort%jmax25top  = param_derived%jmax25top(ipft,1)
+          currentCohort%tpu25top   = param_derived%tpu25top(ipft,1)
+          currentCohort%kp25top    = param_derived%kp25top(ipft,1)
        
        else
 


### PR DESCRIPTION
### Description:
This PR addresses issue https://github.com/ESCOMP/CTSM/issues/1485 in which fates satellite phenology (SP) mode does not pass an exact start (ERS) regression test.  

The issue has two subset issues that are fixed here:

1. It was determined that the ERS `COMPARE_base_rest` failure is due to the difference in the `gpp_tstep` during restart.  This difference is due both `gpp_tstep` needing to be carried over during restart and to a subset of cohort parameters not being updated to match the pre-restart state in `UpdateCohortBioPhysRates`.  This routine uses leaf biomass as a check to determine how to set `vcmax25top`, `jmax25top`, `tpu25top`, and `kp25top`, which eventually are used as inputs to update `gpp_tstep`.  This routine is run whenever cohorts are created or fused as well as during the restart process, although in SP mode this routine is only called during initial cohort creation and during restart.  During SP mode initialization all cohorts start with some leaf biomass and thus the above cohort parameters are defined as non-zero. That said its possible that the cohort is then set to a zero leaf biomass due to a satellite phenology update which is then written for the restart.  Given that there would be zero leaf biomass, the cohort parameters would be set to zero, thus causing a mismatch in the downstream `gpp_tstep` update.  
2. The ERS was failing to run after restart due to updates introduced in #735.  A simple SP mode check has been introduced to avoid this update.

### Collaborators:
@ckoven @rgknox 

### Expectation of Answer Changes:
PR should be b4b

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [x] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag: `ctsm5.1.dev066`

CTSM (or) E3SM (specify which) baseline hash-tag: `ctsm5.1.dev066`

FATES baseline hash-tag: `sci.1.52.0_api.20.0.0`

Test Output:
`/glade/u/home/glemieux/scratch/ctsm-tests/tests_issue_1485-dev066-sci1520-fatessuite1`


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

