### PR TITLE
move frac_lai and frac_sai calculation outside do ib=1,hlm_numSWb loop

### DIFF
--- a/biogeophys/EDSurfaceAlbedoMod.F90
+++ b/biogeophys/EDSurfaceAlbedoMod.F90
@@ -142,7 +142,7 @@ contains
                    bc_out(s)%fabd_parb(ifp,:) = 0.0_r8
                    bc_out(s)%fabi_parb(ifp,:) = 0.0_r8
                    currentPatch%radiation_error = 0.0_r8
-                   
+
                    do ib = 1,hlm_numSWb
                       bc_out(s)%albd_parb(ifp,ib) = bc_in(s)%albgr_dir_rb(ib)
                       bc_out(s)%albi_parb(ifp,ib) = bc_in(s)%albgr_dif_rb(ib)
@@ -320,16 +320,18 @@ contains
           do  iv = 1, currentPatch%nrad(L,ft)
              if (currentPatch%canopy_area_profile(L,ft,iv) > 0._r8)then
                 currentPatch%canopy_mask(L,ft) = 1
-                ! layer level reflectance qualities
-                do ib = 1,hlm_numSWb !vis, nir
-                   if(currentPatch%elai_profile(L,ft,iv)+ currentPatch%esai_profile(L,ft,iv).gt.0.0_r8) then
-                      frac_lai = currentPatch%elai_profile(L,ft,iv)/&
-                           (currentPatch%elai_profile(L,ft,iv)+ currentPatch%esai_profile(L,ft,iv))
-                   else
-                      frac_lai = 1.0_r8
-                   endif
-                   !frac_lai = 1.0_r8 ! make the same as previous codebase, in theory.
-                   frac_sai = 1.0_r8 - frac_lai
+
+               if(currentPatch%elai_profile(L,ft,iv)+ currentPatch%esai_profile(L,ft,iv).gt.0.0_r8) then
+                  frac_lai = currentPatch%elai_profile(L,ft,iv)/&
+                       (currentPatch%elai_profile(L,ft,iv)+ currentPatch%esai_profile(L,ft,iv))
+               else
+                  frac_lai = 1.0_r8
+               endif
+               !frac_lai = 1.0_r8 ! make the same as previous codebase, in theory.
+               frac_sai = 1.0_r8 - frac_lai
+
+               ! layer level reflectance qualities
+               do ib = 1,hlm_numSWb !vis, nir
 
                    rho_layer(L,ft,iv,ib)=frac_lai*rhol(ft,ib)+frac_sai*rhos(ft,ib)
                    tau_layer(L,ft,iv,ib)=frac_lai*taul(ft,ib)+frac_sai*taus(ft,ib)
@@ -340,7 +342,7 @@ contains
                    tau_layer(L,ft,iv,ib)=tau_layer(L,ft,iv,ib)*(1.0_r8- currentPatch%fcansno) &
                         + tau_snow(ib) * currentPatch%fcansno
 
-                   ! fraction of incoming light absorbed by leaves or stems. 
+                   ! fraction of incoming light absorbed by leaves or stems.
                    f_abs(L,ft,iv,ib) = 1.0_r8 - tau_layer(L,ft,iv,ib) - rho_layer(L,ft,iv,ib)
 
                    ! the fraction of the vegetation absorbed light which is absorbed by leaves
@@ -594,10 +596,10 @@ contains
              endif ! currentPatch%canopy_mask
           end do!ft
        end do!L
-       
+
        ! Zero out the radiation error for the current patch before conducting the conservation check
        currentPatch%radiation_error = 0.0_r8
-       
+
        do ib = 1,hlm_numSWb
           Dif_dn(:,:,:) = 0.00_r8
           Dif_up(:,:,:) = 0.00_r8
@@ -1011,7 +1013,7 @@ contains
 
           ! ignore the current patch radiation error if the veg-covered fraction of the patch is really small
           if ( (currentPatch%total_canopy_area / currentPatch%area) .gt. tolerance ) then
-             ! normalize rad error by the veg-covered fraction of the patch because that is 
+             ! normalize rad error by the veg-covered fraction of the patch because that is
              ! the only part that this code applies to
              currentPatch%radiation_error = currentPatch%radiation_error + error &
                   * currentPatch%total_canopy_area / currentPatch%area
@@ -1242,11 +1244,11 @@ subroutine ED_SunShadeFracs(nsites, sites,bc_in,bc_out)
                  end do !iv
               end do !FT
            end do !CL
-           
-           ! Convert normalized radiation error units from fraction of radiation to W/m2 
+
+           ! Convert normalized radiation error units from fraction of radiation to W/m2
            cpatch%radiation_error = cpatch%radiation_error * (bc_in(s)%solad_parb(ifp,ipar) + &
                 bc_in(s)%solai_parb(ifp,ipar))
-                
+
            ! output the actual PAR profiles through the canopy for diagnostic purposes
            do CL = 1, cpatch%NCL_p
               do FT = 1,numpft


### PR DESCRIPTION
### Description:

Fixes a minor issue where the calculation of `frac_lai` and `frac_sai` was calculated twice unnecessarily inside the `do ib = 1,hlm_numSWb` loop. I moved the calculation outside of the loop and tested to make sure updates were bit for bit.

This will save us (a small amount) of run time and make the code more accurate/readable.

This resolves issue #843.

### Collaborators:
@glemieux

### Expectation of Answer Changes:
None. I ran a simple fates test suite and everything was bit-for-bit.


### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:

I ran a fates test suite on Cheyenne against `fates-sci.1.55.4_api.22.1.0-ctsm5.1.dev084`, however CTSM is currently on `dev085` so there were some expected NLCOMP diffs from the update to `dev085`. I will run the required tests again when it is time to push this through.

CTSM (or) E3SM (specify which) test hash-tag:

ctsm5.1.dev085

CTSM (or) E3SM (specify which) baseline hash-tag:

ctsm5.1.dev084

FATES baseline hash-tag:

fates-sci.1.55.4_api.22.1.0

Test Output:

Many NLCOMP diffs from the difference between `dev085` and `dev084` but this was expected. Once we update our baselines I will test again.

Tests are on Cheyenne: /glade/scratch/afoster/tests_0317-152648ch