### PR TITLE
add the continous taper function

### DIFF
--- a/biogeophys/FatesPlantHydraulicsMod.F90
+++ b/biogeophys/FatesPlantHydraulicsMod.F90
@@ -4629,8 +4629,7 @@ function xylemtaper(pexp, dz) result(chi_tapnotap)
     real(r8) , intent(in) :: dz     ! hydraulic distance from petiole to node of interest[m]
     !
     ! !LOCAL VARIABLES:
-    real(r8) :: qexp                ! total conductance exponent (as in Fig. 2b of Savage et al. (2010)
-    real(r8) :: qexp_notap          ! same as qexp, but without xylem taper; i.e., pexp = 0
+    real(r8) :: qexp                ! total conductance exponent (as in Fig. 2b of Savage et al. (2010) minus a0 term
     real(r8) :: lN=0.005_r8         ! petiole length[m]
     real(r8) :: mu=1.0E-03_r8       ! viscosity[kg m-1 s-1]
     real(r8) :: rintN=0.00001_r8    ! internal conduit diameter in petiole[m]
@@ -4661,16 +4660,15 @@ function xylemtaper(pexp, dz) result(chi_tapnotap)
     a2 =  1.096488_r8
     a1 =  1.844792_r8
     a0 =  1.320732_r8
-    qexp         = a5*pexp**5 + a4*pexp**4 + a3*pexp**3 + a2*pexp**2 + a1*pexp + a0
-    qexp_notap   = a0
+    
+    qexp         = a5*pexp**5 + a4*pexp**4 + a3*pexp**3 + a2*pexp**2 + a1*pexp
 
     num          = 3._r8*log(1._r8 - dz/lN * (1._r8-n_ext**(1._r8/3._r8)))
     den          = log(n_ext)
     big_N        = num/den - 1._r8
     r0rN         = n_ext**(big_N/2._r8)
-    ktap         = kN * (r0rN**qexp)
-    knotap       = kN * (r0rN**qexp_notap)
-    chi_tapnotap = ktap / knotap
+    
+    chi_tapnotap = r0rN**qexp
 
     return
 

--- a/biogeophys/FatesPlantHydraulicsMod.F90
+++ b/biogeophys/FatesPlantHydraulicsMod.F90
@@ -4631,15 +4631,9 @@ function xylemtaper(pexp, dz) result(chi_tapnotap)
     ! !LOCAL VARIABLES:
     real(r8) :: qexp                ! total conductance exponent (as in Fig. 2b of Savage et al. (2010) minus a0 term
     real(r8) :: lN=0.005_r8         ! petiole length[m]
-    real(r8) :: mu=1.0E-03_r8       ! viscosity[kg m-1 s-1]
-    real(r8) :: rintN=0.00001_r8    ! internal conduit diameter in petiole[m]
-    real(r8) :: NsegintN=200        ! number of conduits in a single terminal twig[-]
-    real(r8) :: kN                  ! conductance for laminar flow through all conduits in a terminal twig, according to Hagen-Poiseuille[kg Pa-1 s-1]
     real(r8) :: n_ext=2._r8         ! number of daughter branches per parent branch, assumed constant throughout tree (self-similarity)  [-]
     real(r8) :: big_n               ! number of branching levels (allowed here to take on non-integer values): increases with tree size  [-]
     real(r8) :: r0rN                ! ratio of stem radius to terminal twig radius; r.ext0/r.extN (x-axis of Savage et al. (2010) Fig 2a)[-]
-    real(r8) :: ktap                ! hydraulic conductance along the pathway,accounting for xylem taper                                [kg s-1 MPa-1]
-    real(r8) :: knotap              ! hydraulic conductance along the pathway,not accounting for xylem taper                            [kg s-1 MPa-1]
     real(r8) :: num                 ! temporary
     real(r8) :: den                 ! temporary
     real(r8) :: a5,a4,a3,a2,a1,a0   ! coefficients of 5th-order polynomial fit to Savage et al. Fig. 2b (qexp vs. pexp)
@@ -4651,8 +4645,6 @@ function xylemtaper(pexp, dz) result(chi_tapnotap)
     real(r8) :: chi_tapnotap        ! ratio of total tree conductance accounting for xylem taper to that without, over interval dz
     !
     !------------------------------------------------------------------------
-
-    kN = NsegintN*pi*rintN**(4.0_r8)/(8.0_r8*mu*lN)
 
     a5 = -3.555547_r8
     a4 =  9.760275_r8


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Based on our sensitivity analysis, the taper function play a key role regulating plant hydrodynamics. In the original code, the taper exponent can only take 3 discrete values: 1/3, 1/6, and 1. This pull request added a continuous function to interpolate the exponents through an empirical polynomial. 
### Description:
The main change is in the xylemtaper function in FatesPlantHydraulicsMod.F90.

### Collaborators:
@bchristo @rgknox 

### Expectation of Answer Changes:
The hydrodynamics will change as the exponents are based on the empirical polynomial, but should be close to the old code. 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

