### PR TITLE
Add two new ecosystem-level height metrics

### DIFF
--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -195,8 +195,8 @@ module FatesHistoryInterfaceMod
 
   integer :: ih_fates_fraction_si
 
-  integer :: ih_ba_weighted_height
-  integer :: ih_ca_weighted_height
+  integer :: ih_ba_weighted_height_si
+  integer :: ih_ca_weighted_height_si
 
   integer :: ih_cwd_elcwd
 
@@ -1810,8 +1810,8 @@ end subroutine flush_hvars
                hio_area_plant_si       => this%hvars(ih_area_plant_si)%r81d, &
                hio_area_trees_si  => this%hvars(ih_area_trees_si)%r81d, &
                hio_fates_fraction_si   => this%hvars(ih_fates_fraction_si)%r81d, &
-               hio_ba_weighted_height  => this%hvars(ih_ba_weighted_height)%r81d, &
-               hio_ca_weighted_height  => this%hvars(ih_ca_weighted_height)%r81d, &
+               hio_ba_weighted_height_si  => this%hvars(ih_ba_weighted_height_si)%r81d, &
+               hio_ca_weighted_height_si  => this%hvars(ih_ca_weighted_height_si)%r81d, &
                hio_canopy_spread_si    => this%hvars(ih_canopy_spread_si)%r81d, &
                hio_biomass_si_pft      => this%hvars(ih_biomass_si_pft)%r82d, &
                hio_leafbiomass_si_pft  => this%hvars(ih_leafbiomass_si_pft)%r82d, &
@@ -2551,7 +2551,7 @@ end subroutine flush_hvars
                   hio_ddbh_si_scpf(io_si,scpf) = hio_ddbh_si_scpf(io_si,scpf) + &
                      ccohort%ddbhdt*ccohort%n / m2_per_ha * m_per_cm
 
-                  hio_ba_weighted_height(io_si) = hio_ba_weighted_height(io_si) + &
+                  hio_ba_weighted_height_si(io_si) = hio_ba_weighted_height_si(io_si) + &
                        ccohort%hite * &
                        0.25_r8*pi_const*((dbh/100.0_r8)**2.0_r8)*ccohort%n / m2_per_ha
 
@@ -2763,7 +2763,7 @@ end subroutine flush_hvars
                   hio_yesterdaycanopylevel_canopy_si_scls(io_si,scls) + &
                   ccohort%canopy_layer_yesterday * ccohort%n / m2_per_ha
 
-                  hio_ca_weighted_height(io_si) = hio_ca_weighted_height(io_si) + &
+                  hio_ca_weighted_height_si(io_si) = hio_ca_weighted_height_si(io_si) + &
                        ccohort%hite * ccohort%c_area / m2_per_ha
                else canlayer
                   hio_nplant_understory_si_scag(io_si,iscag) = hio_nplant_understory_si_scag(io_si,iscag) + ccohort%n / m2_per_ha
@@ -2968,9 +2968,9 @@ end subroutine flush_hvars
 
       ! divide basal-area-weighted height by basal area to get mean
       if ( sum(hio_ba_si_scpf(io_si,:)) .gt. tiny ) then
-         hio_ba_weighted_height(io_si) = hio_ba_weighted_height(io_si) / sum(hio_ba_si_scpf(io_si,:))
+         hio_ba_weighted_height_si(io_si) = hio_ba_weighted_height_si(io_si) / sum(hio_ba_si_scpf(io_si,:))
       else
-         hio_ba_weighted_height(io_si) = 0._r8
+         hio_ba_weighted_height_si(io_si) = 0._r8
       endif
 
       ! divide so-far-just-summed but to-be-averaged patch-age-class variables by patch-age-class area to get mean values

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -1799,7 +1799,6 @@ end subroutine flush_hvars
     type(ed_patch_type),pointer  :: cpatch
     type(ed_cohort_type),pointer :: ccohort
 
-    real(r8), parameter :: tiny = 1.e-5_r8      ! some small number
     real(r8), parameter :: reallytalltrees = 1000.   ! some large number (m)
 
     integer :: tmp
@@ -2967,7 +2966,7 @@ end subroutine flush_hvars
       end do patchloop !patch loop
 
       ! divide basal-area-weighted height by basal area to get mean
-      if ( sum(hio_ba_si_scpf(io_si,:)) .gt. tiny ) then
+      if ( sum(hio_ba_si_scpf(io_si,:)) .gt. nearzero ) then
          hio_ba_weighted_height_si(io_si) = hio_ba_weighted_height_si(io_si) / sum(hio_ba_si_scpf(io_si,:))
       else
          hio_ba_weighted_height_si(io_si) = 0._r8
@@ -2975,7 +2974,7 @@ end subroutine flush_hvars
 
       ! divide so-far-just-summed but to-be-averaged patch-age-class variables by patch-age-class area to get mean values
       do ipa2 = 1, nlevage
-         if (hio_area_si_age(io_si, ipa2) .gt. tiny) then
+         if (hio_area_si_age(io_si, ipa2) .gt. nearzero) then
                hio_lai_si_age(io_si, ipa2) = hio_lai_si_age(io_si, ipa2) / (hio_area_si_age(io_si, ipa2)*AREA)
                hio_ncl_si_age(io_si, ipa2) = hio_ncl_si_age(io_si, ipa2) / (hio_area_si_age(io_si, ipa2)*AREA)
             do i_pft = 1, numpft
@@ -3562,7 +3561,6 @@ end subroutine flush_hvars
     real(r8) :: patch_area_by_age(nlevage)  ! patch area in each bin for normalizing purposes
     real(r8) :: canopy_area_by_age(nlevage) ! canopy area in each bin for normalizing purposes
     real(r8) :: site_area_veg               ! area of the site that is not bare-ground 
-    real(r8), parameter :: tiny = 1.e-5_r8      ! some small number
     integer  :: ipa2     ! patch incrementer
     integer :: cnlfpft_indx, cnlf_indx, ipft, ican, ileaf ! more iterators and indices
     type(ed_patch_type),pointer  :: cpatch
@@ -3938,7 +3936,7 @@ end subroutine flush_hvars
          end do !patch loop
 
          do ipa2 = 1, nlevage
-            if (patch_area_by_age(ipa2) .gt. tiny) then
+            if (patch_area_by_age(ipa2) .gt. nearzero) then
                hio_gpp_si_age(io_si, ipa2) = hio_gpp_si_age(io_si, ipa2) / (patch_area_by_age(ipa2))
                hio_npp_si_age(io_si, ipa2) = hio_npp_si_age(io_si, ipa2) / (patch_area_by_age(ipa2))
             else
@@ -3947,7 +3945,7 @@ end subroutine flush_hvars
             endif
 
             ! Normalize resistance diagnostics
-            if (canopy_area_by_age(ipa2) .gt. tiny) then
+            if (canopy_area_by_age(ipa2) .gt. nearzero) then
                hio_c_stomata_si_age(io_si,ipa2) = &
                     hio_c_stomata_si_age(io_si,ipa2) / canopy_area_by_age(ipa2)
 
@@ -3961,7 +3959,7 @@ end subroutine flush_hvars
          end do
 
          ! Normalize resistance diagnostics
-         if ( sum(canopy_area_by_age(1:nlevage)) .gt. tiny) then
+         if ( sum(canopy_area_by_age(1:nlevage)) .gt. nearzero) then
             hio_c_stomata_si(io_si) = hio_c_stomata_si(io_si) / sum(canopy_area_by_age(1:nlevage))
             hio_c_lblayer_si(io_si) = hio_c_lblayer_si(io_si) / sum(canopy_area_by_age(1:nlevage))
          else
@@ -4003,7 +4001,6 @@ end subroutine update_history_hifrq
     integer  :: ipa      ! The local "I"ndex of "PA"tches
     integer  :: ft               ! functional type index
 !    integer  :: io_shsl  ! The combined "SH"ell "S"oil "L"ayer index in the IO array
-    real(r8), parameter :: tiny = 1.e-5_r8      ! some small number
     real(r8) :: ncohort_scpf(nlevsclass*maxpft)  ! Bins to count up cohorts counts used in weighting
     ! should be "hio_nplant_si_scpf"
     real(r8) :: nplant_scpf(nlevsclass*maxpft)  ! Bins to count up cohorts counts used in weighting

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -4482,13 +4482,13 @@ end subroutine update_history_hifrq
          long='basal area-weighted mean height of woody plants', use_default='active', &
          avgflag='A', vtype=site_r8, hlms='CLM:ALM',                           &
          upfreq=1, ivar=ivar, initialize=initialize_variables,                 &
-         index=ih_ba_weighted_heght_si)
+         index=ih_ba_weighted_height_si)
 
     call this%set_history_var(vname='FATES_CA_WEIGHTED_HEIGHT', units='m',        &
          long='crown area-weighted mean height of canopy plants', use_default='active', &
          avgflag='A', vtype=site_r8, hlms='CLM:ALM',                           &
          upfreq=1, ivar=ivar, initialize=initialize_variables,                 &
-         index=ih_ca_weighted_heght_si)
+         index=ih_ca_weighted_height_si)
 
     call this%set_history_var(vname='FATES_COLD_STATUS', units='',             &
           long='site-level cold status, 0=not cold-dec, 1=too cold for leaves, 2=not too cold',  &


### PR DESCRIPTION
This PR adds two metrics for average canopy height.  The first is a crown-area-weighted canopy height for all plants in the canopy. This approach averages in zero height for the unoccupied areas when the canopy is not closed. This is roughly what would be returned as the mean height from lidar returns, and is also close to what FATES is currently doing for aerodynamic roughness height scaling.  The second new variable is a basal-area-weighted average height of all trees; this is equivalent to what is called "Lorey's height" in the forestry literature. This variable doesn't take into account canopy strata or canopy closure.

### Description:

### Collaborators:
email discussion thread with @mpaiao @jkshuman @JessicaNeedham @adamhb @pollybuotte @lmkueppers @XiulinGao

### Expectation of Answer Changes:
This also changes two numbers in adjacent lines of code that are very close to pi to just make them pi, so it will be answer changing for the existing basal area calculation as well as the 2 new variables.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

