### PR TITLE
Create github workflow to add new issues to triage board automatically

### DIFF
--- a/.github/workflows/add-to-gh_projects.yml
+++ b/.github/workflows/add-to-gh_projects.yml
@@ -1,0 +1,23 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Add issue to github project issue triage board
+
+# Controls when the workflow will run
+on:
+  issues:
+    types:
+      - opened
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  add-to-project:
+    name: add issue to issue triage board project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.3.0
+        with:
+          # URL of the project to add issues to
+          project-url: https://github.com/orgs/NGEET/projects/1
+          # A GitHub personal access token with write access to the project
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+


### PR DESCRIPTION
Automate adding issues to the [NGEET issue board project](https://github.com/orgs/NGEET/projects/1).

### Description:
This PR adds a new subfolder to the `.github` folder to enable workflows to be run automatically by github actions.  This particular workflow calls the Github Action [Add-To-Project](https://github.com/actions/add-to-project).  

### Collaborators:
None

### Expectation of Answer Changes:
None as this is a github configuration update

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

