### PR TITLE
Add mortality and productivity aboveground carbon fluxes as history variables

### DIFF
--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -864,9 +864,10 @@ contains
             currentCohort%n * (struct_c+sapw_c+leaf_c+fnrt_c+store_c+repro_c)
    end if
 
-   currentSite%term_bagw_flux(currentCohort%size_class, currentCohort%pft) = &
-        currentSite%term_bagw_flux(currentCohort%size_class, currentCohort%pft) + &
-        currentCohort%n * (struct_c+sapw_c)
+   currentSite%term_abg_flux(currentCohort%size_class, currentCohort%pft) = &
+        currentSite%term_abg_flux(currentCohort%size_class, currentCohort%pft) + &
+        currentCohort%n * ( (struct_c+sapw_c+store_c) * prt_params%allom_agb_frac(currentCohort%pft) + &
+        leaf_c )
   
 
    ! put the litter from the terminated cohorts

--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -864,6 +864,11 @@ contains
             currentCohort%n * (struct_c+sapw_c+leaf_c+fnrt_c+store_c+repro_c)
    end if
 
+   currentSite%term_bagw_flux(currentCohort%size_class, currentCohort%pft) = &
+        currentSite%term_bagw_flux(currentCohort%size_class, currentCohort%pft) + &
+        currentCohort%n * (struct_c+sapw_c)
+  
+
    ! put the litter from the terminated cohorts
    ! straight into the fragmenting pools
 

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -399,6 +399,7 @@ contains
     real(r8) :: sapw_c                       ! sapwood carbon [kg]
     real(r8) :: store_c                      ! storage carbon [kg]
     real(r8) :: struct_c                     ! structure carbon [kg]
+    real(r8) :: repro_c                      ! reproductive carbon [kg]
     real(r8) :: total_c                      ! total carbon of plant [kg]
     real(r8) :: leaf_burn_frac               ! fraction of leaves burned in fire
                                              ! for both woody and grass species
@@ -662,6 +663,7 @@ contains
                          leaf_c   = currentCohort%prt%GetState(leaf_organ, all_carbon_elements)
                          fnrt_c   = currentCohort%prt%GetState(fnrt_organ, all_carbon_elements)
                          store_c  = currentCohort%prt%GetState(store_organ, all_carbon_elements)
+                         repro_c  = currentCohort%prt%GetState(repro_organ, all_carbon_elements)
                          total_c  = sapw_c + struct_c + leaf_c + fnrt_c + store_c
 
                          ! treefall mortality is the current disturbance
@@ -722,10 +724,11 @@ contains
                                        (nc%n * ED_val_understorey_death / hlm_freq_day ) * &
                                        total_c * g_per_kg * days_per_sec * years_per_day * ha_per_m2
 
-                                  currentSite%imort_bagw_flux(currentCohort%size_class, currentCohort%pft) = &
-                                       currentSite%imort_bagw_flux(currentCohort%size_class, currentCohort%pft) + &
+                                  currentSite%imort_abg_flux(currentCohort%size_class, currentCohort%pft) = &
+                                       currentSite%imort_abg_flux(currentCohort%size_class, currentCohort%pft) + &
                                        (nc%n * ED_val_understorey_death / hlm_freq_day ) * &
-                                       (sapw_c + struct_c) * prt_params%allom_agb_frac(currentCohort%pft) * &
+                                       ( (sapw_c + struct_c + store_c) * prt_params%allom_agb_frac(currentCohort%pft) + &
+                                       leaf_c ) * &
                                        g_per_kg * days_per_sec * years_per_day * ha_per_m2
 
 
@@ -817,10 +820,11 @@ contains
                                     total_c * g_per_kg * days_per_sec * ha_per_m2
                             end if
 
-                            currentSite%fmort_bagw_flux(currentCohort%size_class, currentCohort%pft) = &
-                                 currentSite%fmort_bagw_flux(currentCohort%size_class, currentCohort%pft) + &
+                            currentSite%fmort_abg_flux(currentCohort%size_class, currentCohort%pft) = &
+                                 currentSite%fmort_abg_flux(currentCohort%size_class, currentCohort%pft) + &
                                  (nc%n * currentCohort%fire_mort) * &
-                                 (sapw_c + struct_c) * prt_params%allom_agb_frac(currentCohort%pft) * &
+                                 ( (sapw_c + struct_c + store_c) * prt_params%allom_agb_frac(currentCohort%pft) + &
+                                 leaf_c ) * &
                                  g_per_kg * days_per_sec * ha_per_m2
                             
 

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -722,6 +722,13 @@ contains
                                        (nc%n * ED_val_understorey_death / hlm_freq_day ) * &
                                        total_c * g_per_kg * days_per_sec * years_per_day * ha_per_m2
 
+                                  currentSite%imort_bagw_flux(currentCohort%size_class, currentCohort%pft) = &
+                                       currentSite%imort_bagw_flux(currentCohort%size_class, currentCohort%pft) + &
+                                       (nc%n * ED_val_understorey_death / hlm_freq_day ) * &
+                                       (sapw_c + struct_c) * prt_params%allom_agb_frac(currentCohort%pft) * &
+                                       g_per_kg * days_per_sec * years_per_day * ha_per_m2
+
+
                                   ! Step 2:  Apply survivor ship function based on the understory death fraction
                                   ! remaining of understory plants of those that are knocked over
                                   ! by the overstorey trees dying...
@@ -809,6 +816,13 @@ contains
                                     (nc%n * currentCohort%fire_mort) * &
                                     total_c * g_per_kg * days_per_sec * ha_per_m2
                             end if
+
+                            currentSite%fmort_bagw_flux(currentCohort%size_class, currentCohort%pft) = &
+                                 currentSite%fmort_bagw_flux(currentCohort%size_class, currentCohort%pft) + &
+                                 (nc%n * currentCohort%fire_mort) * &
+                                 (sapw_c + struct_c) * prt_params%allom_agb_frac(currentCohort%pft) * &
+                                 g_per_kg * days_per_sec * ha_per_m2
+                            
 
                             currentSite%fmort_rate_cambial(currentCohort%size_class, currentCohort%pft) = &
                                  currentSite%fmort_rate_cambial(currentCohort%size_class, currentCohort%pft) + &

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -135,6 +135,10 @@ contains
     allocate(site_in%fmort_carbonflux_canopy(1:numpft))
     allocate(site_in%fmort_carbonflux_ustory(1:numpft))
     
+    allocate(site_in%term_bagw_flux(1:nlevsclass,1:numpft))
+    allocate(site_in%imort_bagw_flux(1:nlevsclass,1:numpft))
+    allocate(site_in%fmort_bagw_flux(1:nlevsclass,1:numpft))
+    
     site_in%nlevsoil   = bc_in%nlevsoil
     allocate(site_in%rootfrac_scr(site_in%nlevsoil))
     allocate(site_in%zi_soil(0:site_in%nlevsoil))
@@ -245,6 +249,10 @@ contains
     site_in%fmort_carbonflux_ustory(:) = 0._r8
     site_in%fmort_rate_cambial(:,:) = 0._r8
     site_in%fmort_rate_crown(:,:) = 0._r8
+    site_in%term_bagw_flux(:,:) = 0._r8
+    site_in%imort_bagw_flux(:,:) = 0._r8
+    site_in%fmort_bagw_flux(:,:) = 0._r8
+
 
     ! fusoin-induced growth flux of individuals
     site_in%growthflux_fusion(:,:) = 0._r8

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -135,9 +135,9 @@ contains
     allocate(site_in%fmort_carbonflux_canopy(1:numpft))
     allocate(site_in%fmort_carbonflux_ustory(1:numpft))
     
-    allocate(site_in%term_bagw_flux(1:nlevsclass,1:numpft))
-    allocate(site_in%imort_bagw_flux(1:nlevsclass,1:numpft))
-    allocate(site_in%fmort_bagw_flux(1:nlevsclass,1:numpft))
+    allocate(site_in%term_abg_flux(1:nlevsclass,1:numpft))
+    allocate(site_in%imort_abg_flux(1:nlevsclass,1:numpft))
+    allocate(site_in%fmort_abg_flux(1:nlevsclass,1:numpft))
     
     site_in%nlevsoil   = bc_in%nlevsoil
     allocate(site_in%rootfrac_scr(site_in%nlevsoil))
@@ -249,9 +249,9 @@ contains
     site_in%fmort_carbonflux_ustory(:) = 0._r8
     site_in%fmort_rate_cambial(:,:) = 0._r8
     site_in%fmort_rate_crown(:,:) = 0._r8
-    site_in%term_bagw_flux(:,:) = 0._r8
-    site_in%imort_bagw_flux(:,:) = 0._r8
-    site_in%fmort_bagw_flux(:,:) = 0._r8
+    site_in%term_abg_flux(:,:) = 0._r8
+    site_in%imort_abg_flux(:,:) = 0._r8
+    site_in%fmort_abg_flux(:,:) = 0._r8
 
 
     ! fusoin-induced growth flux of individuals

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -796,6 +796,11 @@ module EDTypesMod
      real(r8), allocatable :: fmort_carbonflux_canopy(:) ! biomass of canopy indivs killed due to fire per year. [gC/m2/sec]
      real(r8), allocatable :: fmort_carbonflux_ustory(:) ! biomass of understory indivs killed due to fire per year [gC/m2/sec] 
 
+     real(r8), allocatable :: term_bagw_flux(:,:)          ! aboveground woody biomass lost due to termination mortality x size x pft
+     real(r8), allocatable :: imort_bagw_flux(:,:)         ! aboveground woody biomass lost due to impact mortality x size x pft
+     real(r8), allocatable :: fmort_bagw_flux(:,:)         ! aboveground woody biomass lost due to fire mortality x size x pft
+
+
      real(r8) :: demotion_carbonflux                     ! biomass of demoted individuals from canopy to understory [kgC/ha/day]
      real(r8) :: promotion_carbonflux                    ! biomass of promoted individuals from understory to canopy [kgC/ha/day]
      real(r8) :: recruitment_rate(1:maxpft)              ! number of individuals that were recruited into new cohorts

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -796,9 +796,9 @@ module EDTypesMod
      real(r8), allocatable :: fmort_carbonflux_canopy(:) ! biomass of canopy indivs killed due to fire per year. [gC/m2/sec]
      real(r8), allocatable :: fmort_carbonflux_ustory(:) ! biomass of understory indivs killed due to fire per year [gC/m2/sec] 
 
-     real(r8), allocatable :: term_bagw_flux(:,:)          ! aboveground woody biomass lost due to termination mortality x size x pft
-     real(r8), allocatable :: imort_bagw_flux(:,:)         ! aboveground woody biomass lost due to impact mortality x size x pft
-     real(r8), allocatable :: fmort_bagw_flux(:,:)         ! aboveground woody biomass lost due to fire mortality x size x pft
+     real(r8), allocatable :: term_abg_flux(:,:)          ! aboveground biomass lost due to termination mortality x size x pft
+     real(r8), allocatable :: imort_abg_flux(:,:)         ! aboveground biomass lost due to impact mortality x size x pft
+     real(r8), allocatable :: fmort_abg_flux(:,:)         ! aboveground biomass lost due to fire mortality x size x pft
 
 
      real(r8) :: demotion_carbonflux                     ! biomass of demoted individuals from canopy to understory [kgC/ha/day]

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -5598,18 +5598,18 @@ end subroutine update_history_hifrq
          upfreq=1, ivar=ivar, initialize=initialize_variables,                 &
          index=ih_cstarvmortality_carbonflux_si_pft)
 
-    call this%set_history_var(vname='FATES_ABOVEGROUND_MORTALITY_SZPF', units='kg m-2 s-1',    &
+    call this%set_history_var(vname='FATES_AGW_MORTALITY_SZPF', units='kg m-2 s-1',    &
          long='Aboveground woody flux of carbon from AGB to necromass due to mortality', &
          use_default='inactive', avgflag='A', vtype=site_size_pft_r8, hlms='CLM:ALM', &
          upfreq=1, ivar=ivar, initialize=initialize_variables,                 &
          index=ih_bagw_mortality_si_scpf)
 
-    call this%set_history_var(vname='FATES_ABOVEGROUND_PRODUCTIVITY_SZPF', units='kg m-2 s-1',    &
+    call this%set_history_var(vname='FATES_AGW_PRODUCTIVITY_SZPF', units='kg m-2 s-1',    &
          long='Aboveground woody carbon productivity', &
          use_default='inactive', avgflag='A', vtype=site_size_pft_r8, hlms='CLM:ALM', &
          upfreq=1, ivar=ivar, initialize=initialize_variables,                 &
          index=ih_bagw_productivity_si_scpf)
-
+    
     ! size class by age dimensioned variables
 
     call this%set_history_var(vname='FATES_NPLANT_SZAP', units = 'm-2',        &

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -2638,6 +2638,7 @@ end subroutine flush_hvars
                     (ccohort%lmort_direct + ccohort%lmort_collateral + ccohort%lmort_infra) * total_m * &
                     ccohort%n * ha_per_m2
 
+               
                hio_hydraulicmortality_carbonflux_si_pft(io_si,ccohort%pft) = hio_hydraulicmortality_carbonflux_si_pft(io_si,ccohort%pft) + &
                     ccohort%hmort * total_m * ccohort%n * days_per_sec * years_per_day * ha_per_m2
 
@@ -2649,13 +2650,11 @@ end subroutine flush_hvars
                     (ccohort%bmort + ccohort%hmort + ccohort%cmort + &
                     ccohort%frmort + ccohort%smort + ccohort%asmort) * &
                     ( (sapw_m + struct_m + store_m ) * prt_params%allom_agb_frac(ccohort%pft) + &
-                    leaf_m ) * &
-                    ccohort%n * days_per_sec * years_per_day * ha_per_m2 + &
+                    leaf_m ) * ccohort%n * days_per_sec * years_per_day * ha_per_m2 + &
                     (ccohort%lmort_direct + ccohort%lmort_collateral + ccohort%lmort_infra) * &
                     ( (sapw_m + struct_m + store_m ) * prt_params%allom_agb_frac(ccohort%pft) + &
-                    leaf_m ) * &
-                    ccohort%n * ha_per_m2
-
+                    leaf_m ) * ccohort%n * ha_per_m2
+   
                ! Aboveground woody productivity
                hio_abg_productivity_cflux_si_scpf(io_si,scpf) = hio_abg_productivity_cflux_si_scpf(io_si,scpf) + &
                     ( (sapw_m_net_alloc + struct_m_net_alloc + store_m_net_alloc) * prt_params%allom_agb_frac(ccohort%pft) + &
@@ -2994,6 +2993,7 @@ end subroutine flush_hvars
          cpatch => cpatch%younger
       end do patchloop !patch loop
 
+    
       ! divide basal-area-weighted height by basal area to get mean
       if ( sum(hio_ba_si_scpf(io_si,:)) .gt. nearzero ) then
          hio_ba_weighted_height_si(io_si) = hio_ba_weighted_height_si(io_si) / sum(hio_ba_si_scpf(io_si,:))
@@ -3118,10 +3118,8 @@ end subroutine flush_hvars
          hio_mortality_carbonflux_si_pft(io_si,i_pft) = hio_mortality_carbonflux_si_pft(io_si,i_pft) + &
               (sites(s)%fmort_carbonflux_canopy(i_pft) + &
               sites(s)%fmort_carbonflux_ustory(i_pft) + &
-              sites(s)%imort_carbonflux(i_pft) ) / g_per_kg + &  ! cdk
-              (sites(s)%term_carbonflux_canopy(i_pft) + &
-              sites(s)%term_carbonflux_ustory(i_pft) ) * days_per_sec * ha_per_m2
-
+              sites(s)%imort_carbonflux(i_pft) ) / g_per_kg  ! cdk
+   
          hio_firemortality_carbonflux_si_pft(io_si,i_pft) = sites(s)%fmort_carbonflux_canopy(i_pft) / g_per_kg
       end do
 
@@ -3131,11 +3129,12 @@ end subroutine flush_hvars
             i_scpf = (i_pft-1)*nlevsclass + i_scls
             hio_abg_mortality_cflux_si_scpf(io_si,i_scpf) = hio_abg_mortality_cflux_si_scpf(io_si,i_scpf) + &
                  (sites(s)%fmort_abg_flux(i_scls,i_pft) / g_per_kg ) + &
-                 (sites(s)%imort_abg_flux(i_scls,i_pft)  / g_per_kg) + &
+                 (sites(s)%imort_abg_flux(i_scls,i_pft) / g_per_kg) + &
                  (sites(s)%term_abg_flux(i_scls,i_pft)  * days_per_sec * ha_per_m2 ) ! jfn
          end do
       end do
 
+      
       sites(s)%term_nindivs_canopy(:,:) = 0._r8
       sites(s)%term_nindivs_ustory(:,:) = 0._r8
       sites(s)%imort_carbonflux(:) = 0._r8

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -417,6 +417,9 @@ module FatesHistoryInterfaceMod
   integer :: ih_crownfiremort_si_scpf
   integer :: ih_cambialfiremort_si_scpf
 
+  integer :: ih_bagw_mortality_si_scpf
+  integer :: ih_bagw_productivity_si_scpf
+
   integer :: ih_m10_si_capf
   integer :: ih_nplant_si_capf
 
@@ -1923,6 +1926,9 @@ end subroutine flush_hvars
                hio_crownfiremort_si_scpf     => this%hvars(ih_crownfiremort_si_scpf)%r82d, &
                hio_cambialfiremort_si_scpf   => this%hvars(ih_cambialfiremort_si_scpf)%r82d, &
 
+               hio_bagw_mortality_si_scpf    => this%hvars(ih_bagw_mortality_si_scpf)%r82d, &
+               hio_bagw_productivity_si_scpf => this%hvars(ih_bagw_productivity_si_scpf)%r82d, &
+               
                hio_fire_c_to_atm_si  => this%hvars(ih_fire_c_to_atm_si)%r81d, &
                hio_burn_flux_elem    => this%hvars(ih_burn_flux_elem)%r82d, &
 
@@ -2534,6 +2540,10 @@ end subroutine flush_hvars
                hio_npp_stor_si_scpf(io_si,scpf) = hio_npp_stor_si_scpf(io_si,scpf) + &
                   store_m_net_alloc*n_perm2 / days_per_year / sec_per_day
 
+               hio_bagw_productivity_si_scpf(io_si,scpf) = hio_bagw_productivity_si_scpf(io_si,scpf) + &
+                    (sapw_m_net_alloc + struct_m_net_alloc) * n_perm2 * (prt_params%allom_agb_frac(ccohort%pft)) / &
+                  days_per_year / sec_per_day
+
                ! Woody State Variables (basal area growth increment)
                if ( prt_params%woody(ft) == itrue) then
 
@@ -2583,6 +2593,17 @@ end subroutine flush_hvars
                   hio_m10_si_cacls(io_si,cacls) = hio_m10_si_cacls(io_si,cacls)+ &
                      ccohort%asmort*ccohort%n / m2_per_ha
                end if
+
+               hio_bagw_mortality_si_scpf(io_si,scpf) = hio_bagw_mortality_si_scpf(io_si,scpf) + &
+                    (ccohort%bmort + ccohort%hmort + ccohort%cmort + &
+                    ccohort%frmort + ccohort%smort + ccohort%asmort) * &
+                    (sapw_m + struct_m) * prt_params%allom_agb_frac(ccohort%pft) * &
+                    ccohort%n * days_per_sec * years_per_day * ha_per_m2 + &
+                    (ccohort%lmort_direct + ccohort%lmort_collateral + ccohort%lmort_infra) * &
+                    (sapw_m + struct_m) * prt_params%allom_agb_frac(ccohort%pft) * &
+                    ccohort%n * ha_per_m2
+
+
 
                hio_m1_si_scls(io_si,scls) = hio_m1_si_scls(io_si,scls) + ccohort%bmort*ccohort%n / m2_per_ha
                hio_m2_si_scls(io_si,scls) = hio_m2_si_scls(io_si,scls) + ccohort%hmort*ccohort%n / m2_per_ha
@@ -3094,6 +3115,17 @@ end subroutine flush_hvars
          hio_firemortality_carbonflux_si_pft(io_si,i_pft) = sites(s)%fmort_carbonflux_canopy(i_pft) / g_per_kg
       end do
 
+      ! add imort and fmort to aboveground woody mortality 
+      do i_pft = 1, numpft
+         do i_scls = 1,nlevsclass
+            i_scpf = (i_pft-1)*nlevsclass + i_scls
+            hio_bagw_mortality_si_scpf(io_si,i_scpf) = hio_bagw_mortality_si_scpf(io_si,i_scpf) + &
+                 (sites(s)%fmort_bagw_flux(i_scls,i_pft) / g_per_kg ) + &
+                 (sites(s)%imort_bagw_flux(i_scls,i_pft)  / g_per_kg) + &
+                 (sites(s)%term_bagw_flux(i_scls,i_pft)  * days_per_sec * ha_per_m2 ) ! jfn
+         end do
+      end do
+
       sites(s)%term_nindivs_canopy(:,:) = 0._r8
       sites(s)%term_nindivs_ustory(:,:) = 0._r8
       sites(s)%imort_carbonflux(:) = 0._r8
@@ -3105,6 +3137,9 @@ end subroutine flush_hvars
       sites(s)%fmort_rate_cambial(:,:) = 0._r8
       sites(s)%fmort_rate_crown(:,:) = 0._r8
       sites(s)%growthflux_fusion(:,:) = 0._r8
+      sites(s)%fmort_bagw_flux(:,:) = 0._r8
+      sites(s)%imort_bagw_flux(:,:) = 0._r8
+      sites(s)%term_bagw_flux(:,:) = 0._r8
 
       ! pass the recruitment rate as a flux to the history, and then reset the recruitment buffer
       do i_pft = 1, numpft
@@ -5562,6 +5597,18 @@ end subroutine update_history_hifrq
          use_default='active', avgflag='A', vtype=site_pft_r8, hlms='CLM:ALM', &
          upfreq=1, ivar=ivar, initialize=initialize_variables,                 &
          index=ih_cstarvmortality_carbonflux_si_pft)
+
+    call this%set_history_var(vname='FATES_ABOVEGROUND_MORTALITY_SZPF', units='kg m-2 s-1',    &
+         long='Aboveground woody flux of carbon from AGB to necromass due to mortality', &
+         use_default='inactive', avgflag='A', vtype=site_size_pft_r8, hlms='CLM:ALM', &
+         upfreq=1, ivar=ivar, initialize=initialize_variables,                 &
+         index=ih_bagw_mortality_si_scpf)
+
+    call this%set_history_var(vname='FATES_ABOVEGROUND_PRODUCTIVITY_SZPF', units='kg m-2 s-1',    &
+         long='Aboveground woody carbon productivity', &
+         use_default='inactive', avgflag='A', vtype=site_size_pft_r8, hlms='CLM:ALM', &
+         upfreq=1, ivar=ivar, initialize=initialize_variables,                 &
+         index=ih_bagw_productivity_si_scpf)
 
     ! size class by age dimensioned variables
 

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -2644,7 +2644,7 @@ end subroutine flush_hvars
                hio_cstarvmortality_carbonflux_si_pft(io_si,ccohort%pft) = hio_cstarvmortality_carbonflux_si_pft(io_si,ccohort%pft) + &
                     ccohort%cmort * total_m * ccohort%n * days_per_sec * years_per_day * ha_per_m2
 
-               ! Aboveground woody mortality
+               ! Aboveground mortality
                hio_abg_mortality_cflux_si_scpf(io_si,scpf) = hio_abg_mortality_cflux_si_scpf(io_si,scpf) + &
                     (ccohort%bmort + ccohort%hmort + ccohort%cmort + &
                     ccohort%frmort + ccohort%smort + ccohort%asmort) * &
@@ -3118,7 +3118,9 @@ end subroutine flush_hvars
          hio_mortality_carbonflux_si_pft(io_si,i_pft) = hio_mortality_carbonflux_si_pft(io_si,i_pft) + &
               (sites(s)%fmort_carbonflux_canopy(i_pft) + &
               sites(s)%fmort_carbonflux_ustory(i_pft) + &
-              sites(s)%imort_carbonflux(i_pft) ) / g_per_kg !cdk
+              sites(s)%imort_carbonflux(i_pft) ) / g_per_kg + &  ! cdk
+              (sites(s)%term_carbonflux_canopy(i_pft) + &
+              sites(s)%term_carbonflux_ustory(i_pft) ) * days_per_sec * ha_per_m2
 
          hio_firemortality_carbonflux_si_pft(io_si,i_pft) = sites(s)%fmort_carbonflux_canopy(i_pft) / g_per_kg
       end do

--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -211,6 +211,9 @@ module FatesRestartInterfaceMod
   integer :: ir_imortcflux_sipft
   integer :: ir_fmortcflux_cano_sipft
   integer :: ir_fmortcflux_usto_sipft
+  integer :: ir_bagw_term_flux_siscpf
+  integer :: ir_bagw_imort_flux_siscpf
+  integer :: ir_bagw_fmort_flux_siscpf
   integer :: ir_cwdagin_flxdg
   integer :: ir_cwdbgin_flxdg
   integer :: ir_leaflittin_flxdg
@@ -1246,7 +1249,22 @@ contains
    call this%set_restart_var(vname='fates_termcflux_ustory', vtype=cohort_r8, &
          long_name='fates diagnostic term carbon flux understory', &
          units='', flushval = flushzero, &
-         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index =   ir_termcflux_usto_sipft )
+         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_termcflux_usto_sipft )
+
+   call this%set_restart_var(vname='fates_bagw_term_flux', vtype=cohort_r8, &
+         long_name='fates aboveground biomass loss from termination mortality', &
+         units='', flushval = flushzero, &
+         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_bagw_term_flux_siscpf )
+
+   call this%set_restart_var(vname='fates_bagw_imort_flux', vtype=cohort_r8, &
+         long_name='fates aboveground biomass loss from impact mortality', &
+         units='', flushval = flushzero, &
+         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_bagw_imort_flux_siscpf )
+
+   call this%set_restart_var(vname='fates_bagw_fmort_flux', vtype=cohort_r8, &
+         long_name='fates aboveground biomass loss from fire mortality', &
+         units='', flushval = flushzero, &
+         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_bagw_fmort_flux_siscpf )
 
    call this%set_restart_var(vname='fates_democflux', vtype=site_r8, &
          long_name='fates diagnostic demotion carbon flux', &
@@ -1825,8 +1843,11 @@ contains
            rio_promcflux_si            => this%rvars(ir_promcflux_si)%r81d, &
            rio_imortcflux_sipft        => this%rvars(ir_imortcflux_sipft)%r81d, &
            rio_fmortcflux_cano_sipft   => this%rvars(ir_fmortcflux_cano_sipft)%r81d, &
-           rio_fmortcflux_usto_sipft   => this%rvars(ir_fmortcflux_usto_sipft)%r81d)
-
+           rio_fmortcflux_usto_sipft   => this%rvars(ir_fmortcflux_usto_sipft)%r81d, &
+           rio_bagw_imort_flux_siscpf => this%rvars(ir_bagw_imort_flux_siscpf)%r81d, &
+           rio_bagw_fmort_flux_siscpf => this%rvars(ir_bagw_fmort_flux_siscpf)%r81d, &
+           rio_bagw_term_flux_siscpf  => this%rvars(ir_bagw_term_flux_siscpf)%r81d )
+           
 
        totalCohorts = 0
 
@@ -2198,6 +2219,10 @@ contains
                 rio_termnindiv_cano_siscpf(io_idx_si_scpf) = sites(s)%term_nindivs_canopy(i_scls,i_pft)
                 rio_termnindiv_usto_siscpf(io_idx_si_scpf) = sites(s)%term_nindivs_ustory(i_scls,i_pft)
                 rio_growflx_fusion_siscpf(io_idx_si_scpf)  = sites(s)%growthflux_fusion(i_scls, i_pft)
+
+                rio_bagw_term_flux_siscpf(io_idx_si_scpf) = sites(s)%term_bagw_flux(i_scls, i_pft)
+                rio_bagw_imort_flux_siscpf(io_idx_si_scpf) = sites(s)%imort_bagw_flux(i_scls, i_pft)
+                rio_bagw_fmort_flux_siscpf(io_idx_si_scpf) = sites(s)%fmort_bagw_flux(i_scls, i_pft)
 
                 io_idx_si_scpf = io_idx_si_scpf + 1
              end do
@@ -2658,7 +2683,10 @@ contains
           rio_promcflux_si            => this%rvars(ir_promcflux_si)%r81d, &
           rio_imortcflux_sipft        => this%rvars(ir_imortcflux_sipft)%r81d, &
           rio_fmortcflux_cano_sipft   => this%rvars(ir_fmortcflux_cano_sipft)%r81d, &
-          rio_fmortcflux_usto_sipft   => this%rvars(ir_fmortcflux_usto_sipft)%r81d)
+          rio_fmortcflux_usto_sipft   => this%rvars(ir_fmortcflux_usto_sipft)%r81d, &
+          rio_bagw_term_flux_siscpf   => this%rvars(ir_bagw_term_flux_siscpf)%r81d, &
+          rio_bagw_imort_flux_siscpf  => this%rvars(ir_bagw_imort_flux_siscpf)%r81d, &
+          rio_bagw_fmort_flux_siscpf  => this%rvars(ir_bagw_fmort_flux_siscpf)%r81d )
 
 
        totalcohorts = 0
@@ -3068,6 +3096,11 @@ contains
                 sites(s)%term_nindivs_canopy(i_scls,i_pft) = rio_termnindiv_cano_siscpf(io_idx_si_scpf)
                 sites(s)%term_nindivs_ustory(i_scls,i_pft) = rio_termnindiv_usto_siscpf(io_idx_si_scpf)
                 sites(s)%growthflux_fusion(i_scls, i_pft)  = rio_growflx_fusion_siscpf(io_idx_si_scpf)
+
+                sites(s)%term_bagw_flux(i_scls,i_pft) = rio_bagw_term_flux_siscpf(io_idx_si_scpf)
+                sites(s)%imort_bagw_flux(i_scls,i_pft) = rio_bagw_imort_flux_siscpf(io_idx_si_scpf)
+                sites(s)%fmort_bagw_flux(i_scls,i_pft) = rio_bagw_fmort_flux_siscpf(io_idx_si_scpf)
+
                 io_idx_si_scpf = io_idx_si_scpf + 1
              end do
 

--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -211,9 +211,9 @@ module FatesRestartInterfaceMod
   integer :: ir_imortcflux_sipft
   integer :: ir_fmortcflux_cano_sipft
   integer :: ir_fmortcflux_usto_sipft
-  integer :: ir_bagw_term_flux_siscpf
-  integer :: ir_bagw_imort_flux_siscpf
-  integer :: ir_bagw_fmort_flux_siscpf
+  integer :: ir_abg_term_flux_siscpf
+  integer :: ir_abg_imort_flux_siscpf
+  integer :: ir_abg_fmort_flux_siscpf
   integer :: ir_cwdagin_flxdg
   integer :: ir_cwdbgin_flxdg
   integer :: ir_leaflittin_flxdg
@@ -1251,20 +1251,20 @@ contains
          units='', flushval = flushzero, &
          hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_termcflux_usto_sipft )
 
-   call this%set_restart_var(vname='fates_bagw_term_flux', vtype=cohort_r8, &
+   call this%set_restart_var(vname='fates_abg_term_flux', vtype=cohort_r8, &
          long_name='fates aboveground biomass loss from termination mortality', &
          units='', flushval = flushzero, &
-         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_bagw_term_flux_siscpf )
+         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_abg_term_flux_siscpf )
 
-   call this%set_restart_var(vname='fates_bagw_imort_flux', vtype=cohort_r8, &
+   call this%set_restart_var(vname='fates_abg_imort_flux', vtype=cohort_r8, &
          long_name='fates aboveground biomass loss from impact mortality', &
          units='', flushval = flushzero, &
-         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_bagw_imort_flux_siscpf )
+         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_abg_imort_flux_siscpf )
 
-   call this%set_restart_var(vname='fates_bagw_fmort_flux', vtype=cohort_r8, &
+   call this%set_restart_var(vname='fates_abg_fmort_flux', vtype=cohort_r8, &
          long_name='fates aboveground biomass loss from fire mortality', &
          units='', flushval = flushzero, &
-         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_bagw_fmort_flux_siscpf )
+         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_abg_fmort_flux_siscpf )
 
    call this%set_restart_var(vname='fates_democflux', vtype=site_r8, &
          long_name='fates diagnostic demotion carbon flux', &
@@ -1844,9 +1844,9 @@ contains
            rio_imortcflux_sipft        => this%rvars(ir_imortcflux_sipft)%r81d, &
            rio_fmortcflux_cano_sipft   => this%rvars(ir_fmortcflux_cano_sipft)%r81d, &
            rio_fmortcflux_usto_sipft   => this%rvars(ir_fmortcflux_usto_sipft)%r81d, &
-           rio_bagw_imort_flux_siscpf => this%rvars(ir_bagw_imort_flux_siscpf)%r81d, &
-           rio_bagw_fmort_flux_siscpf => this%rvars(ir_bagw_fmort_flux_siscpf)%r81d, &
-           rio_bagw_term_flux_siscpf  => this%rvars(ir_bagw_term_flux_siscpf)%r81d )
+           rio_abg_imort_flux_siscpf => this%rvars(ir_abg_imort_flux_siscpf)%r81d, &
+           rio_abg_fmort_flux_siscpf => this%rvars(ir_abg_fmort_flux_siscpf)%r81d, &
+           rio_abg_term_flux_siscpf  => this%rvars(ir_abg_term_flux_siscpf)%r81d )
            
 
        totalCohorts = 0
@@ -2220,9 +2220,9 @@ contains
                 rio_termnindiv_usto_siscpf(io_idx_si_scpf) = sites(s)%term_nindivs_ustory(i_scls,i_pft)
                 rio_growflx_fusion_siscpf(io_idx_si_scpf)  = sites(s)%growthflux_fusion(i_scls, i_pft)
 
-                rio_bagw_term_flux_siscpf(io_idx_si_scpf) = sites(s)%term_bagw_flux(i_scls, i_pft)
-                rio_bagw_imort_flux_siscpf(io_idx_si_scpf) = sites(s)%imort_bagw_flux(i_scls, i_pft)
-                rio_bagw_fmort_flux_siscpf(io_idx_si_scpf) = sites(s)%fmort_bagw_flux(i_scls, i_pft)
+                rio_abg_term_flux_siscpf(io_idx_si_scpf) = sites(s)%term_abg_flux(i_scls, i_pft)
+                rio_abg_imort_flux_siscpf(io_idx_si_scpf) = sites(s)%imort_abg_flux(i_scls, i_pft)
+                rio_abg_fmort_flux_siscpf(io_idx_si_scpf) = sites(s)%fmort_abg_flux(i_scls, i_pft)
 
                 io_idx_si_scpf = io_idx_si_scpf + 1
              end do
@@ -2684,9 +2684,9 @@ contains
           rio_imortcflux_sipft        => this%rvars(ir_imortcflux_sipft)%r81d, &
           rio_fmortcflux_cano_sipft   => this%rvars(ir_fmortcflux_cano_sipft)%r81d, &
           rio_fmortcflux_usto_sipft   => this%rvars(ir_fmortcflux_usto_sipft)%r81d, &
-          rio_bagw_term_flux_siscpf   => this%rvars(ir_bagw_term_flux_siscpf)%r81d, &
-          rio_bagw_imort_flux_siscpf  => this%rvars(ir_bagw_imort_flux_siscpf)%r81d, &
-          rio_bagw_fmort_flux_siscpf  => this%rvars(ir_bagw_fmort_flux_siscpf)%r81d )
+          rio_abg_term_flux_siscpf   => this%rvars(ir_abg_term_flux_siscpf)%r81d, &
+          rio_abg_imort_flux_siscpf  => this%rvars(ir_abg_imort_flux_siscpf)%r81d, &
+          rio_abg_fmort_flux_siscpf  => this%rvars(ir_abg_fmort_flux_siscpf)%r81d )
 
 
        totalcohorts = 0
@@ -3097,9 +3097,9 @@ contains
                 sites(s)%term_nindivs_ustory(i_scls,i_pft) = rio_termnindiv_usto_siscpf(io_idx_si_scpf)
                 sites(s)%growthflux_fusion(i_scls, i_pft)  = rio_growflx_fusion_siscpf(io_idx_si_scpf)
 
-                sites(s)%term_bagw_flux(i_scls,i_pft) = rio_bagw_term_flux_siscpf(io_idx_si_scpf)
-                sites(s)%imort_bagw_flux(i_scls,i_pft) = rio_bagw_imort_flux_siscpf(io_idx_si_scpf)
-                sites(s)%fmort_bagw_flux(i_scls,i_pft) = rio_bagw_fmort_flux_siscpf(io_idx_si_scpf)
+                sites(s)%term_abg_flux(i_scls,i_pft) = rio_abg_term_flux_siscpf(io_idx_si_scpf)
+                sites(s)%imort_abg_flux(i_scls,i_pft) = rio_abg_imort_flux_siscpf(io_idx_si_scpf)
+                sites(s)%fmort_abg_flux(i_scls,i_pft) = rio_abg_fmort_flux_siscpf(io_idx_si_scpf)
 
                 io_idx_si_scpf = io_idx_si_scpf + 1
              end do


### PR DESCRIPTION
### Description:
This PR adds two new history variables, FATES_ABOVEGROUND_MORT_SZPF and FATES_ABOVEGROUND_PROD_SZPF -  aboveground mortality and productivity carbon fluxes. These history variables will allow direct comparisons with the results from Piponiot et al. 2022, and potentially other forest plot data.

https://nph.onlinelibrary.wiley.com/doi/10.1111/nph.17995

Piponiot et al. output AWP and AWM - which they describe as “aboveground woody productivity (AWP), the flux in AGB associated with tree growth and recruitment) and aboveground woody mortality (AWM, the flux from AGB to necromass due to mortality)”. 

I think woody here refers to woody plants, rather than woody parts. AWP and AWM are described as AGB fluxes, and AGB is calculated using equations from Chave et al. 2014, and others, which I believe includes leaves (although I’m not totally sure after reading it again). Leaves are probably a very small part of biomass anyway (less than 5% according to Chave et al. 2014). To be consistent with AGB calculations in FATES, I included leaves but not reproductive tissues. Although I'm curious why reproductive tissue isn't included in AGB....
 
I wanted these variables to be FATES_ABOVEGROUND_MORTALITY_CFLUX_SZPF and FATES_ABOVEGROUND_PRODUCTIVITY_CFLUX_SZPF to be consistent with other history variables but the names were too long and the HLM failed to recognise them. I’m open to suggestions on alternatives. 

Results here are based on a 400 year run at BCI. New variables are compared with existing flux variables and with results from Piponiot et al. 


### Collaborators:
@ckoven @jenniferholm 

### Expectation of Answer Changes:
No changes expected. 


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:
![Fluxes_by_size_v_BCI](https://user-images.githubusercontent.com/10586303/197294552-ee1e616d-703c-4ec4-9c51-51190ce95950.png)

![Fluxes_through_time](https://user-images.githubusercontent.com/10586303/197295434-40364d92-8ee9-4586-9f62-214c6ed4726f.png)

