### PR TITLE
bugfix - cohort pointers and termination

### DIFF
--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -721,7 +721,13 @@ contains
                 ! put the litter from the terminated cohorts
                 ! straight into the fragmenting pools
                 call terminate_cohort(currentSite,currentPatch,currentCohort,bc_in)
+                ! Since this cohort will be removed from the list
+                ! lets temporarily remember the cohort that was taller than
+                ! current, because that cohort now points to the cohort that
+                ! is shorter
+                nextc => currentCohort%taller
                 deallocate(currentCohort)
+                currentCohort => nextc
              else
              call carea_allom(currentCohort%dbh,currentCohort%n, &
                   currentSite%spread,currentCohort%pft,currentCohort%c_area)

--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -621,6 +621,8 @@ contains
        currentCohort => currentPatch%tallest
        do while (associated(currentCohort))
 
+          nextc => currentCohort%shorter
+
           if(currentCohort%canopy_layer == i_lyr )then
 
              cc_loss         = currentCohort%excl_weight
@@ -721,13 +723,7 @@ contains
                 ! put the litter from the terminated cohorts
                 ! straight into the fragmenting pools
                 call terminate_cohort(currentSite,currentPatch,currentCohort,bc_in)
-                ! Since this cohort will be removed from the list
-                ! lets temporarily remember the cohort that was taller than
-                ! current, because that cohort now points to the cohort that
-                ! is shorter
-                nextc => currentCohort%taller
                 deallocate(currentCohort)
-                currentCohort => nextc
              else
              call carea_allom(currentCohort%dbh,currentCohort%n, &
                   currentSite%spread,currentCohort%pft,currentCohort%c_area)
@@ -735,7 +731,11 @@ contains
 
           endif !canopy layer = i_ly
 
-          currentCohort => currentCohort%shorter
+          ! We dont use our typical (point to smaller)
+          ! here, because, we may had deallocated the existing
+          ! currentCohort
+
+          currentCohort => nextc
        enddo !currentCohort
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

This PR is intended as a hotfix.  There was a regression in tag [sci.1.55.0_api.22.0.0](https://github.com/NGEET/fates/releases/tag/sci.1.55.0_api.22.0.0) . A pointer (currentCohort) was being deallocated (and thus nullified), yet, we were later in the sequence expecting to use that pointer (to find the next currentCohort in the sequence).  This set of changes simply saves the pointer information before deallocation/nullification so it can be used later.

### Collaborators:

@glemieux 

### Expectation of Answer Changes:

This should have b4b changes, however, since the tests did not trigger a particular aspect of cohort termination, there may not be any changes even with this fix.


### Checklist:

- [X] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [X] If answers were expected to change, evaluation was performed and provided


### Test Results:
TBD
