### PR TITLE
Grass PFT only creates leaves not cwd

### DIFF
--- a/biogeochem/CMIP data.txt
+++ b/biogeochem/CMIP data.txt
@@ -1,0 +1,24 @@
+. 	
+CMIP6.CMIP.NCAR.CESM2.historical.r11i1p1f1.day.rlds.gn'
+
+
+
+CF Standard Name | Unit | AMIP
+
+---------------- | ---- | ----
+
+specific_humidity | 1 | hus
+
+precipitation_flux | kg m-2 s-1 | pr
+
+surface_air_pressure | Pa | ps 
+
+surface_downwelling_longwave_flux_in_air | W/m2 | rlds
+
+surface_downwelling_shortwave_flux_in_air | W/m2 | rsds
+
+air_temperature | K | ta
+
+eastward_wind | ms-1 | ua
+
+northward_wind | ms-1 | va

--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -978,12 +978,11 @@ contains
                 leaf_m   = ccohort%prt%GetState(leaf_organ, element_list(el))+ &
                         ccohort%prt%GetState(store_organ, element_list(el))+ &
                         ccohort%prt%GetState(sapw_organ, element_list(el))+ &
-                        ccohort%prt%GetState(fnrt_organ, element_list(el))+ &
                         ccohort%prt%GetState(struct_organ, element_list(el))+ &
                         ccohort%prt%GetState(repro_organ, element_list(el))
                 store_m  = 0_r8
                 sapw_m   = 0_r8
-                fnrt_m   = 0_r8
+                fnrt_m   = ccohort%prt%GetState(fnrt_organ, element_list(el))
                 struct_m = 0_r8
                 repro_m  = 0_r8
         end if

--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -967,12 +967,26 @@ contains
 
     do el=1,num_elements
 
-       leaf_m   = ccohort%prt%GetState(leaf_organ, element_list(el))
-       store_m  = ccohort%prt%GetState(store_organ, element_list(el))
-       sapw_m   = ccohort%prt%GetState(sapw_organ, element_list(el))
-       fnrt_m   = ccohort%prt%GetState(fnrt_organ, element_list(el))
-       struct_m = ccohort%prt%GetState(struct_organ, element_list(el))
-       repro_m  = ccohort%prt%GetState(repro_organ, element_list(el))
+       if ( prt_params%woody(pft) == itrue) then !trees only
+                leaf_m   = ccohort%prt%GetState(leaf_organ, element_list(el))
+                store_m  = ccohort%prt%GetState(store_organ, element_list(el))
+                sapw_m   = ccohort%prt%GetState(sapw_organ, element_list(el))
+                fnrt_m   = ccohort%prt%GetState(fnrt_organ, element_list(el))
+                struct_m = ccohort%prt%GetState(struct_organ, element_list(el))
+                repro_m  = ccohort%prt%GetState(repro_organ, element_list(el))
+        else
+                leaf_m   = ccohort%prt%GetState(leaf_organ, element_list(el))+ &
+                        ccohort%prt%GetState(store_organ, element_list(el))+ &
+                        ccohort%prt%GetState(sapw_organ, element_list(el))+ &
+                        ccohort%prt%GetState(fnrt_organ, element_list(el))+ &
+                        ccohort%prt%GetState(struct_organ, element_list(el))+ &
+                        ccohort%prt%GetState(repro_organ, element_list(el))
+                store_m  = 0_r8
+                sapw_m   = 0_r8
+                fnrt_m   = 0_r8
+                struct_m = 0_r8
+                repro_m  = 0_r8
+        end if
 
        litt => cpatch%litter(el)
        flux_diags => csite%flux_diags(el)

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -1864,6 +1864,7 @@ contains
              sapw_m          = currentCohort%prt%GetState(sapw_organ,element_id)
              struct_m        = currentCohort%prt%GetState(struct_organ,element_id)
           else
+             ! for non-woody plants all stem fluxes go into the same leaf litter pool
              leaf_m          = currentCohort%prt%GetState(leaf_organ,element_id) + &
                      currentCohort%prt%GetState(sapw_organ,element_id) + &
                      currentCohort%prt%GetState(struct_organ,element_id)

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -1661,8 +1661,7 @@ contains
              repro_m  = currentCohort%prt%GetState(repro_organ, element_id)
           
              if (prt_params%woody(currentCohort%pft) == itrue) then
-                ! Assumption: for woody plants, we lump fluxes from deadwood and sapwood together in CWD pool.
-                ! for non-woody plants, we put all stem fluxes into the same leaf litter pool.
+                ! Assumption: for woody plants fluxes from deadwood and sapwood go together in CWD pool
                 leaf_m          = currentCohort%prt%GetState(leaf_organ,element_id)
                 sapw_m          = currentCohort%prt%GetState(sapw_organ,element_id)
                 struct_m        = currentCohort%prt%GetState(struct_organ,element_id)

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -859,7 +859,7 @@ contains
                             do el = 1,num_elements
 
                                leaf_m = nc%prt%GetState(leaf_organ, element_list(el))
-                               ! for grasses burn all aboveground tissues, for woody plants burn only leaves
+                               ! for woody plants burn only leaves
                                if(int(prt_params%woody(currentCohort%pft)) == itrue)then
 
                                   leaf_m = nc%prt%GetState(leaf_organ, element_list(el))

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -865,7 +865,7 @@ contains
                                   leaf_m = nc%prt%GetState(leaf_organ, element_list(el))
 
                                else
-
+                               ! for grasses burn all aboveground tissues
                                   leaf_m = nc%prt%GetState(leaf_organ, element_list(el)) + &
                                        nc%prt%GetState(sapw_organ, element_list(el)) + &
                                        nc%prt%GetState(struct_organ, element_list(el))

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -1859,8 +1859,7 @@ contains
           repro_m  = currentCohort%prt%GetState(repro_organ, element_id)
 
           if (prt_params%woody(currentCohort%pft) == itrue) then
-             ! Assumption: for woody plants, we lump fluxes from deadwood and sapwood together in CWD pool.
-             ! for non-woody plants, we put all stem fluxes into the same leaf litter pool.
+             ! Assumption: for woody plants fluxes from deadwood and sapwood go together in CWD pool
              leaf_m          = currentCohort%prt%GetState(leaf_organ,element_id)
              sapw_m          = currentCohort%prt%GetState(sapw_organ,element_id)
              struct_m        = currentCohort%prt%GetState(struct_organ,element_id)

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -1666,6 +1666,7 @@ contains
                 sapw_m          = currentCohort%prt%GetState(sapw_organ,element_id)
                 struct_m        = currentCohort%prt%GetState(struct_organ,element_id)
              else
+                ! for non-woody plants all stem fluxes go into the same leaf litter pool
                 leaf_m          = currentCohort%prt%GetState(leaf_organ,element_id) + &
                      currentCohort%prt%GetState(sapw_organ,element_id) + &
                      currentCohort%prt%GetState(struct_organ,element_id)

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -2214,6 +2214,7 @@ contains
           sapw_m          = currentCohort%prt%GetState(sapw_organ,element_id)
           struct_m        = currentCohort%prt%GetState(struct_organ,element_id)
        else
+          ! for non-woody plants all stem fluxes go into the same leaf litter pool
           leaf_m_turnover   = currentCohort%prt%GetTurnover(leaf_organ,element_id) + &
                currentCohort%prt%GetTurnover(sapw_organ,element_id) + &
                currentCohort%prt%GetTurnover(struct_organ,element_id)

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -2193,24 +2193,46 @@ contains
     currentCohort => currentPatch%shortest
     do while(associated(currentCohort))
        pft = currentCohort%pft
-
-      call set_root_fraction(currentSite%rootfrac_scr, pft, currentSite%zi_soil, &
+       call set_root_fraction(currentSite%rootfrac_scr, pft, currentSite%zi_soil, &
            bc_in%max_rooting_depth_index_col)
 
-       leaf_m_turnover   = currentCohort%prt%GetTurnover(leaf_organ,element_id)
-       store_m_turnover  = currentCohort%prt%GetTurnover(store_organ,element_id)
-       fnrt_m_turnover   = currentCohort%prt%GetTurnover(fnrt_organ,element_id)
-       sapw_m_turnover   = currentCohort%prt%GetTurnover(sapw_organ,element_id)
-       struct_m_turnover = currentCohort%prt%GetTurnover(struct_organ,element_id)
-       repro_m_turnover  = currentCohort%prt%GetTurnover(repro_organ,element_id)
-
-       leaf_m          = currentCohort%prt%GetState(leaf_organ,element_id)
-       store_m         = currentCohort%prt%GetState(store_organ,element_id)
-       fnrt_m          = currentCohort%prt%GetState(fnrt_organ,element_id)
-       sapw_m          = currentCohort%prt%GetState(sapw_organ,element_id)
-       struct_m        = currentCohort%prt%GetState(struct_organ,element_id)
-       repro_m         = currentCohort%prt%GetState(repro_organ,element_id)
-
+       if ( prt_params%woody(pft) == itrue) then !trees only
+          leaf_m_turnover   = currentCohort%prt%GetTurnover(leaf_organ, element_id)
+          store_m_turnover  = currentCohort%prt%GetTurnover(store_organ,element_id)
+          sapw_m_turnover   = currentCohort%prt%GetTurnover(sapw_organ, element_id)
+          fnrt_m_turnover   = currentCohort%prt%GetTurnover(fnrt_organ, element_id)
+          struct_m_turnover = currentCohort%prt%GetTurnover(struct_organ, element_id)
+          repro_m_turnover  = currentCohort%prt%GetTurnover(repro_organ, element_id)
+          leaf_m   = currentCohort%prt%GetState(leaf_organ, element_id)
+          store_m  = currentCohort%prt%GetState(store_organ, element_id)
+          sapw_m   = currentCohort%prt%GetState(sapw_organ, element_id)
+          fnrt_m   = currentCohort%prt%GetState(fnrt_organ, element_id)
+          struct_m = currentCohort%prt%GetState(struct_organ, element_id)
+          repro_m  = currentCohort%prt%GetState(repro_organ, element_id)
+       else ! grass PFTs should not spawn anything other than leaves. 
+          leaf_m_turnover   = currentCohort%prt%GetTurnover(leaf_organ, element_id)+ &
+                        currentCohort%prt%GetTurnover(store_organ, element_id)+ &
+                        currentCohort%prt%GetTurnover(sapw_organ, element_id)+ &
+                        currentCohort%prt%GetTurnover(fnrt_organ, element_id)+ &
+                        currentCohort%prt%GetTurnover(struct_organ, element_id)+ &
+                        currentCohort%prt%GetTurnover(repro_organ, element_id)
+          store_m_turnover  = 0_r8
+          sapw_m_turnover   = 0_r8
+          fnrt_m_turnover   = 0_r8
+          struct_m_turnover = 0_r8
+          repro_m_turnover  = 0_r8
+          leaf_m   = currentCohort%prt%GetState(leaf_organ, element_id)+ &
+                        currentCohort%prt%GetState(store_organ, element_id)+ &
+                        currentCohort%prt%GetState(sapw_organ, element_id)+ &
+                        currentCohort%prt%GetState(fnrt_organ, element_id)+ &
+                        currentCohort%prt%GetState(struct_organ, element_id)+ &
+                        currentCohort%prt%GetState(repro_organ, element_id)
+          store_m  = 0_r8
+          sapw_m   = 0_r8
+          fnrt_m   = 0_r8
+          struct_m = 0_r8
+          repro_m  = 0_r8
+       end if
        plant_dens =  currentCohort%n/currentPatch%area
 
        ! ---------------------------------------------------------------------------------

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -2213,23 +2213,22 @@ contains
           leaf_m_turnover   = currentCohort%prt%GetTurnover(leaf_organ, element_id)+ &
                         currentCohort%prt%GetTurnover(store_organ, element_id)+ &
                         currentCohort%prt%GetTurnover(sapw_organ, element_id)+ &
-                        currentCohort%prt%GetTurnover(fnrt_organ, element_id)+ &
+                        
                         currentCohort%prt%GetTurnover(struct_organ, element_id)+ &
                         currentCohort%prt%GetTurnover(repro_organ, element_id)
           store_m_turnover  = 0_r8
           sapw_m_turnover   = 0_r8
-          fnrt_m_turnover   = 0_r8
+          fnrt_m_turnover   = currentCohort%prt%GetTurnover(fnrt_organ, element_id)
           struct_m_turnover = 0_r8
           repro_m_turnover  = 0_r8
           leaf_m   = currentCohort%prt%GetState(leaf_organ, element_id)+ &
                         currentCohort%prt%GetState(store_organ, element_id)+ &
                         currentCohort%prt%GetState(sapw_organ, element_id)+ &
-                        currentCohort%prt%GetState(fnrt_organ, element_id)+ &
                         currentCohort%prt%GetState(struct_organ, element_id)+ &
                         currentCohort%prt%GetState(repro_organ, element_id)
           store_m  = 0_r8
           sapw_m   = 0_r8
-          fnrt_m   = 0_r8
+          fnrt_m   = currentCohort%prt%GetState(fnrt_organ, element_id)
           struct_m = 0_r8
           repro_m  = 0_r8
        end if

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -2205,8 +2205,7 @@ contains
        repro_m         = currentCohort%prt%GetState(repro_organ,element_id)
 
        if (prt_params%woody(currentCohort%pft) == itrue) then
-          ! Assumption: for woody plants, we lump fluxes from deadwood and sapwood together in CWD pool.
-          ! for non-woody plants, we put all stem fluxes into the same leaf litter pool.
+          ! Assumption: for woody plants fluxes from deadwood and sapwood go together in CWD pool
           leaf_m_turnover   = currentCohort%prt%GetTurnover(leaf_organ,element_id)
           sapw_m_turnover   = currentCohort%prt%GetTurnover(sapw_organ,element_id)
           struct_m_turnover = currentCohort%prt%GetTurnover(struct_organ,element_id)

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -764,7 +764,7 @@ contains
                  lb = (1.0_r8 + (8.729_r8 * &
                       ((1.0_r8 -(exp(-0.03_r8 * m_per_min__to__km_per_hour * currentPatch%effect_wspeed)))**2.155_r8)))
              else ! EQ 80 grass fuels (CFFBPS Ont.Inf.Rep. ST-X-3, 1992, but with a correction from an errata published within 
-                  ! Information Report GLC-X-10 by Bottom et al., 2009 because there is a typo in CFFBPS Ont.Inf.Rep. ST-X-3, 1992)
+                  ! Information Report GLC-X-10 by Wotten et al., 2009 because there is a typo in CFFBPS Ont.Inf.Rep. ST-X-3, 1992)
                  lb = (1.1_r8*((m_per_min__to__km_per_hour * currentPatch%effect_wspeed)**0.464_r8))
              endif
           endif

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -765,7 +765,7 @@ contains
                  lb = (1.0_r8 + (8.729_r8 * &
                       ((1.0_r8 -(exp(-0.03_r8 * m_per_min__to__km_per_hour * currentPatch%effect_wspeed)))**2.155_r8)))
              else ! EQ 80 grass fuels (CFFBPS Ont.Inf.Rep. ST-X-3, 1992, but with a correction from an errata published within 
-                  ! Information Report GLC-X-10 by Wotten et al., 2009 because there is a typo in CFFBPS Ont.Inf.Rep. ST-X-3, 1992)
+                  ! Information Report GLC-X-10 by Wotton et al., 2009 for a typo in CFFBPS Ont.Inf.Rep. ST-X-3, 1992)
                  lb = (1.1_r8*((m_per_min__to__km_per_hour * currentPatch%effect_wspeed)**0.464_r8))
              endif
           endif

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -192,7 +192,8 @@ contains
        currentPatch%livegrass = 0.0_r8 
        currentCohort => currentPatch%tallest
        do while(associated(currentCohort))
-          if( prt_params%woody(currentCohort%pft) == ifalse)then 
+           ! for grasses sum all aboveground tissues
+           if( prt_params%woody(currentCohort%pft) == ifalse)then 
              
              currentPatch%livegrass = currentPatch%livegrass + &
                   ( currentCohort%prt%GetState(leaf_organ, all_carbon_elements) + &


### PR DESCRIPTION
In response to issue #884

Modified EDCohortDynamicsMod.F90 (@ln970): if the pft is grass then all of its organs are treated as leaves for calculation of coarse woody debris(cwd).
EDPatchDynamicsMod.F90 (@ln 1641):  When patches spawn, only tree pft donate dead tress or cwd, and mass to the new patch, if pft is grass it assumed that grass was consumed in fire. This may not resolve fluxes to the atmosphere accurately.
EDPhysiologyMod.F90 (@ln 2199):  When other litter fluxes occur, if pft is grass, then it only turnsover  or contributes leaves not coarse woody debris.

<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

