### PR TITLE
Fix the calculation to `FATES_TVEG` to avoid crashing in debug mode with fates sp runs

### DIFF
--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -3588,16 +3588,13 @@ end subroutine flush_hvars
          
          patch_area_by_age(1:nlevage) = 0._r8
          canopy_area_by_age(1:nlevage) = 0._r8
-         site_area_veg = area
          
          ! Calculate the site-level total vegetated area (i.e. non-bareground)
-         cpatch => sites(s)%oldest_patch
-         do while(associated(cpatch))
-            if (nocomp_pft_label .eq. 0) then
-               site_area_veg = site_area_veg - cpatch%area
-            endif
-            cpatch => cpatch%younger
-         end do
+         if (hlm_use_nocomp .eq. itrue) then
+            site_area_veg = area - sites(s)%area_pft(0)
+         else
+            site_area_veg = area
+         end if
 
          cpatch => sites(s)%oldest_patch
          do while(associated(cpatch))
@@ -3627,9 +3624,10 @@ end subroutine flush_hvars
                  cpatch%radiation_error * cpatch%area * AREA_INV
                  
             ! Only accumulate the instantaneous vegetation temperature for vegetated patches
-            if (nocomp_pft_label .ne. 0) then
+            if (cpatch%patchno .ne. 0) then
                hio_tveg(io_si) = hio_tveg(io_si) + &
-                  (bc_in(s)%t_veg_pa(cpatch%patchno) - t_water_freeze_k_1atm) * cpatch%area / site_area_veg
+                  (bc_in(s)%t_veg_pa(cpatch%patchno) - t_water_freeze_k_1atm) * &
+                  cpatch%area / site_area_veg
             end if
             
             ccohort => cpatch%shortest


### PR DESCRIPTION
### Description:
This PR fixes https://github.com/NGEET/fates/issues/861.  It replaces https://github.com/NGEET/fates/pull/874 as the fix after @ckoven noted that the prior fix was not correctly calculating the instantaneous vegetated temperature due to area scaling.


### Collaborators:
@ckoven @rgknox

### Expectation of Answer Changes:
Not expected to change answers.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [x] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
`/glade/u/home/glemieux/scratch/ctsm-tests/tests_pr877`

CTSM (or) E3SM (specify which) test hash-tag: `ctsm5.1.dev098`

CTSM (or) E3SM (specify which) baseline hash-tag: `ctsm5.1.dev098`

FATES baseline hash-tag: `fates-sci.1.57.1_api.23.0.0-ctsm5.1.dev098`

Test Output: B4B

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

