### PR TITLE
Fix mean vegetation temperature output for exact restarts

### DIFF
--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -292,11 +292,9 @@ contains
     integer  :: dleafoff   ! DOY for drought-decid leaf-off, initial guess
     integer  :: dleafon    ! DOY for drought-decid leaf-on, initial guess
     integer  :: ft         ! PFT loop
-    real(r8) :: sumarea    ! area of PFTs in nocomp mode
+    real(r8) :: sumarea    ! area of PFTs in nocomp mode.
     integer  :: hlm_pft    ! used in fixed biogeog mode
     integer  :: fates_pft  ! used in fixed biogeog mode
-    
-    real(r8) :: small_patch_tol = 0.01_r8 ! Do not allocate pft area below this threshhold
     !----------------------------------------------------------------------
 
 
@@ -348,38 +346,25 @@ contains
 
              sites(s)%area_pft(1:numpft) = 0._r8
              do hlm_pft = 1,size( EDPftvarcon_inst%hlm_pft_map,2)
-                
-                ! loop round all fates pfts for all hlm pfts
-                do fates_pft = 1,numpft
-                
+                do fates_pft = 1,numpft ! loop round all fates pfts for all hlm pfts
                    sites(s)%area_pft(fates_pft) = sites(s)%area_pft(fates_pft) + &
                         EDPftvarcon_inst%hlm_pft_map(fates_pft,hlm_pft) * bc_in(s)%pft_areafrac(hlm_pft)
-                
-                   ! Check for negative pft area
-                   if(sites(s)%area_pft(fates_pft) .lt. 0._r8)then
-                      write(fates_log(),*) 'negative area',s,ft,sites(s)%area_pft(ft)
-                      call endrun(msg=errMsg(sourcefile, __LINE__))
-                   end if
-                   
-                   ! remove tiny patches to prevent numerical errors in terminate patches
-                   if(sites(s)%area_pft(fates_pft) .lt. small_patch_tol)then
-                     if(debug) write(fates_log(),*)  'removing small pft patches',s,fates_pft,sites(s)%area_pft(fates_pft)
-                     sites(s)%area_pft(fates_pft) = 0.0_r8
-                  endif
-                  
-                  ! rescale units to m2
-                  sites(s)%area_pft(fates_pft)= sites(s)%area_pft(fates_pft) * AREA 
-        
-                end do !fates_pft
+                end do
              end do !hlm_pft
 
-             ! Check that the sum of the areas is not greater than the notional area
-             sumarea = sum(sites(s)%area_pft(1:numpft))
-             if(sumarea .gt. area)then
-               write(fates_log(),*) 'Total pft area for site is larger than notional area',s,sum(sites(s)%area_pft)
-               call endrun(msg=errMsg(sourcefile, __LINE__))
-             endif
-                          
+             do ft =  1,numpft
+                if(sites(s)%area_pft(ft).lt.0.01_r8.and.sites(s)%area_pft(ft).gt.0.0_r8)then
+                   if(debug) write(fates_log(),*)  'removing small pft patches',s,ft,sites(s)%area_pft(ft)
+                   sites(s)%area_pft(ft)=0.0_r8
+                   ! remove tiny patches to prevent numerical errors in terminate patches
+                endif
+                if(sites(s)%area_pft(ft).lt.0._r8)then
+                   write(fates_log(),*) 'negative area',s,ft,sites(s)%area_pft(ft)
+                   call endrun(msg=errMsg(sourcefile, __LINE__))
+                end if
+                sites(s)%area_pft(ft)= sites(s)%area_pft(ft) * AREA ! rescale units to m2.
+             end do
+
              ! re-normalize PFT area to ensure it sums to one.
              ! note that in areas of 'bare ground' (PFT 0 in CLM/ELM)
              ! the bare ground will no longer be proscribed and should emerge from FATES
@@ -387,9 +372,10 @@ contains
 
              if(hlm_use_nocomp.eq.ifalse)then ! when not in nocomp (i.e. or SP) mode, 
                 ! subsume bare ground evenly into the existing patches.
-                
+
+                sumarea = sum(sites(s)%area_pft(1:numpft))
                 do ft =  1,numpft
-                   if(area-sumarea.gt.nearzero)then
+                   if(sumarea.gt.0._r8)then
                       sites(s)%area_pft(ft) = area * sites(s)%area_pft(ft)/sumarea
                    else
                       sites(s)%area_pft(ft) = area/numpft
@@ -397,8 +383,8 @@ contains
                       ! all pfts and let the model figure out whether land should be bare or not.
                    end if
                 end do !ft
-                
              else ! for sp and nocomp mode, assert a bare ground patch if needed
+                sumarea = sum(sites(s)%area_pft(1:numpft))
                 
                ! In all the other FATES modes, bareground is the area in which plants
                ! do not grow of their own accord. In SP mode we assert that the canopy is full for
@@ -410,12 +396,11 @@ contains
                ! on canopy are inside FATES, and so in SP mode, we define the bare groud
                ! patch as having a PFT identifier as zero.
 
-                if(area-sumarea.gt.nearzero)then !make some bare ground
+                if(sumarea.lt.area)then !make some bare ground
                    sites(s)%area_pft(0) = area - sumarea
                 else
                    sites(s)%area_pft(0) = 0.0_r8
                 end if
-                
              end if !sp mode
           end if !fixed biogeog
 

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -1926,6 +1926,7 @@ contains
         ifp=0
         cpatch => sites(s)%oldest_patch
         do while(associated(cpatch))
+           if (cpatch%patchno .ne. 0) then
            ifp=ifp+1
            call cpatch%tveg24%UpdateRMean(bc_in(s)%t_veg_pa(ifp))
            call cpatch%tveg_lpa%UpdateRMean(bc_in(s)%t_veg_pa(ifp))
@@ -1936,6 +1937,7 @@ contains
            !   call ccohort%tveg_lpa%UpdateRMean(bc_in(s)%t_veg_pa(ifp))
            !   ccohort => ccohort%shorter
            !end do
+           end if
            
            cpatch => cpatch%younger
         enddo

--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -2693,7 +2693,7 @@ contains
 
           ! calculate the bareground area for the pft in no competition modes
           if (hlm_use_nocomp .eq. itrue) then
-             if (sum(sites(s)%area_pft(1:numpft)) .lt. area) then
+             if (area-sum(sites(s)%area_pft(1:numpft)) .gt. nearzero) then
                 sites(s)%area_pft(0) = area - sum(sites(s)%area_pft(1:numpft))
              else
                 sites(s)%area_pft(0) = 0.0_r8

--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -18,7 +18,7 @@ module FatesRestartInterfaceMod
   use FatesInterfaceTypesMod,       only : bc_in_type
   use FatesInterfaceTypesMod,       only : bc_out_type
   use FatesInterfaceTypesMod,       only : hlm_use_planthydro
-  use FatesInterfaceTypesMod,       only : hlm_use_sp
+  use FatesInterfaceTypesMod,       only : hlm_use_sp, hlm_use_nocomp
   use FatesInterfaceTypesMod,       only : fates_maxElementsPerSite
   use EDCohortDynamicsMod,     only : UpdateCohortBioPhysRates
   use FatesHydraulicsMemMod,   only : nshell
@@ -36,7 +36,7 @@ module FatesRestartInterfaceMod
   use FatesLitterMod,          only : litter_type
   use FatesLitterMod,          only : ncwd
   use FatesLitterMod,          only : ndcmpy
-  use EDTypesMod,              only : nfsc
+  use EDTypesMod,              only : nfsc, nlevleaf, area
   use PRTGenericMod,           only : prt_global
   use PRTGenericMod,           only : num_elements
   use FatesRunningMeanMod,     only : rmean_type
@@ -2685,11 +2685,19 @@ contains
              sites(s)%recruitment_rate(i_pft) = rio_recrate_sift(io_idx_co_1st+i_pft-1)
           enddo
 
-         !variables for fixed biogeography mode. These are currently used in restart even when this is off.
+          ! variables for fixed biogeography mode. These are currently used in restart even when this is off.
           do i_pft = 1,numpft
              sites(s)%use_this_pft(i_pft) = rio_use_this_pft_sift(io_idx_co_1st+i_pft-1)
              sites(s)%area_pft(i_pft)     = rio_area_pft_sift(io_idx_co_1st+i_pft-1)
           enddo
+
+          ! calculate the bareground area for the pft in no competition modes
+          if (hlm_use_nocomp .eq. itrue) then
+             if (sum(sites(s)%area_pft(1:numpft)) .lt. area) then
+                sites(s)%area_pft(0) = area - sum(sites(s)%area_pft(1:numpft))
+             else
+                sites(s)%area_pft(0) = 0.0_r8
+          endif
 
           ! Mass balance and diagnostics across elements at the site level
           do el = 1, num_elements

--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -2692,8 +2692,8 @@ contains
              sites(s)%area_pft(i_pft)     = rio_area_pft_sift(io_idx_co_1st+i_pft-1)
           enddo
 
-          ! calculate the bareground area for the pft in no competition modes
-          if (hlm_use_nocomp .eq. itrue) then
+          ! calculate the bareground area for the pft in no competition + fixed biogeo modes
+          if (hlm_use_nocomp .eq. itrue .and. hlm_use_fixed_biogeog .eq. itrue) then
              if (area-sum(sites(s)%area_pft(1:numpft)) .gt. nearzero) then
                 sites(s)%area_pft(0) = area - sum(sites(s)%area_pft(1:numpft))
              else

--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -9,6 +9,7 @@ module FatesRestartInterfaceMod
   use FatesConstantsMod,       only : ifalse
   use FatesConstantsMod,       only : fates_unset_r8, fates_unset_int
   use FatesConstantsMod,       only : primaryforest
+  use FatesConstantsMod,       only : nearzero
   use FatesGlobals,            only : fates_log
   use FatesGlobals,            only : endrun => fates_endrun
   use FatesIODimensionsMod,    only : fates_io_dimension_type

--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -2697,6 +2697,7 @@ contains
                 sites(s)%area_pft(0) = area - sum(sites(s)%area_pft(1:numpft))
              else
                 sites(s)%area_pft(0) = 0.0_r8
+             endif
           endif
 
           ! Mass balance and diagnostics across elements at the site level

--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -19,7 +19,8 @@ module FatesRestartInterfaceMod
   use FatesInterfaceTypesMod,       only : bc_in_type
   use FatesInterfaceTypesMod,       only : bc_out_type
   use FatesInterfaceTypesMod,       only : hlm_use_planthydro
-  use FatesInterfaceTypesMod,       only : hlm_use_sp, hlm_use_nocomp
+  use FatesInterfaceTypesMod,       only : hlm_use_sp
+  use FatesInterfaceTypesMod,       only : hlm_use_nocomp, hlm_use_fixed_biogeog
   use FatesInterfaceTypesMod,       only : fates_maxElementsPerSite
   use EDCohortDynamicsMod,     only : UpdateCohortBioPhysRates
   use FatesHydraulicsMemMod,   only : nshell


### PR DESCRIPTION
Addresses #908  and addresses #911. 

### Description:
The `FATES_TVEG` and `FATES_TVEG24` history output variables were found to have non-b4b restarts when testing the `aux_clm` suite for https://github.com/ESCOMP/CTSM/pull/1849.  It was found that both had issues with satellite phenology restarts due to mishandling of the bareground patch `area_pft` and patch iteration during running means update, respectively.  This pull request adds in the necessary checks for the bareground patch and conduct site-level calculations, as needed.

### Collaborators: 
@rgknox 

### Expectation of Answer Changes: 
Potentially, for satellite phenology ERS tests only

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [x] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided

### Test Results:
B4B aside from expected failures

CTSM (or) E3SM (specify which) test hash-tag: [c6d8032c9](https://github.com/ESCOMP/CTSM/commit/c6d8032c9224e90978c8f73b8ddde23b41671671)

CTSM (or) E3SM (specify which) baseline hash-tag: [c6d8032c9](https://github.com/ESCOMP/CTSM/commit/c6d8032c9224e90978c8f73b8ddde23b41671671)

FATES baseline hash-tag: `fates-sci.1.59.6_api.24.1.0-ctsm5.1.dev111`

Test Output:

`/glade/u/home/glemieux/scratch/ctsm-tests/tests_pr914-2`


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

