### PR TITLE
allow disturbance in nocomp mode

### DIFF
--- a/main/EDMainMod.F90
+++ b/main/EDMainMod.F90
@@ -260,15 +260,10 @@ contains
     ! Patch dynamics sub-routines: fusion, new patch creation (spwaning), termination.
     !*********************************************************************************
 
+    ! turn off patch dynamics if SP or ST3 modes in use
     do_patch_dynamics = itrue
     if(hlm_use_ed_st3.eq.itrue .or. &
-       hlm_use_nocomp.eq.itrue .or. &
        hlm_use_sp.eq.itrue)then
-      ! n.b. this is currently set to false to get around a memory leak that occurs
-      ! when we have multiple patches for each PFT.
-      ! when this is fixed, we will need another option for 'one patch per PFT' vs 'multiple patches per PFT'
-      ! hlm_use_sp check provides cover for potential changes in nocomp logic (nocomp required by spmode, but
-      ! not the other way around).
        do_patch_dynamics = ifalse
     end if
 

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -48,6 +48,7 @@ module FatesHistoryInterfaceMod
   use FatesInterfaceTypesMod        , only : bc_in_type
   use FatesInterfaceTypesMod        , only : hlm_model_day
   use FatesInterfaceTypesMod        , only : nlevcoage
+  use FatesInterfaceTypesMod        , only : hlm_use_nocomp
   use FatesAllometryMod             , only : CrownDepth
 
   use EDPftvarcon              , only : EDPftvarcon_inst
@@ -513,6 +514,8 @@ module FatesHistoryInterfaceMod
   integer :: ih_canopycrownarea_si_pft
   integer :: ih_gpp_si_pft
   integer :: ih_npp_si_pft
+  integer :: ih_nocomp_pftpatchfraction_si_pft
+  integer :: ih_nocomp_pftnpatches_si_pft
 
   ! indices to (site x patch-age) variables
   integer :: ih_area_si_age
@@ -2237,6 +2240,16 @@ end subroutine flush_hvars
             iagepft = cpatch%age_class + (i_pft-1) * nlevage
             hio_scorch_height_si_agepft(io_si,iagepft) = hio_scorch_height_si_agepft(io_si,iagepft) + &
                cpatch%Scorch_ht(i_pft) * cpatch%area
+
+            ! and also pft-labeled patch areas in the event that we are in nocomp mode
+            if ( hlm_use_nocomp .eq. itrue .and. cpatch%nocomp_pft_label .eq. i_pft) then 
+               this%hvars(ih_nocomp_pftpatchfraction_si_pft)%r82d(io_si,i_pft) = &
+                    this%hvars(ih_nocomp_pftpatchfraction_si_pft)%r82d(io_si,i_pft) + cpatch%area * AREA_INV
+
+               this%hvars(ih_nocomp_pftnpatches_si_pft)%r82d(io_si,i_pft) = &
+                    this%hvars(ih_nocomp_pftnpatches_si_pft)%r82d(io_si,i_pft) + 1._r8
+            endif
+            
          end do
 
          ! fractional area burnt [frac/day] -> [frac/sec]
@@ -4534,6 +4547,20 @@ end subroutine update_history_hifrq
          use_default='active', avgflag='A', vtype=site_pft_r8, hlms='CLM:ALM', &
          upfreq=1, ivar=ivar, initialize=initialize_variables,                 &
          index=ih_mortality_si_pft)
+
+    nocomp_if: if (hlm_use_nocomp .eq. itrue) then
+       call this%set_history_var(vname='FATES_NOCOMP_NPATCHES_PF', units='',      &
+            long='number of patches per PFT (nocomp-mode-only)',                  &
+            use_default='active', avgflag='A', vtype=site_pft_r8, hlms='CLM:ALM', &
+            upfreq=1, ivar=ivar, initialize=initialize_variables,                 &
+            index=ih_nocomp_pftnpatches_si_pft)
+
+       call this%set_history_var(vname='FATES_NOCOMP_PATCHAREA_PF', units='m2 m-2',&
+            long='total patch area allowed per PFT (nocomp-mode-only)',           &
+            use_default='active', avgflag='A', vtype=site_pft_r8, hlms='CLM:ALM', &
+            upfreq=1, ivar=ivar, initialize=initialize_variables,                 &
+            index=ih_nocomp_pftpatchfraction_si_pft)
+    endif nocomp_if
 
     ! patch age class variables
     call this%set_history_var(vname='FATES_PATCHAREA_AP', units='m2 m-2',      &

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -2255,8 +2255,8 @@ end subroutine flush_hvars
 
          ! and also the bareground-labeled patch area in the event that we are in nocomp mode
          if ( hlm_use_nocomp .eq. itrue .and. cpatch%nocomp_pft_label .eq. 0) then 
-            this%hvars(ih_nocomp_baregroundpatchfraction_si)%r82d(io_si) = &
-                 this%hvars(ih_nocomp_baregroundpatchfraction_si)%r82d(io_si) + cpatch%area * AREA_INV
+            this%hvars(ih_nocomp_baregroundpatchfraction_si)%r81d(io_si) = &
+                 this%hvars(ih_nocomp_baregroundpatchfraction_si)%r81d(io_si) + cpatch%area * AREA_INV
          endif
 
          ! fractional area burnt [frac/day] -> [frac/sec]

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -339,6 +339,7 @@ module FatesHistoryInterfaceMod
   integer :: ih_h2oveg_recruit_si
   integer :: ih_h2oveg_growturn_err_si
   integer :: ih_h2oveg_hydro_err_si
+  integer :: ih_nocomp_baregroundpatchfraction_si
 
   integer :: ih_site_cstatus_si
   integer :: ih_site_dstatus_si
@@ -2251,6 +2252,12 @@ end subroutine flush_hvars
             endif
             
          end do
+
+         ! and also the bareground-labeled patch area in the event that we are in nocomp mode
+         if ( hlm_use_nocomp .eq. itrue .and. cpatch%nocomp_pft_label .eq. 0) then 
+            this%hvars(ih_nocomp_baregroundpatchfraction_si)%r82d(io_si) = &
+                 this%hvars(ih_nocomp_baregroundpatchfraction_si)%r82d(io_si) + cpatch%area * AREA_INV
+         endif
 
          ! fractional area burnt [frac/day] -> [frac/sec]
          hio_area_burnt_si_age(io_si,cpatch%age_class) = hio_area_burnt_si_age(io_si,cpatch%age_class) + &
@@ -4560,6 +4567,12 @@ end subroutine update_history_hifrq
             use_default='active', avgflag='A', vtype=site_pft_r8, hlms='CLM:ALM', &
             upfreq=1, ivar=ivar, initialize=initialize_variables,                 &
             index=ih_nocomp_pftpatchfraction_si_pft)
+
+       call this%set_history_var(vname='FATES_NOCOMP_BAREGROUND_PATCHAREA', units='m2 m-2',&
+            long='total bare-ground patch area (nocomp-mode-only)',           &
+            use_default='active', avgflag='A', vtype=site_r8, hlms='CLM:ALM', &
+            upfreq=1, ivar=ivar, initialize=initialize_variables,             &
+            index=ih_nocomp_baregroundpatchfraction_si)
     endif nocomp_if
 
     ! patch age class variables


### PR DESCRIPTION
Currently, disturbance processes are turned off while in nocomp mode.  This PR includes changes that enables the tracking of patch-level nocomp PFT labels during patch creation and fusion processes, which allows for turning on disturbance when nocomp mode is active.

Note that this still does not allow for disturbance in SP mode, because that wouldn't really make sense.  But it does enable it in non-SP nocomp modes.

This should not require any changes to the interface or parameter file.

### Description:
To do this, a few things needed to be done:
1. Removed hard-coded switches that turn off disturbance when nocomp was active
2. Added logic during patch-generating disturbance so that it loops over nocomp PFTs and does the entire disturbance logic separately for each nocomp PFT, so that each newly-disturbed patch only draws from older patches with the same nocomp PFT identity.
3. Added logic to force the preservation of nocomp PFT identity during patch fusion.

Since the disturbance and in particular patch fusion code already has a lot of nested if and do blocks, I also went through fairly liberally and added names to a lot of these blocks.  I had to do this to be able to figure out where to insert the code in the right places.  Hopefully this adds a greater degree of readibility to those codes.  I have not (so far) gone through and re-indented the code, as that will generate a ton of whitespace changes.

### Collaborators:
Some discussion with @rosiealice and @rgknox 

### Expectation of Answer Changes:
should be bit for bit in all non-nocomp and SP configurations.  Should be answer changing in non-SP nocomp configurations.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
not yet tested.
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

