### PR TITLE
Remove memory and lai variables

### DIFF
--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -1493,7 +1493,6 @@ contains
     real(r8) :: fraction_exposed         ! how much of this layer is not covered by snow?
     real(r8) :: layer_top_hite           ! notional top height of this canopy layer (m)
     real(r8) :: layer_bottom_hite        ! notional bottom height of this canopy layer (m)
-    integer  :: smooth_leaf_distribution ! is the leaf distribution this option (1) or not (0)
     real(r8) :: frac_canopy(N_HITE_BINS) ! amount of canopy in each height class
     real(r8) :: minh(N_HITE_BINS)        ! minimum height in height class (m)
     real(r8) :: maxh(N_HITE_BINS)        ! maximum height in height class (m)
@@ -1504,7 +1503,6 @@ contains
 
     !----------------------------------------------------------------------
 
-    smooth_leaf_distribution = 0
 
     ! Here we are trying to generate a profile of leaf area, indexed by 'z' and by pft
     ! We assume that each point in the canopy recieved the light attenuated by the average

--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -1449,8 +1449,6 @@ contains
     !
     ! currentCohort%treelai    ! LAI per unit crown area  (m2/m2)
     ! currentCohort%treesai    ! SAI per unit crown area  (m2/m2)
-    ! currentCohort%lai        ! LAI per unit canopy area (m2/m2)
-    ! currentCohort%sai        ! SAI per unit canopy area (m2/m2)
     ! currentCohort%NV         ! The number of discrete vegetation
     !                          ! layers needed to describe this crown
     !
@@ -1477,7 +1475,7 @@ contains
     ! !USES:
 
     use EDtypesMod           , only : area, dinc_vai, dlower_vai, hitemax, n_hite_bins
-  
+
     !
     ! !ARGUMENTS
     type(ed_site_type)     , intent(inout) :: currentSite
@@ -1497,7 +1495,6 @@ contains
     real(r8) :: layer_bottom_hite        ! notional bottom height of this canopy layer (m)
     integer  :: smooth_leaf_distribution ! is the leaf distribution this option (1) or not (0)
     real(r8) :: frac_canopy(N_HITE_BINS) ! amount of canopy in each height class
-    real(r8) :: patch_lai                ! LAI summed over the patch in m2/m2 of canopy area
     real(r8) :: minh(N_HITE_BINS)        ! minimum height in height class (m)
     real(r8) :: maxh(N_HITE_BINS)        ! maximum height in height class (m)
     real(r8) :: dh                       ! vertical detph of height class (m)
@@ -1525,7 +1522,6 @@ contains
        currentPatch%canopy_layer_tlai(:)        = 0._r8
        currentPatch%ncan(:,:)                   = 0
        currentPatch%nrad(:,:)                   = 0
-       patch_lai                                = 0._r8
        currentPatch%tlai_profile(:,:,:)         = 0._r8
        currentPatch%tsai_profile(:,:,:)         = 0._r8
        currentPatch%elai_profile(:,:,:)         = 0._r8
@@ -1541,307 +1537,223 @@ contains
 
        if (currentPatch%total_canopy_area > nearzero ) then
 
-          call UpdatePatchLAI(currentPatch, patch_lai)
+          call UpdatePatchLAI(currentPatch)
 
-          if(smooth_leaf_distribution == 1)then
+          ! -----------------------------------------------------------------------------
+          ! Standard canopy layering model.
+          ! Go through all cohorts and add their leaf area
+          ! and canopy area to the accumulators.
+          ! -----------------------------------------------------------------------------
 
-             ! -----------------------------------------------------------------------------
-             ! we are going to ignore the concept of canopy layers, and put all of the leaf
-             ! area into height banded bins.  using the same domains as we had before, except
-             ! that CL always = 1
-             ! -----------------------------------------------------------------------------
+          currentCohort => currentPatch%shortest
+          do while(associated(currentCohort))
+             ft = currentCohort%pft
+             cl = currentCohort%canopy_layer
 
-             ! this is a crude way of dividing up the bins. Should it be a function of actual maximum height?
-             dh = 1.0_r8*(HITEMAX/N_HITE_BINS)
-             do iv = 1,N_HITE_BINS
-                if (iv == 1) then
-                   minh(iv) = 0.0_r8
-                   maxh(iv) = dh
-                else
-                   minh(iv) = (iv-1)*dh
-                   maxh(iv) = (iv)*dh
-                endif
-             enddo
+             ! ----------------------------------------------------------------
+             ! How much of each tree is stem area index? Assuming that there is
+             ! This may indeed be zero if there is a sensecent grass
+             ! ----------------------------------------------------------------
 
-             currentCohort => currentPatch%shortest
-             do while(associated(currentCohort))
-                ft = currentCohort%pft
-                min_chite = currentCohort%hite - currentCohort%hite * prt_params%crown_depth_frac(ft)
-                max_chite = currentCohort%hite
-                do iv = 1,N_HITE_BINS
-                   frac_canopy(iv) = 0.0_r8
-                   ! this layer is in the middle of the canopy
-                   if(max_chite > maxh(iv).and.min_chite < minh(iv))then
-                      frac_canopy(iv)= min(1.0_r8,dh / (currentCohort%hite*prt_params%crown_depth_frac(ft) ))
-                      ! this is the layer with the bottom of the canopy in it.
-                   elseif(min_chite < maxh(iv).and.min_chite > minh(iv).and.max_chite > maxh(iv))then
-                      frac_canopy(iv) = (maxh(iv) -min_chite ) / (currentCohort%hite*prt_params%crown_depth_frac(ft)  )
-                      ! this is the layer with the top of the canopy in it.
-                   elseif(max_chite > minh(iv).and.max_chite < maxh(iv).and.min_chite < minh(iv))then
-                      frac_canopy(iv) = (max_chite - minh(iv)) / (currentCohort%hite*prt_params%crown_depth_frac(ft))
-                   elseif(max_chite < maxh(iv).and.min_chite > minh(iv))then !the whole cohort is within this layer.
-                      frac_canopy(iv) = 1.0_r8
-                   endif
-
-                   ! no m2 of leaf per m2 of ground in each height class
-                   currentPatch%tlai_profile(1,ft,iv) = currentPatch%tlai_profile(1,ft,iv) + frac_canopy(iv) * &
-                        currentCohort%lai
-                   currentPatch%tsai_profile(1,ft,iv) = currentPatch%tsai_profile(1,ft,iv) + frac_canopy(iv) * &
-                        currentCohort%sai
-
-                   !snow burial
-                   if(currentSite%snow_depth  > maxh(iv))then
-                      fraction_exposed = 0._r8
-                   endif
-                   if(currentSite%snow_depth < minh(iv))then
-                      fraction_exposed = 1._r8
-                   endif
-                   if(currentSite%snow_depth >= minh(iv) .and. currentSite%snow_depth <= maxh(iv)) then !only partly hidden...
-                      fraction_exposed = 1._r8 - max(0._r8,(min(1.0_r8,(currentSite%snow_depth-minh(iv))/dh)))
-                   endif
-
-                   currentPatch%elai_profile(1,ft,iv) = currentPatch%tlai_profile(1,ft,iv) * fraction_exposed
-                   currentPatch%esai_profile(1,ft,iv) = currentPatch%tsai_profile(1,ft,iv) * fraction_exposed
-
-                enddo ! (iv) hite bins
-
-                currentCohort => currentCohort%taller
-
-             enddo !currentCohort
-
-             ! -----------------------------------------------------------------------------
-             ! Perform a leaf area conservation check on the LAI profile
-             lai = 0.0_r8
-             do ft = 1,numpft
-                lai = lai+ sum(currentPatch%tlai_profile(1,ft,:))
-             enddo
-
-             if(lai > patch_lai)then
-                write(fates_log(), *) 'FATES: problem with lai assignments'
-                call endrun(msg=errMsg(sourcefile, __LINE__))
+             if( (currentCohort%treelai+currentCohort%treesai) > 0._r8)then
+                fleaf = currentCohort%treelai / (currentCohort%treelai + currentCohort%treesai)
+             else
+                fleaf = 0._r8
              endif
 
+             currentPatch%nrad(cl,ft) = currentPatch%ncan(cl,ft)
 
-          else ! smooth leaf distribution
-
-             ! -----------------------------------------------------------------------------
-             ! Standard canopy layering model.
-             ! Go through all cohorts and add their leaf area
-             ! and canopy area to the accumulators.
-             ! -----------------------------------------------------------------------------
-
-
-             currentCohort => currentPatch%shortest
-             do while(associated(currentCohort))
-                ft = currentCohort%pft
-                cl = currentCohort%canopy_layer
-
-                ! ----------------------------------------------------------------
-                ! How much of each tree is stem area index? Assuming that there is
-                ! This may indeed be zero if there is a sensecent grass
-                ! ----------------------------------------------------------------
-
-                if( (currentCohort%treelai+currentCohort%treesai) > 0._r8)then
-                   fleaf = currentCohort%lai / (currentCohort%lai + currentCohort%sai)
-                else
-                   fleaf = 0._r8
-                endif
-
-                currentPatch%nrad(cl,ft) = currentPatch%ncan(cl,ft)
-
-                if (currentPatch%nrad(cl,ft) > nlevleaf ) then
-                   write(fates_log(), *) 'Number of radiative leaf layers is larger'
-                   write(fates_log(), *) ' than the maximum allowed.'
-                   write(fates_log(), *) ' cl: ',cl
-                   write(fates_log(), *) ' ft: ',ft
-                   write(fates_log(), *) ' nlevleaf: ',nlevleaf
-                   write(fates_log(), *) ' currentPatch%nrad(cl,ft): ', currentPatch%nrad(cl,ft)
-                   call endrun(msg=errMsg(sourcefile, __LINE__))
-                end if
-
-
-                ! --------------------------------------------------------------------------
-                ! Whole layers.  Make a weighted average of the leaf area in each layer
-                ! before dividing it by the total area. Fill up layer for whole layers.
-                ! --------------------------------------------------------------------------
-
-                do iv = 1,currentCohort%NV
-
-                   ! This loop builds the arrays that define the effective (not snow covered)
-                   ! and total (includes snow covered) area indices for leaves and stems
-                   ! We calculate the absolute elevation of each layer to help determine if the layer
-                   ! is obscured by snow.
-
-                   layer_top_hite = currentCohort%hite - &
-                        ( real(iv-1,r8)/currentCohort%NV * currentCohort%hite *  &
-                        prt_params%crown_depth_frac(currentCohort%pft) )
-
-                   layer_bottom_hite = currentCohort%hite - &
-                        ( real(iv,r8)/currentCohort%NV * currentCohort%hite * &
-                        prt_params%crown_depth_frac(currentCohort%pft) )
-
-                   fraction_exposed = 1.0_r8
-                   if(currentSite%snow_depth  > layer_top_hite)then
-                      fraction_exposed = 0._r8
-                   endif
-                   if(currentSite%snow_depth < layer_bottom_hite)then
-                      fraction_exposed = 1._r8
-                   endif
-                   if(currentSite%snow_depth >= layer_bottom_hite .and. &
-                        currentSite%snow_depth <= layer_top_hite) then !only partly hidden...
-                      fraction_exposed =  1._r8 - max(0._r8,(min(1.0_r8,(currentSite%snow_depth -layer_bottom_hite)/ &
-                           (layer_top_hite-layer_bottom_hite ))))
-                   endif
-
-                   if(iv==currentCohort%NV) then
-                      remainder = (currentCohort%treelai + currentCohort%treesai) - &
-                           (dlower_vai(iv) - dinc_vai(iv))
-                      if(remainder > dinc_vai(iv) )then
-                         write(fates_log(), *)'ED: issue with remainder', &
-                              currentCohort%treelai,currentCohort%treesai,dinc_vai(iv), & 
-                              currentCohort%NV,remainder
-
-                         call endrun(msg=errMsg(sourcefile, __LINE__))
-                      endif
-                   else
-                      remainder = dinc_vai(iv)
-                   end if
-
-                   currentPatch%tlai_profile(cl,ft,iv) = currentPatch%tlai_profile(cl,ft,iv) + &
-                        remainder * fleaf * currentCohort%c_area/currentPatch%total_canopy_area
-
-                   currentPatch%elai_profile(cl,ft,iv) = currentPatch%elai_profile(cl,ft,iv) + &
-                        remainder * fleaf * currentCohort%c_area/currentPatch%total_canopy_area * &
-                        fraction_exposed
-
-                   currentPatch%tsai_profile(cl,ft,iv) = currentPatch%tsai_profile(cl,ft,iv) + &
-                        remainder * (1._r8 - fleaf) * currentCohort%c_area/currentPatch%total_canopy_area
-
-                   currentPatch%esai_profile(cl,ft,iv) = currentPatch%esai_profile(cl,ft,iv) + &
-                        remainder * (1._r8 - fleaf) * currentCohort%c_area/currentPatch%total_canopy_area * &
-                        fraction_exposed
-
-                   currentPatch%canopy_area_profile(cl,ft,iv) = currentPatch%canopy_area_profile(cl,ft,iv) + &
-                        currentCohort%c_area/currentPatch%total_canopy_area
-
-                   currentPatch%layer_height_profile(cl,ft,iv) = currentPatch%layer_height_profile(cl,ft,iv) + &
-                        (remainder * fleaf * currentCohort%c_area/currentPatch%total_canopy_area * &
-                        (layer_top_hite+layer_bottom_hite)/2.0_r8) !average height of layer.
-
-                end do
-
-                currentCohort => currentCohort%taller
-
-             enddo !cohort
-
-             ! --------------------------------------------------------------------------
-
-             ! If there is an upper-story, the top canopy layer
-             ! should have a value of exactly 1.0 in its top leaf layer
-             ! --------------------------------------------------------------------------
-
-             if ( (currentPatch%NCL_p > 1) .and. &
-                  (sum(currentPatch%canopy_area_profile(1,:,1)) < 0.9999 )) then
-                write(fates_log(), *) 'FATES: canopy_area_profile was less than 1 at the canopy top'
-                write(fates_log(), *) 'cl: ',1
-                write(fates_log(), *) 'iv: ',1
-                write(fates_log(), *) 'sum(cpatch%canopy_area_profile(1,:,1)): ', &
-                     sum(currentPatch%canopy_area_profile(1,:,1))
-                currentCohort => currentPatch%shortest
-                do while(associated(currentCohort))
-                   if(currentCohort%canopy_layer==1)then
-                      write(fates_log(), *) 'FATES: cohorts',currentCohort%dbh,currentCohort%c_area, &
-                           currentPatch%total_canopy_area,currentPatch%area
-                      write(fates_log(), *) 'ED: fracarea', currentCohort%pft, &
-                           currentCohort%c_area/currentPatch%total_canopy_area
-                   endif
-                   currentCohort => currentCohort%taller
-                enddo !currentCohort
+             if (currentPatch%nrad(cl,ft) > nlevleaf ) then
+                write(fates_log(), *) 'Number of radiative leaf layers is larger'
+                write(fates_log(), *) ' than the maximum allowed.'
+                write(fates_log(), *) ' cl: ',cl
+                write(fates_log(), *) ' ft: ',ft
+                write(fates_log(), *) ' nlevleaf: ',nlevleaf
+                write(fates_log(), *) ' currentPatch%nrad(cl,ft): ', currentPatch%nrad(cl,ft)
                 call endrun(msg=errMsg(sourcefile, __LINE__))
-
              end if
 
 
              ! --------------------------------------------------------------------------
-             ! In the following loop we are now normalizing the effective and
-             ! total area profiles to convert from units of leaf/stem area per vegetated
-             ! canopy area, into leaf/stem area per area of their own radiative column
-             ! which is typically the footprint of all cohorts contained in the canopy
-             ! layer x pft bins.
-             ! Also perform some checks on area normalization.
-             ! Check the area of each leaf layer, across pfts.
-             ! It should never be larger than 1 or less than 0.
+             ! Whole layers.  Make a weighted average of the leaf area in each layer
+             ! before dividing it by the total area. Fill up layer for whole layers.
              ! --------------------------------------------------------------------------
 
-             do cl = 1,currentPatch%NCL_p
+             do iv = 1,currentCohort%NV
+
+                ! This loop builds the arrays that define the effective (not snow covered)
+                ! and total (includes snow covered) area indices for leaves and stems
+                ! We calculate the absolute elevation of each layer to help determine if the layer
+                ! is obscured by snow.
+
+                layer_top_hite = currentCohort%hite - &
+                     ( real(iv-1,r8)/currentCohort%NV * currentCohort%hite *  &
+                     prt_params%crown_depth_frac(currentCohort%pft) )
+
+                layer_bottom_hite = currentCohort%hite - &
+                     ( real(iv,r8)/currentCohort%NV * currentCohort%hite * &
+                     prt_params%crown_depth_frac(currentCohort%pft) )
+
+                fraction_exposed = 1.0_r8
+                if(currentSite%snow_depth  > layer_top_hite)then
+                   fraction_exposed = 0._r8
+                endif
+                if(currentSite%snow_depth < layer_bottom_hite)then
+                   fraction_exposed = 1._r8
+                endif
+                if(currentSite%snow_depth >= layer_bottom_hite .and. &
+                     currentSite%snow_depth <= layer_top_hite) then !only partly hidden...
+                   fraction_exposed =  1._r8 - max(0._r8,(min(1.0_r8,(currentSite%snow_depth -layer_bottom_hite)/ &
+                        (layer_top_hite-layer_bottom_hite ))))
+                endif
+
+                if(iv==currentCohort%NV) then
+                   remainder = (currentCohort%treelai + currentCohort%treesai) - &
+                        (dlower_vai(iv) - dinc_vai(iv))
+                   if(remainder > dinc_vai(iv) )then
+                      write(fates_log(), *)'ED: issue with remainder', &
+                           currentCohort%treelai,currentCohort%treesai,dinc_vai(iv), & 
+                           currentCohort%NV,remainder
+
+                      call endrun(msg=errMsg(sourcefile, __LINE__))
+                   endif
+                else
+                   remainder = dinc_vai(iv)
+                end if
+
+                currentPatch%tlai_profile(cl,ft,iv) = currentPatch%tlai_profile(cl,ft,iv) + &
+                     remainder * fleaf * currentCohort%c_area/currentPatch%total_canopy_area
+
+                currentPatch%elai_profile(cl,ft,iv) = currentPatch%elai_profile(cl,ft,iv) + &
+                     remainder * fleaf * currentCohort%c_area/currentPatch%total_canopy_area * &
+                     fraction_exposed
+
+                currentPatch%tsai_profile(cl,ft,iv) = currentPatch%tsai_profile(cl,ft,iv) + &
+                     remainder * (1._r8 - fleaf) * currentCohort%c_area/currentPatch%total_canopy_area
+
+                currentPatch%esai_profile(cl,ft,iv) = currentPatch%esai_profile(cl,ft,iv) + &
+                     remainder * (1._r8 - fleaf) * currentCohort%c_area/currentPatch%total_canopy_area * &
+                     fraction_exposed
+
+                currentPatch%canopy_area_profile(cl,ft,iv) = currentPatch%canopy_area_profile(cl,ft,iv) + &
+                     currentCohort%c_area/currentPatch%total_canopy_area
+
+                currentPatch%layer_height_profile(cl,ft,iv) = currentPatch%layer_height_profile(cl,ft,iv) + &
+                     (remainder * fleaf * currentCohort%c_area/currentPatch%total_canopy_area * &
+                     (layer_top_hite+layer_bottom_hite)/2.0_r8) !average height of layer.
+
+             end do
+
+             currentCohort => currentCohort%taller
+
+          enddo !cohort
+
+          ! --------------------------------------------------------------------------
+
+          ! If there is an upper-story, the top canopy layer
+          ! should have a value of exactly 1.0 in its top leaf layer
+          ! --------------------------------------------------------------------------
+
+          if ( (currentPatch%NCL_p > 1) .and. &
+               (sum(currentPatch%canopy_area_profile(1,:,1)) < 0.9999 )) then
+             write(fates_log(), *) 'FATES: canopy_area_profile was less than 1 at the canopy top'
+             write(fates_log(), *) 'cl: ',1
+             write(fates_log(), *) 'iv: ',1
+             write(fates_log(), *) 'sum(cpatch%canopy_area_profile(1,:,1)): ', &
+                  sum(currentPatch%canopy_area_profile(1,:,1))
+             currentCohort => currentPatch%shortest
+             do while(associated(currentCohort))
+                if(currentCohort%canopy_layer==1)then
+                   write(fates_log(), *) 'FATES: cohorts',currentCohort%dbh,currentCohort%c_area, &
+                        currentPatch%total_canopy_area,currentPatch%area
+                   write(fates_log(), *) 'ED: fracarea', currentCohort%pft, &
+                        currentCohort%c_area/currentPatch%total_canopy_area
+                endif
+                currentCohort => currentCohort%taller
+             enddo !currentCohort
+             call endrun(msg=errMsg(sourcefile, __LINE__))
+
+          end if
+
+
+          ! --------------------------------------------------------------------------
+          ! In the following loop we are now normalizing the effective and
+          ! total area profiles to convert from units of leaf/stem area per vegetated
+          ! canopy area, into leaf/stem area per area of their own radiative column
+          ! which is typically the footprint of all cohorts contained in the canopy
+          ! layer x pft bins.
+          ! Also perform some checks on area normalization.
+          ! Check the area of each leaf layer, across pfts.
+          ! It should never be larger than 1 or less than 0.
+          ! --------------------------------------------------------------------------
+
+          do cl = 1,currentPatch%NCL_p
+             do iv = 1,currentPatch%ncan(cl,ft)
+
+                if( debug .and. sum(currentPatch%canopy_area_profile(cl,:,iv)) > 1.0001_r8 ) then
+
+                   write(fates_log(), *) 'FATES: A canopy_area_profile exceeded 1.0'
+                   write(fates_log(), *) 'cl: ',cl
+                   write(fates_log(), *) 'iv: ',iv
+                   write(fates_log(), *) 'sum(cpatch%canopy_area_profile(cl,:,iv)): ', &
+                        sum(currentPatch%canopy_area_profile(cl,:,iv))
+                   currentCohort => currentPatch%shortest
+                   do while(associated(currentCohort))
+                      if(currentCohort%canopy_layer==cl)then
+                         write(fates_log(), *) 'FATES: cohorts in layer cl = ',cl, &
+                              currentCohort%dbh,currentCohort%c_area, &
+                              currentPatch%total_canopy_area,currentPatch%area
+                         write(fates_log(), *) 'ED: fracarea', currentCohort%pft, &
+                              currentCohort%c_area/currentPatch%total_canopy_area
+                      endif
+                      currentCohort => currentCohort%taller
+                   enddo !currentCohort
+                   call endrun(msg=errMsg(sourcefile, __LINE__))
+                end if
+             end do
+
+             do ft = 1,numpft
                 do iv = 1,currentPatch%ncan(cl,ft)
 
-                   if( debug .and. sum(currentPatch%canopy_area_profile(cl,:,iv)) > 1.0001_r8 ) then
+                   if( currentPatch%canopy_area_profile(cl,ft,iv) > nearzero ) then
 
-                      write(fates_log(), *) 'FATES: A canopy_area_profile exceeded 1.0'
-                      write(fates_log(), *) 'cl: ',cl
-                      write(fates_log(), *) 'iv: ',iv
-                      write(fates_log(), *) 'sum(cpatch%canopy_area_profile(cl,:,iv)): ', &
-                           sum(currentPatch%canopy_area_profile(cl,:,iv))
-                      currentCohort => currentPatch%shortest
-                      do while(associated(currentCohort))
-                         if(currentCohort%canopy_layer==cl)then
-                            write(fates_log(), *) 'FATES: cohorts in layer cl = ',cl, &
-                                 currentCohort%dbh,currentCohort%c_area, &
-                                 currentPatch%total_canopy_area,currentPatch%area
-                            write(fates_log(), *) 'ED: fracarea', currentCohort%pft, &
-                                 currentCohort%c_area/currentPatch%total_canopy_area
-                         endif
-                         currentCohort => currentCohort%taller
-                      enddo !currentCohort
-                      call endrun(msg=errMsg(sourcefile, __LINE__))
+                      currentPatch%tlai_profile(cl,ft,iv) = currentPatch%tlai_profile(cl,ft,iv) / &
+                           currentPatch%canopy_area_profile(cl,ft,iv)
+
+                      currentPatch%tsai_profile(cl,ft,iv) = currentPatch%tsai_profile(cl,ft,iv) / &
+                           currentPatch%canopy_area_profile(cl,ft,iv)
+
+                      currentPatch%elai_profile(cl,ft,iv) = currentPatch%elai_profile(cl,ft,iv) / &
+                           currentPatch%canopy_area_profile(cl,ft,iv)
+
+                      currentPatch%esai_profile(cl,ft,iv) = currentPatch%esai_profile(cl,ft,iv) / &
+                           currentPatch%canopy_area_profile(cl,ft,iv)
                    end if
-                end do
 
-                do ft = 1,numpft
-                   do iv = 1,currentPatch%ncan(cl,ft)
-
-                      if( currentPatch%canopy_area_profile(cl,ft,iv) > nearzero ) then
-
-                         currentPatch%tlai_profile(cl,ft,iv) = currentPatch%tlai_profile(cl,ft,iv) / &
-                              currentPatch%canopy_area_profile(cl,ft,iv)
-
-                         currentPatch%tsai_profile(cl,ft,iv) = currentPatch%tsai_profile(cl,ft,iv) / &
-                              currentPatch%canopy_area_profile(cl,ft,iv)
-
-                         currentPatch%elai_profile(cl,ft,iv) = currentPatch%elai_profile(cl,ft,iv) / &
-                              currentPatch%canopy_area_profile(cl,ft,iv)
-
-                         currentPatch%esai_profile(cl,ft,iv) = currentPatch%esai_profile(cl,ft,iv) / &
-                              currentPatch%canopy_area_profile(cl,ft,iv)
-                      end if
-
-                      if(currentPatch%tlai_profile(cl,ft,iv)>nearzero )then
-                         currentPatch%layer_height_profile(cl,ft,iv) = currentPatch%layer_height_profile(cl,ft,iv) &
-                              /currentPatch%tlai_profile(cl,ft,iv)
-                      end if
-
-                   enddo
+                   if(currentPatch%tlai_profile(cl,ft,iv)>nearzero )then
+                      currentPatch%layer_height_profile(cl,ft,iv) = currentPatch%layer_height_profile(cl,ft,iv) &
+                           /currentPatch%tlai_profile(cl,ft,iv)
+                   end if
 
                 enddo
+
              enddo
+          enddo
 
-             ! --------------------------------------------------------------------------
-             ! Set the mask that identifies which PFT x can-layer combinations have
-             ! scattering elements in them.
-             ! --------------------------------------------------------------------------
+          ! --------------------------------------------------------------------------
+          ! Set the mask that identifies which PFT x can-layer combinations have
+          ! scattering elements in them.
+          ! --------------------------------------------------------------------------
 
-             do cl = 1,currentPatch%NCL_p
-                do ft = 1,numpft
-                   do  iv = 1, currentPatch%nrad(cl,ft)
-                      if(currentPatch%canopy_area_profile(cl,ft,iv) > 0._r8)then
-                         currentPatch%canopy_mask(cl,ft) = 1
-                      endif
-                   end do !iv
-                enddo !ft
-             enddo ! loop over cl
-
-          endif !leaf distribution
+          do cl = 1,currentPatch%NCL_p
+             do ft = 1,numpft
+                do  iv = 1, currentPatch%nrad(cl,ft)
+                   if(currentPatch%canopy_area_profile(cl,ft,iv) > 0._r8)then
+                      currentPatch%canopy_mask(cl,ft) = 1
+                   endif
+                end do !iv
+             enddo !ft
+          enddo ! loop over cl
 
        end if
 
@@ -2180,7 +2092,7 @@ contains
   
   ! ===============================================================================================
 
-  subroutine UpdatePatchLAI(currentPatch, patch_lai)
+  subroutine UpdatePatchLAI(currentPatch)
 
    ! --------------------------------------------------------------------------------------------
    ! This subroutine works through the current patch cohorts and updates the canopy_layer_tlai
@@ -2192,7 +2104,6 @@ contains
 
    ! Arguments
    type(ed_patch_type),intent(inout), target   :: currentPatch
-   real(r8), intent(inout) :: patch_lai
 
    ! Local Variables
    type(ed_cohort_type), pointer :: currentCohort
@@ -2219,11 +2130,10 @@ contains
             ! Update the number of number of vegetation layers
             currentPatch%ncan(cl,ft) = max(currentPatch%ncan(cl,ft),currentCohort%NV)
 
-            ! Update the patch canopy layer tlai
-            currentPatch%canopy_layer_tlai(cl) = currentPatch%canopy_layer_tlai(cl) + currentCohort%lai
+            ! Update the patch canopy layer tlai (LAI per canopy area)
+            currentPatch%canopy_layer_tlai(cl) = currentPatch%canopy_layer_tlai(cl) +  &
+                 currentCohort%treelai *currentCohort%c_area/currentPatch%total_canopy_area
             
-            ! Calculate the total patch lai
-            patch_lai = patch_lai + currentCohort%lai
          end if
          currentCohort => currentCohort%shorter
 
@@ -2263,9 +2173,7 @@ contains
            currentCohort%vcmax25top,4)
    end if
 
-   ! Update the cohort lai and sai
-   currentCohort%lai =  currentCohort%treelai *currentCohort%c_area/patcharea
-   currentCohort%sai =  currentCohort%treesai *currentCohort%c_area/patcharea
+ 
 
    ! Number of actual vegetation layers in this cohort's crown
    currentCohort%nv =  count((currentCohort%treelai+currentCohort%treesai) .gt. dlower_vai(:)) + 1

--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -1555,7 +1555,7 @@ contains
              ! This may indeed be zero if there is a sensecent grass
              ! ----------------------------------------------------------------
 
-             if( (currentCohort%treelai+currentCohort%treesai) > 0._r8)then
+             if( (currentCohort%treelai+currentCohort%treesai) > nearzero)then
                 fleaf = currentCohort%treelai / (currentCohort%treelai + currentCohort%treesai)
              else
                 fleaf = 0._r8

--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -1499,7 +1499,8 @@ contains
     real(r8) :: dh                       ! vertical detph of height class (m)
     real(r8) :: min_chite                ! bottom of cohort canopy  (m)
     real(r8) :: max_chite                ! top of cohort canopy      (m)
-    real(r8) :: lai                      ! summed lai for checking m2 m-2
+    real(r8) :: lai                      ! we use this to preserve b4b right now (m2/m2)
+    real(r8) :: sai                      ! ""
 
     !----------------------------------------------------------------------
 
@@ -1552,9 +1553,11 @@ contains
              ! How much of each tree is stem area index? Assuming that there is
              ! This may indeed be zero if there is a sensecent grass
              ! ----------------------------------------------------------------
-
+             lai = currentCohort%treelai * currentCohort%c_area/currentPatch%total_canopy_area
+             sai = currentCohort%treesai * currentCohort%c_area/currentPatch%total_canopy_area
              if( (currentCohort%treelai+currentCohort%treesai) > nearzero)then
-                fleaf = currentCohort%treelai / (currentCohort%treelai + currentCohort%treesai)
+                !fleaf = currentCohort%treelai / (currentCohort%treelai + currentCohort%treesai)
+                fleaf = lai / (lai+sai)
              else
                 fleaf = 0._r8
              endif

--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -1499,8 +1499,8 @@ contains
     real(r8) :: dh                       ! vertical detph of height class (m)
     real(r8) :: min_chite                ! bottom of cohort canopy  (m)
     real(r8) :: max_chite                ! top of cohort canopy      (m)
-    real(r8) :: lai                      ! we use this to preserve b4b right now (m2/m2)
-    real(r8) :: sai                      ! ""
+    real(r8) :: lai                      ! leaf area per canopy area
+    real(r8) :: sai                      ! stem area per canopy area
 
     !----------------------------------------------------------------------
 
@@ -1556,7 +1556,9 @@ contains
              lai = currentCohort%treelai * currentCohort%c_area/currentPatch%total_canopy_area
              sai = currentCohort%treesai * currentCohort%c_area/currentPatch%total_canopy_area
              if( (currentCohort%treelai+currentCohort%treesai) > nearzero)then
-                !fleaf = currentCohort%treelai / (currentCohort%treelai + currentCohort%treesai)
+                
+                ! See issue: https://github.com/NGEET/fates/issues/899
+                ! fleaf = currentCohort%treelai / (currentCohort%treelai + currentCohort%treesai)
                 fleaf = lai / (lai+sai)
              else
                 fleaf = 0._r8

--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -147,8 +147,7 @@ contains
 
 
   subroutine create_cohort(currentSite, patchptr, pft, nn, hite, coage, dbh,   &
-                           prt, leafmemory, sapwmemory, structmemory, &
-                           status, recruitstatus,ctrim, carea, clayer, spread, bc_in)
+                           prt, status, recruitstatus,ctrim, carea, clayer, spread, bc_in)
     !
     ! !DESCRIPTION:
     ! create new cohort
@@ -181,12 +180,6 @@ contains
     real(r8), intent(in)      :: dbh              ! dbh: cm
     class(prt_vartypes),target :: prt             ! The allocated PARTEH
                                                   ! object
-    real(r8), intent(in)      :: leafmemory       ! target leaf biomass- set from
-                                                  ! previous year: kGC per indiv
-    real(r8), intent(in)   :: sapwmemory          ! target sapwood biomass- set from
-                                                  ! previous year: kGC per indiv
-    real(r8), intent(in)   :: structmemory        ! target structural biomass- set from
-                                                  ! previous year: kGC per indiv
     real(r8), intent(in)      :: ctrim            ! What is the fraction of the maximum
                                                   ! leaf biomass that we are targeting?
     real(r8), intent(in)      :: spread           ! The community assembly effects how
@@ -237,9 +230,6 @@ contains
     new_cohort%canopy_trim  = ctrim
     new_cohort%canopy_layer = clayer
     new_cohort%canopy_layer_yesterday = real(clayer, r8)
-    new_cohort%leafmemory   = leafmemory
-    new_cohort%sapwmemory   = sapwmemory
-    new_cohort%structmemory = structmemory
 
     ! This sets things like vcmax25top, that depend on the
     ! leaf age fractions (which are defined by PARTEH)
@@ -544,9 +534,6 @@ contains
     currentCohort%dbh                = nan ! 'diameter at breast height' in cm
     currentCohort%coage              = nan ! age of the cohort in years
     currentCohort%hite               = nan ! height: meters
-    currentCohort%leafmemory         = nan ! target leaf biomass- set from previous year: kGC per indiv
-    currentCohort%sapwmemory         = nan ! target sapwood biomass- set from previous year: kGC per indiv
-    currentCohort%structmemory       = nan ! target structural biomass- set from previous year: kGC per indiv
     currentCohort%lai                = nan ! leaf area index of cohort   m2/m2
     currentCohort%sai                = nan ! stem area index of cohort   m2/m2
     currentCohort%g_sb_laweight      = nan ! Total leaf conductance of cohort (stomata+blayer) weighted by leaf-area [m/s]*[m2]
@@ -1198,7 +1185,6 @@ contains
                                       write(fates_log(),*) 'Cohort I, Cohort II'
                                       write(fates_log(),*) 'n:',currentCohort%n,nextc%n
                                       write(fates_log(),*) 'isnew:',currentCohort%isnew,nextc%isnew
-                                      write(fates_log(),*) 'leafmemory:',currentCohort%leafmemory,nextc%leafmemory
                                       write(fates_log(),*) 'hite:',currentCohort%hite,nextc%hite
                                       write(fates_log(),*) 'coage:',currentCohort%coage,nextc%coage
                                       write(fates_log(),*) 'dbh:',currentCohort%dbh,nextc%dbh
@@ -1235,15 +1221,6 @@ contains
                                    ! Leaf biophysical rates (use leaf mass weighting)
                                    ! -----------------------------------------------------------------
                                    call UpdateCohortBioPhysRates(currentCohort)
-
-                                   currentCohort%leafmemory   = (currentCohort%n*currentCohort%leafmemory   &
-                                        + nextc%n*nextc%leafmemory)/newn
-
-                                   currentCohort%sapwmemory   = (currentCohort%n*currentCohort%sapwmemory   &
-                                        + nextc%n*nextc%sapwmemory)/newn
-
-                                   currentCohort%structmemory   = (currentCohort%n*currentCohort%structmemory   &
-                                        + nextc%n*nextc%structmemory)/newn
 
                                    currentCohort%canopy_trim = (currentCohort%n*currentCohort%canopy_trim &
                                         + nextc%n*nextc%canopy_trim)/newn
@@ -1810,9 +1787,6 @@ contains
     n%dbh             = o%dbh
     n%coage           = o%coage
     n%hite            = o%hite
-    n%leafmemory      = o%leafmemory
-    n%sapwmemory      = o%sapwmemory
-    n%structmemory    = o%structmemory
     n%lai             = o%lai
     n%sai             = o%sai
     n%g_sb_laweight   = o%g_sb_laweight

--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -277,8 +277,6 @@ contains
                                   patchptr%canopy_layer_tlai, new_cohort%treelai,new_cohort%vcmax25top,2 )
     end if
 
-    new_cohort%lai     = new_cohort%treelai * new_cohort%c_area/patchptr%area
-
 
     ! Put cohort at the right place in the linked list
     storebigcohort   => patchptr%tallest
@@ -534,8 +532,6 @@ contains
     currentCohort%dbh                = nan ! 'diameter at breast height' in cm
     currentCohort%coage              = nan ! age of the cohort in years
     currentCohort%hite               = nan ! height: meters
-    currentCohort%lai                = nan ! leaf area index of cohort   m2/m2
-    currentCohort%sai                = nan ! stem area index of cohort   m2/m2
     currentCohort%g_sb_laweight      = nan ! Total leaf conductance of cohort (stomata+blayer) weighted by leaf-area [m/s]*[m2]
     currentCohort%canopy_trim        = nan ! What is the fraction of the maximum leaf biomass that we are targeting? :-
     currentCohort%leaf_cost          = nan ! How much does it cost to maintain leaves: kgC/m2/year-1
@@ -1787,8 +1783,6 @@ contains
     n%dbh             = o%dbh
     n%coage           = o%coage
     n%hite            = o%hite
-    n%lai             = o%lai
-    n%sai             = o%sai
     n%g_sb_laweight   = o%g_sb_laweight
     n%leaf_cost       = o%leaf_cost
     n%canopy_layer    = o%canopy_layer

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -1066,7 +1066,7 @@ contains
     real(r8) :: deficit_c              ! Amount of C needed to get flushing pools "on-allometry"
     real(r8) :: target_leaf_c
     real(r8) :: target_sapw_c
-    real(r8) :: target_agw_c, target_bgw_c, target_agw_c, target_struct_c
+    real(r8) :: target_agw_c, target_bgw_c, target_struct_c
     real(r8) :: sapw_area
     integer  :: ipft
     real(r8), parameter :: leaf_drop_fraction = 1.0_r8
@@ -1097,9 +1097,9 @@ contains
           ! The site level flags signify that it is no-longer too cold
           ! for leaves. Time to signal flushing
 
-          if (prt_params%season_decid(ipft) == itrue)then
-             if ( currentSite%cstatus == phen_cstat_notcold  )then                ! we have just moved to leaves being on .
-                if (currentCohort%status_coh == leaves_off)then ! Are the leaves currently off?
+          if_colddec: if (prt_params%season_decid(ipft) == itrue)then
+             if_notcold: if ( currentSite%cstatus == phen_cstat_notcold  )then                ! we have just moved to leaves being on .
+                if_leaves_off: if (currentCohort%status_coh == leaves_off)then ! Are the leaves currently off?
                    currentCohort%status_coh = leaves_on         ! Leaves are on, so change status to
                    ! stop flow of carbon out of bstore.
 
@@ -1153,16 +1153,15 @@ contains
                       
                    end if
 
-                endif
-                endif !pft phenology
-             endif ! growing season
+                endif if_leaves_off
+             endif if_notcold
 
              !COLD LEAF OFF
-             if (currentSite%cstatus == phen_cstat_nevercold .or. &
+             if_cold:  if (currentSite%cstatus == phen_cstat_nevercold .or. &
                   currentSite%cstatus == phen_cstat_iscold) then ! past leaf drop day? Leaves still on tree?
-
-                if (currentCohort%status_coh == leaves_on) then ! leaves have not dropped
-
+                
+                if_leaves_on: if (currentCohort%status_coh == leaves_on) then ! leaves have not dropped
+                   
                    ! leaf off occur on individuals bigger than specific size for grass
                    if (currentCohort%dbh > EDPftvarcon_inst%phen_cold_size_threshold(ipft) &
                         .or. prt_params%woody(ipft)==itrue) then
@@ -1187,9 +1186,9 @@ contains
 
                       endif	! woody plant check
                    endif ! individual dbh size check
-                endif !leaf status
-             endif !currentSite status
-          endif  !season_decid
+                endif if_leaves_on !leaf status
+             endif if_cold !currentSite status
+          endif if_colddec  !season_decid
 
           ! DROUGHT LEAF ON
           ! Site level flag indicates it is no longer in drought condition
@@ -1255,7 +1254,6 @@ contains
                       
                    end if
 
-                   endif ! woody plant check
                 endif !currentCohort status again?
              endif   !currentSite status
 

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -425,8 +425,6 @@ contains
 
     real(r8) :: initial_trim              ! Initial trim
     real(r8) :: optimum_trim              ! Optimum trim value
-    real(r8) :: initial_leafmem           ! Initial leafmemory
-    real(r8) :: optimum_leafmem           ! Optimum leafmemory
 
     !----------------------------------------------------------------------
 
@@ -446,15 +444,13 @@ contains
        currentCohort => currentPatch%tallest
        do while (associated(currentCohort))
 
-          ! Save off the incoming trim and leafmemory
+          ! Save off the incoming trim
           initial_trim = currentCohort%canopy_trim
-          initial_leafmem = currentCohort%leafmemory
 
           ! Add debug diagnstic output to determine which cohort
           if (debug) then
              write(fates_log(),*) 'Current cohort:', icohort
              write(fates_log(),*) 'Starting canopy trim:', initial_trim
-             write(fates_log(),*) 'Starting leafmemory:', currentCohort%leafmemory
           endif
 
           trimmed = .false.
@@ -596,10 +592,6 @@ contains
                       if (currentCohort%hite > EDPftvarcon_inst%hgt_min(ipft)) then
                          currentCohort%canopy_trim = currentCohort%canopy_trim - &
                               EDPftvarcon_inst%trim_inc(ipft)
-                         if (prt_params%evergreen(ipft) /= 1)then
-                            currentCohort%leafmemory = currentCohort%leafmemory * &
-                                 (1.0_r8 - EDPftvarcon_inst%trim_inc(ipft))
-                         endif
 
                          trimmed = .true.
 
@@ -641,16 +633,10 @@ contains
 
                 !
                 optimum_trim = (nnu_clai_b(1,1) / cumulative_lai_cohort) * initial_trim
-                optimum_leafmem = (nnu_clai_b(1,1) / cumulative_lai_cohort) * initial_leafmem
 
                 ! Determine if the optimum trim value makes sense.  The smallest cohorts tend to have unrealistic fits.
                 if (optimum_trim > 0. .and. optimum_trim < 1.) then
                    currentCohort%canopy_trim = optimum_trim
-
-                   ! If the cohort pft is not evergreen we reduce the leafmemory as well
-                   if (prt_params%evergreen(ipft) /= 1) then
-                      currentCohort%leafmemory = optimum_leafmem
-                   endif
 
                    trimmed = .true.
 
@@ -1077,7 +1063,11 @@ contains
     real(r8) :: struct_c               ! structural wood carbon [kg]
     real(r8) :: store_c                ! storage carbon [kg]
     real(r8) :: store_c_transfer_frac  ! Fraction of storage carbon used to flush leaves
-    real(r8) :: totalmemory            ! total memory of carbon [kg]
+    real(r8) :: deficit_c              ! Amount of C needed to get flushing pools "on-allometry"
+    real(r8) :: target_leaf_c
+    real(r8) :: target_sapw_c
+    real(r8) :: target_bgw_c, target_agw_c, target_struct_c
+    real(r8) :: sapw_area
     integer  :: ipft
     real(r8), parameter :: leaf_drop_fraction = 1.0_r8
     real(r8), parameter :: carbon_store_buffer = 0.10_r8
@@ -1096,10 +1086,10 @@ contains
 
           if(debug) call currentCohort%prt%CheckMassConservation(ipft,0)
 
-          store_c = currentCohort%prt%GetState(store_organ, all_carbon_elements)
-          leaf_c  = currentCohort%prt%GetState(leaf_organ, all_carbon_elements)
-          sapw_c  = currentCohort%prt%GetState(sapw_organ, all_carbon_elements)
-          struct_c  = currentCohort%prt%GetState(struct_organ, all_carbon_elements)
+          store_c = currentCohort%prt%GetState(store_organ, carbon12_element)
+          leaf_c  = currentCohort%prt%GetState(leaf_organ, carbon12_element)
+          sapw_c  = currentCohort%prt%GetState(sapw_organ, carbon12_element)
+          struct_c  = currentCohort%prt%GetState(struct_organ, carbon12_element)
 
           stem_drop_fraction = EDPftvarcon_inst%phen_stem_drop_fraction(ipft)
 
@@ -1113,18 +1103,24 @@ contains
                    currentCohort%status_coh = leaves_on         ! Leaves are on, so change status to
                    ! stop flow of carbon out of bstore.
 
+                   call bleaf(currentCohort%dbh,currentCohort%pft,currentCohort%canopy_trim,target_leaf_c)
+                   call bsap_allom(currentCohort%dbh,currentCohort%pft,currentCohort%canopy_trim,sapw_area,target_sapw_c)
+                   call bbgw_allom(currentCohort%dbh,currentCohort%pft,target_bgw_c)
+                   call bdead_allom( target_agw_c, target_bgw_c, target_sapw_c, currentCohort%pft, target_struct_c)
+
+                   if(prt_params%woody(ipft) == itrue)then
+                      deficit_c = target_leaf_c
+                   else
+                      deficit_c = target_leaf_c + (target_sapw_c-sapw_c) + (target_struct_c-struct_c)
+                   end if
+                   
                    if(store_c>nearzero) then
-                      ! flush either the amount required from the leafmemory, or -most- of the storage pool
+
+                      ! flush either the amount to get to the target, or -most- of the storage pool
                       ! RF: added a criterion to stop the entire store pool emptying and triggering termination mortality
                       ! n.b. this might not be necessary if we adopted a more gradual approach to leaf flushing...
-                      store_c_transfer_frac =  min((EDPftvarcon_inst%phenflush_fraction(ipft)* &
-                           currentCohort%leafmemory)/store_c,(1.0_r8-carbon_store_buffer))
-
-                      if(prt_params%woody(ipft).ne.itrue)then
-                         totalmemory=currentCohort%leafmemory+currentCohort%sapwmemory+currentCohort%structmemory
-                         store_c_transfer_frac = min((EDPftvarcon_inst%phenflush_fraction(ipft)* &
-                              totalmemory)/store_c, (1.0_r8-carbon_store_buffer))
-                      endif
+                      store_c_transfer_frac = min((EDPftvarcon_inst%phenflush_fraction(ipft)*deficit_c)/store_c, &
+                                                  (1.0_r8-carbon_store_buffer))
 
                    else
                       store_c_transfer_frac = 0.0_r8
@@ -1135,21 +1131,21 @@ contains
                    if(prt_params%woody(ipft) == itrue) then
 
                       call PRTPhenologyFlush(currentCohort%prt, ipft, leaf_organ, store_c_transfer_frac)
-                      currentCohort%leafmemory = 0.0_r8
 
                    else
 
-                      ! Check that the stem drop fraction is set to non-zero amount otherwise flush all carbon store to leaves
+                      ! Check that the stem drop fraction is set to non-zero amount
+                      ! otherwise flush all carbon store to leaves
                       if (stem_drop_fraction .gt. 0.0_r8) then
 
                          call PRTPhenologyFlush(currentCohort%prt, ipft, leaf_organ, &
-                              store_c_transfer_frac*currentCohort%leafmemory/totalmemory)
+                              store_c_transfer_frac*target_leaf_c/deficit_c)
 
                          call PRTPhenologyFlush(currentCohort%prt, ipft, sapw_organ, &
-                              store_c_transfer_frac*currentCohort%sapwmemory/totalmemory)
+                              store_c_transfer_frac*(target_sapw_c-sapw_c)/deficit_c)
 
                          call PRTPhenologyFlush(currentCohort%prt, ipft, struct_organ, &
-                              store_c_transfer_frac*currentCohort%structmemory/totalmemory)
+                              store_c_transfer_frac*(target_struct_c-struct_c)/deficit_c)
 
                       else
 
@@ -1157,10 +1153,6 @@ contains
                               store_c_transfer_frac)
 
                       end if
-
-                      currentCohort%leafmemory = 0.0_r8
-                      currentCohort%structmemory = 0.0_r8
-                      currentCohort%sapwmemory = 0.0_r8
 
                    endif
                 endif !pft phenology
@@ -1179,11 +1171,6 @@ contains
                       ! This sets the cohort to the "leaves off" flag
                       currentCohort%status_coh  = leaves_off
 
-                      ! Remember what the leaf mass was for next year
-                      ! the same amount back on in the spring...
-
-                      currentCohort%leafmemory   = leaf_c
-
                       ! Drop Leaves (this routine will update the leaf state variables,
                       ! for carbon and any other element that are prognostic. It will
                       ! also track the turnover masses that will be sent to litter later on)
@@ -1192,10 +1179,6 @@ contains
                            leaf_organ, leaf_drop_fraction)
 
                       if(prt_params%woody(ipft).ne.itrue)then
-
-                         currentCohort%sapwmemory   = sapw_c * stem_drop_fraction
-
-                         currentCohort%structmemory   = struct_c * stem_drop_fraction
 
                          call PRTDeciduousTurnover(currentCohort%prt,ipft, &
                               sapw_organ, stem_drop_fraction)
@@ -1226,19 +1209,22 @@ contains
                    currentCohort%status_coh = leaves_on    ! Leaves are on, so change status to
                    ! stop flow of carbon out of bstore.
 
+                   call bleaf(currentCohort%dbh,currentCohort%pft,currentCohort%canopy_trim,target_leaf_c)
+                   call bsap_allom(currentCohort%dbh,currentCohort%pft,currentCohort%canopy_trim,sapw_area,target_sapw_c)
+                   call bbgw_allom(currentCohort%dbh,currentCohort%pft,target_bgw_c)
+                   call bdead_allom( target_agw_c, target_bgw_c, target_sapw_c, currentCohort%pft, target_struct_c)
+
+                   if(prt_params%woody(ipft) == itrue)then
+                      deficit_c = target_leaf_c
+                   else
+                      deficit_c = target_leaf_c + (target_sapw_c-sapw_c) + (target_struct_c-struct_c)
+                   end if
+                   
                    if(store_c>nearzero) then
-
-                     store_c_transfer_frac = &
-                          min((EDPftvarcon_inst%phenflush_fraction(ipft)*currentCohort%leafmemory)/store_c, &
-                          (1.0_r8-carbon_store_buffer))
-
-                     if(prt_params%woody(ipft).ne.itrue)then
-
-                        totalmemory=currentCohort%leafmemory+currentCohort%sapwmemory+currentCohort%structmemory
-                        store_c_transfer_frac = min(EDPftvarcon_inst%phenflush_fraction(ipft)*totalmemory/store_c, &
-                             (1.0_r8-carbon_store_buffer))
-
-                      endif
+                      
+                      store_c_transfer_frac = &
+                           min((EDPftvarcon_inst%phenflush_fraction(ipft)*deficit_c)/store_c, &
+                           (1.0_r8-carbon_store_buffer))
 
                    else
                       store_c_transfer_frac = 0.0_r8
@@ -1251,32 +1237,26 @@ contains
                       call PRTPhenologyFlush(currentCohort%prt, ipft, &
                            leaf_organ, store_c_transfer_frac)
 
-                      currentCohort%leafmemory = 0.0_r8
-
                    else
 
                       ! Check that the stem drop fraction is set to non-zero amount otherwise flush all carbon store to leaves
                       if (stem_drop_fraction .gt. 0.0_r8) then
 
                          call PRTPhenologyFlush(currentCohort%prt, ipft, leaf_organ, &
-                              store_c_transfer_frac*currentCohort%leafmemory/totalmemory)
+                              store_c_transfer_frac*target_leaf_c/deficit_c)
 
                          call PRTPhenologyFlush(currentCohort%prt, ipft, sapw_organ, &
-                              store_c_transfer_frac*currentCohort%sapwmemory/totalmemory)
+                              store_c_transfer_frac*(target_sapw_c-sapw_c)/deficit_c)
 
                          call PRTPhenologyFlush(currentCohort%prt, ipft, struct_organ, &
-                              store_c_transfer_frac*currentCohort%structmemory/totalmemory)
-
+                              store_c_transfer_frac*(target_struct_c-struct_c)/deficit_c)
+                         
                       else
 
                          call PRTPhenologyFlush(currentCohort%prt, ipft, leaf_organ, &
                               store_c_transfer_frac)
 
                       end if
-
-                      currentCohort%leafmemory = 0.0_r8
-                      currentCohort%structmemory = 0.0_r8
-                      currentCohort%sapwmemory = 0.0_r8
 
                    endif ! woody plant check
                 endif !currentCohort status again?
@@ -1291,16 +1271,10 @@ contains
                    ! This sets the cohort to the "leaves off" flag
                    currentCohort%status_coh      = leaves_off
 
-                   ! Remember what the leaf mass was for next year
-                   currentCohort%leafmemory   = leaf_c
-
                    call PRTDeciduousTurnover(currentCohort%prt,ipft, &
                         leaf_organ, leaf_drop_fraction)
 
                    if(prt_params%woody(ipft).ne.itrue)then
-
-                      currentCohort%sapwmemory   = sapw_c * stem_drop_fraction
-                      currentCohort%structmemory   = struct_c * stem_drop_fraction
 
                       call PRTDeciduousTurnover(currentCohort%prt,ipft, &
                            sapw_organ, stem_drop_fraction)
@@ -1881,22 +1855,15 @@ contains
 
           ! Default assumption is that leaves are on
           cohortstatus = leaves_on
-          temp_cohort%leafmemory = 0.0_r8
-          temp_cohort%sapwmemory = 0.0_r8
-          temp_cohort%structmemory = 0.0_r8
-
 
           ! But if the plant is seasonally (cold) deciduous, and the site status is flagged
           ! as "cold", then set the cohort's status to leaves_off, and remember the leaf biomass
           if ((prt_params%season_decid(ft) == itrue) .and. &
                (any(currentSite%cstatus == [phen_cstat_nevercold,phen_cstat_iscold]))) then
-             temp_cohort%leafmemory = c_leaf
              c_leaf = 0.0_r8
 
              ! If plant is not woody then set sapwood and structural biomass as well
              if (prt_params%woody(ft).ne.itrue) then
-                temp_cohort%sapwmemory = c_sapw * stem_drop_fraction
-                temp_cohort%structmemory = c_struct * stem_drop_fraction
                 c_sapw = (1.0_r8 - stem_drop_fraction) * c_sapw
                 c_struct = (1.0_r8 - stem_drop_fraction) * c_struct
              endif
@@ -1908,13 +1875,10 @@ contains
           ! biomass
           if ((prt_params%stress_decid(ft) == itrue) .and. &
                (any(currentSite%dstatus == [phen_dstat_timeoff,phen_dstat_moistoff]))) then
-             temp_cohort%leafmemory = c_leaf
              c_leaf = 0.0_r8
 
              ! If plant is not woody then set sapwood and structural biomass as well
              if(prt_params%woody(ft).ne.itrue)then
-                temp_cohort%sapwmemory = c_sapw * stem_drop_fraction
-                temp_cohort%structmemory = c_struct * stem_drop_fraction
                 c_sapw = (1.0_r8 - stem_drop_fraction) * c_sapw
                 c_struct = (1.0_r8 - stem_drop_fraction) * c_struct
              endif
@@ -1988,7 +1952,7 @@ contains
           endif
 
           ! Only bother allocating a new cohort if there is a reasonable amount of it
-       any_recruits: if (temp_cohort%n > min_n_safemath )then
+          any_recruits: if (temp_cohort%n > min_n_safemath )then
 
              ! -----------------------------------------------------------------------------
              ! PART II.
@@ -2091,10 +2055,10 @@ contains
              ! -----------------------------------------------------------------------------------
 
              call prt%CheckInitialConditions()
+
              ! This initializes the cohort
              call create_cohort(currentSite,currentPatch, temp_cohort%pft, temp_cohort%n, &
                   temp_cohort%hite, temp_cohort%coage, temp_cohort%dbh, prt, &
-                  temp_cohort%leafmemory, temp_cohort%sapwmemory, temp_cohort%structmemory, &
                   cohortstatus, recruitstatus, &
                   temp_cohort%canopy_trim,temp_cohort%c_area, &
                   currentPatch%NCL_p, currentSite%spread, bc_in)

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -1108,10 +1108,12 @@ contains
                    call bbgw_allom(currentCohort%dbh,currentCohort%pft,target_bgw_c)
                    call bdead_allom( target_agw_c, target_bgw_c, target_sapw_c, currentCohort%pft, target_struct_c)
 
-                   if(prt_params%woody(ipft) == itrue)then
-                      deficit_c = target_leaf_c
-                   else
+                   if (stem_drop_fraction .gt. 0.0_r8) then
+                      ! Note, this is only true for some grasses, woody plants don't
+                      ! have a stem drop fraction
                       deficit_c = target_leaf_c + (target_sapw_c-sapw_c) + (target_struct_c-struct_c)
+                   else
+                      deficit_c = target_leaf_c
                    end if
                    
                    if(store_c>nearzero) then
@@ -1128,33 +1130,27 @@ contains
 
                    ! This call will request that storage carbon will be transferred to
                    ! leaf tissues. It is specified as a fraction of the available storage
-                   if(prt_params%woody(ipft) == itrue) then
-
-                      call PRTPhenologyFlush(currentCohort%prt, ipft, leaf_organ, store_c_transfer_frac)
-
+                   ! Check that the stem drop fraction is set to non-zero amount
+                   ! otherwise flush all carbon store to leaves
+                   if (stem_drop_fraction .gt. 0.0_r8) then
+                      
+                      call PRTPhenologyFlush(currentCohort%prt, ipft, leaf_organ, &
+                           store_c_transfer_frac*target_leaf_c/deficit_c)
+                      
+                      call PRTPhenologyFlush(currentCohort%prt, ipft, sapw_organ, &
+                           store_c_transfer_frac*(target_sapw_c-sapw_c)/deficit_c)
+                      
+                      call PRTPhenologyFlush(currentCohort%prt, ipft, struct_organ, &
+                           store_c_transfer_frac*(target_struct_c-struct_c)/deficit_c)
+                      
                    else
+                      
+                      call PRTPhenologyFlush(currentCohort%prt, ipft, leaf_organ, &
+                           store_c_transfer_frac)
+                      
+                   end if
 
-                      ! Check that the stem drop fraction is set to non-zero amount
-                      ! otherwise flush all carbon store to leaves
-                      if (stem_drop_fraction .gt. 0.0_r8) then
-
-                         call PRTPhenologyFlush(currentCohort%prt, ipft, leaf_organ, &
-                              store_c_transfer_frac*target_leaf_c/deficit_c)
-
-                         call PRTPhenologyFlush(currentCohort%prt, ipft, sapw_organ, &
-                              store_c_transfer_frac*(target_sapw_c-sapw_c)/deficit_c)
-
-                         call PRTPhenologyFlush(currentCohort%prt, ipft, struct_organ, &
-                              store_c_transfer_frac*(target_struct_c-struct_c)/deficit_c)
-
-                      else
-
-                         call PRTPhenologyFlush(currentCohort%prt, ipft, leaf_organ, &
-                              store_c_transfer_frac)
-
-                      end if
-
-                   endif
+                endif
                 endif !pft phenology
              endif ! growing season
 
@@ -1214,10 +1210,12 @@ contains
                    call bbgw_allom(currentCohort%dbh,currentCohort%pft,target_bgw_c)
                    call bdead_allom( target_agw_c, target_bgw_c, target_sapw_c, currentCohort%pft, target_struct_c)
 
-                   if(prt_params%woody(ipft) == itrue)then
-                      deficit_c = target_leaf_c
-                   else
+                   if (stem_drop_fraction .gt. 0.0_r8) then
+                      ! Note, this is only true for some grasses, woody plants don't
+                      ! have a stem drop fraction
                       deficit_c = target_leaf_c + (target_sapw_c-sapw_c) + (target_struct_c-struct_c)
+                   else
+                      deficit_c = target_leaf_c
                    end if
                    
                    if(store_c>nearzero) then
@@ -1232,31 +1230,23 @@ contains
 
                    ! This call will request that storage carbon will be transferred to
                    ! leaf tissues. It is specified as a fraction of the available storage
-                   if(prt_params%woody(ipft) == itrue) then
-
-                      call PRTPhenologyFlush(currentCohort%prt, ipft, &
-                           leaf_organ, store_c_transfer_frac)
-
+                   if (stem_drop_fraction .gt. 0.0_r8) then
+                      
+                      call PRTPhenologyFlush(currentCohort%prt, ipft, leaf_organ, &
+                           store_c_transfer_frac*target_leaf_c/deficit_c)
+                      
+                      call PRTPhenologyFlush(currentCohort%prt, ipft, sapw_organ, &
+                           store_c_transfer_frac*(target_sapw_c-sapw_c)/deficit_c)
+                      
+                      call PRTPhenologyFlush(currentCohort%prt, ipft, struct_organ, &
+                           store_c_transfer_frac*(target_struct_c-struct_c)/deficit_c)
+                      
                    else
-
-                      ! Check that the stem drop fraction is set to non-zero amount otherwise flush all carbon store to leaves
-                      if (stem_drop_fraction .gt. 0.0_r8) then
-
-                         call PRTPhenologyFlush(currentCohort%prt, ipft, leaf_organ, &
-                              store_c_transfer_frac*target_leaf_c/deficit_c)
-
-                         call PRTPhenologyFlush(currentCohort%prt, ipft, sapw_organ, &
-                              store_c_transfer_frac*(target_sapw_c-sapw_c)/deficit_c)
-
-                         call PRTPhenologyFlush(currentCohort%prt, ipft, struct_organ, &
-                              store_c_transfer_frac*(target_struct_c-struct_c)/deficit_c)
-                         
-                      else
-
-                         call PRTPhenologyFlush(currentCohort%prt, ipft, leaf_organ, &
-                              store_c_transfer_frac)
-
-                      end if
+                      
+                      call PRTPhenologyFlush(currentCohort%prt, ipft, leaf_organ, &
+                           store_c_transfer_frac)
+                      
+                   end if
 
                    endif ! woody plant check
                 endif !currentCohort status again?

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -1066,7 +1066,7 @@ contains
     real(r8) :: deficit_c              ! Amount of C needed to get flushing pools "on-allometry"
     real(r8) :: target_leaf_c
     real(r8) :: target_sapw_c
-    real(r8) :: target_bgw_c, target_agw_c, target_struct_c
+    real(r8) :: target_agw_c, target_bgw_c, target_agw_c, target_struct_c
     real(r8) :: sapw_area
     integer  :: ipft
     real(r8), parameter :: leaf_drop_fraction = 1.0_r8
@@ -1104,9 +1104,12 @@ contains
                    ! stop flow of carbon out of bstore.
 
                    call bleaf(currentCohort%dbh,currentCohort%pft,currentCohort%canopy_trim,target_leaf_c)
-                   call bsap_allom(currentCohort%dbh,currentCohort%pft,currentCohort%canopy_trim,sapw_area,target_sapw_c)
+                   call bsap_allom(currentCohort%dbh,currentCohort%pft, &
+                        currentCohort%canopy_trim,sapw_area,target_sapw_c)
+                   call bagw_allom(currentCohort%dbh,currentCohort%pft,target_agw_c)
                    call bbgw_allom(currentCohort%dbh,currentCohort%pft,target_bgw_c)
-                   call bdead_allom( target_agw_c, target_bgw_c, target_sapw_c, currentCohort%pft, target_struct_c)
+                   call bdead_allom( target_agw_c, target_bgw_c, target_sapw_c, &
+                        currentCohort%pft, target_struct_c)
 
                    if (stem_drop_fraction .gt. 0.0_r8) then
                       ! Note, this is only true for some grasses, woody plants don't
@@ -1205,10 +1208,14 @@ contains
                    currentCohort%status_coh = leaves_on    ! Leaves are on, so change status to
                    ! stop flow of carbon out of bstore.
 
-                   call bleaf(currentCohort%dbh,currentCohort%pft,currentCohort%canopy_trim,target_leaf_c)
-                   call bsap_allom(currentCohort%dbh,currentCohort%pft,currentCohort%canopy_trim,sapw_area,target_sapw_c)
+                   call bleaf(currentCohort%dbh,currentCohort%pft,&
+                        currentCohort%canopy_trim,target_leaf_c)
+                   call bsap_allom(currentCohort%dbh,currentCohort%pft, &
+                        currentCohort%canopy_trim,sapw_area,target_sapw_c)
+                   call bagw_allom(currentCohort%dbh,currentCohort%pft,target_agw_c)
                    call bbgw_allom(currentCohort%dbh,currentCohort%pft,target_bgw_c)
-                   call bdead_allom( target_agw_c, target_bgw_c, target_sapw_c, currentCohort%pft, target_struct_c)
+                   call bdead_allom( target_agw_c, target_bgw_c, target_sapw_c, &
+                        currentCohort%pft, target_struct_c)
 
                    if (stem_drop_fraction .gt. 0.0_r8) then
                       ! Note, this is only true for some grasses, woody plants don't

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -794,9 +794,6 @@ contains
 
              call bstore_allom(temp_cohort%dbh, pft, temp_cohort%canopy_trim, c_store)
 
-             temp_cohort%leafmemory = 0._r8
-             temp_cohort%sapwmemory = 0._r8
-             temp_cohort%structmemory = 0._r8
              cstatus = leaves_on
 
              stem_drop_fraction = EDPftvarcon_inst%phen_stem_drop_fraction(temp_cohort%pft)
@@ -805,9 +802,6 @@ contains
 
                 if( prt_params%season_decid(pft) == itrue .and. &
                     any(site_in%cstatus == [phen_cstat_nevercold,phen_cstat_iscold])) then
-                   temp_cohort%leafmemory = c_leaf
-                   temp_cohort%sapwmemory = c_sapw * stem_drop_fraction
-                   temp_cohort%structmemory = c_struct * stem_drop_fraction
                    c_leaf = 0._r8
                    c_sapw = (1.0_r8-stem_drop_fraction) * c_sapw
                    c_struct  = (1.0_r8-stem_drop_fraction) * c_struct
@@ -816,9 +810,6 @@ contains
 
                 if ( prt_params%stress_decid(pft) == itrue .and. &
                      any(site_in%dstatus == [phen_dstat_timeoff,phen_dstat_moistoff])) then
-                   temp_cohort%leafmemory = c_leaf
-                   temp_cohort%sapwmemory = c_sapw * stem_drop_fraction
-                   temp_cohort%structmemory = c_struct * stem_drop_fraction
                    c_leaf = 0._r8
                    c_sapw = (1.0_r8-stem_drop_fraction) * c_sapw
                    c_struct  = (1.0_r8-stem_drop_fraction) * c_struct
@@ -900,8 +891,7 @@ contains
              call prt_obj%CheckInitialConditions()
 
              call create_cohort(site_in, patch_in, pft, temp_cohort%n, temp_cohort%hite, &
-                  temp_cohort%coage, temp_cohort%dbh, prt_obj, temp_cohort%leafmemory, &
-                  temp_cohort%sapwmemory, temp_cohort%structmemory, cstatus, rstatus,        &
+                  temp_cohort%coage, temp_cohort%dbh, prt_obj, cstatus, rstatus,        &
                   temp_cohort%canopy_trim, temp_cohort%c_area,1, site_in%spread, bc_in)
 
 

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -1690,6 +1690,15 @@ contains
            end if
         end if
 
+        if( (prt_params%woody(ipft) == itrue) .and. &
+            (EDPftvarcon_inst%phen_stem_drop_fraction(ipft) > nearzero ) ) then
+           write(fates_log(),*) ' Non-zero stem-drop fractions are not allowed for woody plants'
+           write(fates_log(),*) ' PFT#: ',ipft
+           write(fates_log(),*) ' part_params%woody:',prt_params%woody(ipft)
+           write(fates_log(),*) ' phen_stem_drop_fraction: ', EDPFtvarcon_inst%phen_stem_drop_fraction(ipft)
+           write(fates_log(),*) ' Aborting'
+           call endrun(msg=errMsg(sourcefile, __LINE__))
+        end if
 
         ! Check if freezing tolerance is within reasonable bounds
         ! ----------------------------------------------------------------------------------

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -218,9 +218,6 @@ module EDTypesMod
      real(r8) ::  canopy_layer_yesterday                 ! recent canopy status of cohort
                                                          ! (1 = canopy, 2 = understorey, etc.)  
                                                          ! real to be conservative during fusion
-
-     real(r8) ::  lai                                    ! leaf area index of cohort: m2 leaf area of entire cohort per m2 of canopy area of a patch
-     real(r8) ::  sai                                    ! stem area index of cohort: m2 leaf area of entire cohort per m2 of canopy area of a patch
      real(r8) ::  g_sb_laweight                          ! Total conductance (stomata+boundary layer) of the cohort, weighted by its leaf area [m/s]*[m2]
      real(r8) ::  canopy_trim                            ! What is the fraction of the maximum leaf biomass that we are targeting? :-
      real(r8) ::  leaf_cost                              ! How much does it cost to maintain leaves: kgC/m2/year-1

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -1041,9 +1041,6 @@ module EDTypesMod
      write(fates_log(),*) 'structural (dead) carbon  = ', ccohort%prt%GetState(struct_organ,all_carbon_elements) 
      write(fates_log(),*) 'storage carbon            = ', ccohort%prt%GetState(store_organ,all_carbon_elements) 
      write(fates_log(),*) 'reproductive carbon       = ', ccohort%prt%GetState(repro_organ,all_carbon_elements) 
-
-     write(fates_log(),*) 'co%lai                    = ', ccohort%lai                         
-     write(fates_log(),*) 'co%sai                    = ', ccohort%sai  
      write(fates_log(),*) 'co%g_sb_laweight          = ', ccohort%g_sb_laweight
      write(fates_log(),*) 'co%leaf_cost              = ', ccohort%leaf_cost
      write(fates_log(),*) 'co%canopy_layer           = ', ccohort%canopy_layer

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -214,9 +214,6 @@ module EDTypesMod
      real(r8) ::  coage                                  ! cohort age in years
      real(r8) ::  hite                                   ! height: meters
      integer  ::  indexnumber                            ! unique number for each cohort. (within clump?)
-     real(r8) ::  leafmemory                             ! target leaf biomass- set from previous year: kGC per indiv
-     real(r8) ::  sapwmemory                             ! target sapwood biomass- set from previous year: kGC per indiv
-     real(r8) ::  structmemory                           ! target structural biomass- set from previous year: kGC per indiv
      integer  ::  canopy_layer                           ! canopy status of cohort (1 = canopy, 2 = understorey, etc.)
      real(r8) ::  canopy_layer_yesterday                 ! recent canopy status of cohort
                                                          ! (1 = canopy, 2 = understorey, etc.)  
@@ -1037,9 +1034,6 @@ module EDTypesMod
      write(fates_log(),*) 'co%dbh                    = ', ccohort%dbh                                        
      write(fates_log(),*) 'co%hite                   = ', ccohort%hite
      write(fates_log(),*) 'co%coage                  = ', ccohort%coage
-     write(fates_log(),*) 'co%leafmemory             = ', ccohort%leafmemory
-     write(fates_log(),*) 'co%sapwmemory             = ', ccohort%sapwmemory
-     write(fates_log(),*) 'co%structmemory           = ', ccohort%structmemory
      
      write(fates_log(),*) 'leaf carbon               = ', ccohort%prt%GetState(leaf_organ,all_carbon_elements) 
      write(fates_log(),*) 'fineroot carbon           = ', ccohort%prt%GetState(fnrt_organ,all_carbon_elements) 

--- a/main/FatesInventoryInitMod.F90
+++ b/main/FatesInventoryInitMod.F90
@@ -1041,32 +1041,22 @@ contains
 
          call bstore_allom(temp_cohort%dbh, temp_cohort%pft, temp_cohort%canopy_trim, c_store)
 
-         temp_cohort%leafmemory = 0._r8
-         temp_cohort%sapwmemory = 0._r8
-         temp_cohort%structmemory = 0._r8
          cstatus = leaves_on
-
          stem_drop_fraction = EDPftvarcon_inst%phen_stem_drop_fraction(temp_cohort%pft)
 
          if( prt_params%season_decid(temp_cohort%pft) == itrue .and. &
               any(csite%cstatus == [phen_cstat_nevercold,phen_cstat_iscold])) then
-            temp_cohort%leafmemory = c_leaf
-            temp_cohort%sapwmemory = c_sapw * stem_drop_fraction
-            temp_cohort%structmemory = c_struct * stem_drop_fraction
             c_leaf  = 0._r8
-	         c_sapw = (1._r8 - stem_drop_fraction) * c_sapw
-	         c_struct  = (1._r8 - stem_drop_fraction) * c_struct
+            c_sapw = (1._r8 - stem_drop_fraction) * c_sapw
+            c_struct  = (1._r8 - stem_drop_fraction) * c_struct
             cstatus = leaves_off
          endif
 
          if ( prt_params%stress_decid(temp_cohort%pft) == itrue .and. &
               any(csite%dstatus == [phen_dstat_timeoff,phen_dstat_moistoff])) then
-            temp_cohort%leafmemory = c_leaf
-            temp_cohort%sapwmemory = c_sapw * stem_drop_fraction
-            temp_cohort%structmemory = c_struct * stem_drop_fraction
             c_leaf  = 0._r8
-	         c_sapw = (1._r8 - stem_drop_fraction) * c_sapw
-	         c_struct  = (1._r8 - stem_drop_fraction) * c_struct
+            c_sapw = (1._r8 - stem_drop_fraction) * c_sapw
+            c_struct  = (1._r8 - stem_drop_fraction) * c_struct
             cstatus = leaves_off
          endif
 
@@ -1161,8 +1151,7 @@ contains
 
          call create_cohort(csite, cpatch, temp_cohort%pft, temp_cohort%n, temp_cohort%hite, &
               temp_cohort%coage, temp_cohort%dbh, &
-              prt_obj, temp_cohort%leafmemory,temp_cohort%sapwmemory, temp_cohort%structmemory, &
-              cstatus, rstatus, temp_cohort%canopy_trim,temp_cohort%c_area, &
+              prt_obj, cstatus, rstatus, temp_cohort%canopy_trim,temp_cohort%c_area, &
               1, csite%spread, bc_in)
 
          deallocate(temp_cohort) ! get rid of temporary cohort

--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -100,9 +100,6 @@ module FatesRestartInterfaceMod
   integer :: ir_coage_co
   integer :: ir_g_sb_laweight_co
   integer :: ir_height_co
-  integer :: ir_leafmemory_co
-  integer :: ir_sapwmemory_co
-  integer :: ir_structmemory_co
   integer :: ir_nplant_co
   integer :: ir_gpp_acc_co
   integer :: ir_npp_acc_co
@@ -713,21 +710,6 @@ contains
     call this%set_restart_var(vname='fates_height', vtype=cohort_r8, &
          long_name='ed cohort - plant height', units='m', flushval = flushzero, &
          hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_height_co )
-
-    call this%set_restart_var(vname='fates_leafmemory', vtype=cohort_r8, &
-         long_name='ed cohort - target leaf biomass set from prev year', &
-         units='kgC/indiv', flushval = flushzero, &
-         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_leafmemory_co )
-
-    call this%set_restart_var(vname='fates_sapwmemory', vtype=cohort_r8, &
-         long_name='ed cohort - target sapwood biomass set from prev year', &
-         units='kgC/indiv', flushval = flushzero, &
-         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_sapwmemory_co )
-
-    call this%set_restart_var(vname='fates_structmemory', vtype=cohort_r8, &
-         long_name='ed cohort - target structural biomass set from prev year', &
-         units='kgC/indiv', flushval = flushzero, &
-         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_structmemory_co )
 
     call this%set_restart_var(vname='fates_nplant', vtype=cohort_r8, &
          long_name='ed cohort - number of plants in the cohort', &
@@ -1773,9 +1755,6 @@ contains
            rio_coage_co                => this%rvars(ir_coage_co)%r81d, &
            rio_g_sb_laweight_co        => this%rvars(ir_g_sb_laweight_co)%r81d, &
            rio_height_co               => this%rvars(ir_height_co)%r81d, &
-           rio_leafmemory_co           => this%rvars(ir_leafmemory_co)%r81d, &
-           rio_sapwmemory_co           => this%rvars(ir_sapwmemory_co)%r81d, &
-           rio_structmemory_co         => this%rvars(ir_structmemory_co)%r81d, &
            rio_nplant_co               => this%rvars(ir_nplant_co)%r81d, &
            rio_gpp_acc_co              => this%rvars(ir_gpp_acc_co)%r81d, &
            rio_npp_acc_co              => this%rvars(ir_npp_acc_co)%r81d, &
@@ -2002,11 +1981,7 @@ contains
                 rio_dbh_co(io_idx_co)          = ccohort%dbh
                 rio_coage_co(io_idx_co)        = ccohort%coage
                 rio_height_co(io_idx_co)       = ccohort%hite
-                rio_leafmemory_co(io_idx_co)   = ccohort%leafmemory
-                rio_sapwmemory_co(io_idx_co)   = ccohort%sapwmemory
-                rio_structmemory_co(io_idx_co) = ccohort%structmemory
                 rio_g_sb_laweight_co(io_idx_co)= ccohort%g_sb_laweight
-
                 rio_nplant_co(io_idx_co)       = ccohort%n
                 rio_gpp_acc_co(io_idx_co)      = ccohort%gpp_acc
                 rio_npp_acc_co(io_idx_co)      = ccohort%npp_acc
@@ -2612,9 +2587,6 @@ contains
           rio_coage_co                => this%rvars(ir_coage_co)%r81d, &
           rio_g_sb_laweight_co        => this%rvars(ir_g_sb_laweight_co)%r81d, &
           rio_height_co               => this%rvars(ir_height_co)%r81d, &
-          rio_leafmemory_co           => this%rvars(ir_leafmemory_co)%r81d, &
-          rio_sapwmemory_co           => this%rvars(ir_sapwmemory_co)%r81d, &
-          rio_structmemory_co         => this%rvars(ir_structmemory_co)%r81d, &
           rio_nplant_co               => this%rvars(ir_nplant_co)%r81d, &
           rio_gpp_acc_co              => this%rvars(ir_gpp_acc_co)%r81d, &
           rio_npp_acc_co              => this%rvars(ir_npp_acc_co)%r81d, &
@@ -2814,9 +2786,6 @@ contains
                 ccohort%coage        = rio_coage_co(io_idx_co)
                 ccohort%g_sb_laweight= rio_g_sb_laweight_co(io_idx_co)
                 ccohort%hite         = rio_height_co(io_idx_co)
-                ccohort%leafmemory   = rio_leafmemory_co(io_idx_co)
-                ccohort%sapwmemory   = rio_sapwmemory_co(io_idx_co)
-                ccohort%structmemory = rio_structmemory_co(io_idx_co)
                 ccohort%n            = rio_nplant_co(io_idx_co)
                 ccohort%gpp_acc      = rio_gpp_acc_co(io_idx_co)
                 ccohort%npp_acc      = rio_npp_acc_co(io_idx_co)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

The memory (laimemory, sapwmemory and structmemory) and lai terms are unecessary.  We don't need the memory terms because we can use the allometry functions to calculate targets.  We don't need the cohort level lai and sai variables because we can derive them from treelai, treesai, crown area and canopy area.  

Fixes #541 

I also removed the smooth leaf distribution code from the canopy vertical profile routine because that is old and unmaintained and is triggering lots of compiler warnings.


<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->


### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

I expect small but subtle differences in results due to the laimemory stuff.  The flushing target was previously laimemory, which was the target when the leaves dropped.  Now the target is just re-caclulated when the leaves are ready to flush.  Its possible that a trimming event would had happened in between, or perhaps due to canopy promotion/demotion/fusion there was a small change in dbh to maintain mass conservation, which would also trigger a difference in the target.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

