### PR TITLE
UpdateAPI tool order of operations update

### DIFF
--- a/tools/UpdateParamAPI.py
+++ b/tools/UpdateParamAPI.py
@@ -319,6 +319,7 @@ def main():
             #    usecase = mod.find('uc').text.strip()
             #except:
             #    print("no use case (uc), exiting");exit(2)
+            usecase = 'undefined'
                 
             try:
                 values = str2fvec(mod.find('val').text.strip())
@@ -344,9 +345,9 @@ def main():
                 print("Unknown value type: {} {}".format(type(values[0]),paramname));exit(2)
 
                 
-            sel_values = selectvalues(ncfile,list(dimnames),ipft_list,values,dcode)
                 
             ncfile = netcdf.netcdf_file(base_nc,"a",mmap=False)
+            sel_values = selectvalues(ncfile,list(dimnames),ipft_list,values,dcode)
             [ncfile,ncvar] = createvar(ncfile,paramname,dimnames,units,longname,usecase,dcode,sel_values)
             ncfile.flush()
             ncfile.close()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->
This PR updates the order of operations to correct an issue with the variable additions need to come after updates.  The issue is that `ncfile` is needs to be called prior to the `selectvalues` call in the add variable routine.

This also adds `undefined` as a `usecase` (as a temporary fix).

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

