### PR TITLE
Add Atkin et al 2017 leaf respiration model

### DIFF
--- a/biogeophys/FatesPlantRespPhotosynthMod.F90
+++ b/biogeophys/FatesPlantRespPhotosynthMod.F90
@@ -2071,7 +2071,7 @@ subroutine LeafLayerMaintenanceRespiration_Atkin_etal_2017(lnc_top, &
    ! and Heskel et al., 2016 https://doi.org/10.1073/pnas.1520282113
    real(r8), parameter :: b = 0.1012_r8       ! (degrees C**-1)
    real(r8), parameter :: c = -0.0005_r8      ! (degrees C**-2)
-   real(r8), parameter :: Tref = tfrz+25._r8  ! (degrees K)
+   real(r8), parameter :: TrefC = 25._r8      ! (degrees C)
    real(r8), parameter :: r_1 = 0.2061_r8     ! (umol CO2/m**2/s / (gN/(m2 leaf))) 
    real(r8), parameter :: r_2 = -0.0402_r8    ! (umol CO2/m**2/s/degree C)
 
@@ -2086,13 +2086,14 @@ subroutine LeafLayerMaintenanceRespiration_Atkin_etal_2017(lnc_top, &
    if ( nint(EDPftvarcon_inst%c3psn(ft)) == 1)then
 
       ! r_0 currently put into the EDPftvarcon_inst%dev_arbitrary_pft
+      ! all figs in Atkin et al 2017 stop at zero Celsius so we will assume acclimation is fixed below that
       r_0 = EDPftvarcon_inst%dev_arbitrary_pft(ft)
-      r_t_ref = r_0 + r_1 * lnc + r_2 * tgrowth
+      r_t_ref = r_0 + r_1 * lnc + r_2 * max(0._r8, (tgrowth - tfrz) )
 
-      lmr = r_t_ref * exp(b * (veg_tempk - Tref) + c * (veg_tempk**2 - Tref**2))
+      lmr = r_t_ref * exp(b * (veg_tempk - tfrz - TrefC) + c * ((veg_tempk-tfrz)**2 - TrefC**2))
 
    else
-      ! revert to Q10 model for C4 plants, parameter values as described above
+      ! revert to Q10 model for C4 plants, parameter values as described above in Ryan 1991 method
 
       lmr25top = 2.525e-6_r8 * (1.5_r8 ** ((25._r8 - 20._r8)/10._r8))
       lmr25top = lmr25top * lnc / (umolC_to_kgC * g_per_kg)

--- a/main/EDParamsMod.F90
+++ b/main/EDParamsMod.F90
@@ -32,7 +32,7 @@ module EDParamsMod
                                                              ! temperature acclimation (NOT YET IMPLEMENTED)
 
    integer,protected, public :: maintresp_model       ! switch for choosing between leaf maintenance
-                                                      ! respiration model. 1=Ryan (1991) (NOT YET IMPLEMENTED)
+                                                      ! respiration model. 1=Ryan (1991), 2=Atkin et al (2015), 3=Heskel et al (2016)
    integer,protected, public :: photo_tempsens_model  ! switch for choosing the model that defines the temperature
                                                       ! sensitivity of photosynthetic parameters (vcmax, jmax).
                                                       ! 1=non-acclimating (NOT YET IMPLEMENTED)

--- a/main/EDParamsMod.F90
+++ b/main/EDParamsMod.F90
@@ -32,7 +32,7 @@ module EDParamsMod
                                                              ! temperature acclimation (NOT YET IMPLEMENTED)
 
    integer,protected, public :: maintresp_model       ! switch for choosing between leaf maintenance
-                                                      ! respiration model. 1=Ryan (1991), 2=Atkin et al (2015), 3=Heskel et al (2016)
+                                                      ! respiration model. 1=Ryan (1991), 2=Atkin et al (2017)
    integer,protected, public :: photo_tempsens_model  ! switch for choosing the model that defines the temperature
                                                       ! sensitivity of photosynthetic parameters (vcmax, jmax).
                                                       ! 1=non-acclimating (NOT YET IMPLEMENTED)

--- a/main/FatesConstantsMod.F90
+++ b/main/FatesConstantsMod.F90
@@ -74,6 +74,10 @@ module FatesConstantsMod
   integer, parameter, public :: hlm_harvest_area_fraction = 1 ! Code for harvesting by area
   integer, parameter, public :: hlm_harvest_carbon = 2 ! Code for harvesting based on carbon extracted.
 
+  ! integer labels for specifying leaf maintenance respiration models
+  integer, parameter, public :: lmrmodel_ryan_1991         = 1
+  integer, parameter, public :: lmrmodel_atkin_etal_2015   = 2
+  integer, parameter, public :: lmrmodel_heskel_etal_2016  = 3
 
   ! Error Tolerances
 

--- a/main/FatesConstantsMod.F90
+++ b/main/FatesConstantsMod.F90
@@ -76,8 +76,7 @@ module FatesConstantsMod
 
   ! integer labels for specifying leaf maintenance respiration models
   integer, parameter, public :: lmrmodel_ryan_1991         = 1
-  integer, parameter, public :: lmrmodel_atkin_etal_2015   = 2
-  integer, parameter, public :: lmrmodel_heskel_etal_2016  = 3
+  integer, parameter, public :: lmrmodel_atkin_etal_2017   = 2
 
   ! Error Tolerances
 

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -1020,7 +1020,8 @@ data:
 
  fates_damage_recovery_scalar = 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ;
 
- fates_dev_arbitrary_pft = _, _, _, _, _, _, _, _, _, _, _, _ ;
+ fates_dev_arbitrary_pft = 1.7560, 1.4995, 1.4995, 1.7560, 1.7560, 1.7560, 
+    2.0749, 2.0749, 2.0749, 2.1956, 2.1956, _ ;
 
  fates_fire_alpha_SH = 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 
     0.2 ;
@@ -1490,7 +1491,7 @@ data:
 
  fates_leaf_theta_cj_c4 = 0.999 ;
 
- fates_maintresp_model = 1 ;
+ fates_maintresp_model = 2 ;
 
  fates_maxcohort = 100 ;
 


### PR DESCRIPTION
This code adds the option for a new leaf maintenance respiration model based on Atkin et al 2017.

### Description:
We've been using the Ryan 1991 https://doi.org/10.2307/1941808 maintenance respiration model in FATES so far.  Newer schemes have been developed that are based on a lot more data.  Discussion in #729 pointed to the Atkin et al 2017 https://doi.org/10.1007/978-3-319-68703-2_6 as one that is based on a very large amount of observations. The model also suggests that respiration acclimates with growing temperature, with important implications (e.g. as explored in Huntingford et al https://doi.org/10.1038/s41467-017-01774-z)

fixes #729.

Some things to think about:

(1) Vertical N scaling and how it scales with respiration: In the Ryan 1991 model leaf respiration scales directly with leaf N, both at the leaf level and therefore also at the canopy level.  Whereas in the Atkin et al 2017 model, respiration is not exactly proportional to leaf nitrogen -- there is a linear leaf N term but also an offset (due to the base PFT-dependent R_0 and growth-temperature-acclimation R_3 terms). So  I think we need to understand how this governs the vertical profiles of respiration (and thus also the vertical profiles of leaf costs vs benefits that governs LAI).

(2) This code allows respiration, but not Vcmax, to acclimate to temperature.  @alistairrogers [makes the point](https://github.com/NGEET/fates/issues/729#issuecomment-816779479) that we probably want to shift to acclimating vcmax and respiration together. So possibly we may want to keep the old respiration model the default until we also have vcmax acclimation merged and also ready to use?

(3) This code only applies to leaves of C3 plants.  Respiration from C4 plant leaves and all non-leaf organs is unchanged here.

(4) We may want to further encapsulate the C4 plant logic into its own subroutine for neatness. Also there are still some preexisting inline magic numbers in the old respiration code that could be better cleaned up and/or pulled out as parameters (Noted I think [here](https://github.com/NGEET/fates/issues/729#issuecomment-1060982197)).

(5) This code pulls out the R_0 terms as PFT parameters (which will need to be moved to a dedicated variable from their current spot in the `EDPftvarcon_inst%dev_arbitrary_pft` variable) but not the scalar parameters.  We may want to pull all of them out into the parameter file?

(6) Overall I think a key question is whether we would want to make this the default leaf respiration model prior to / as part of the larger calibration exercise or not.  This will tend to increase leaf respiration, which the model with current defaults is biased low on, but possibly require other more complex things to be worked out.

### Collaborators:
Discussion with @JessicaNeedham @jenniferholm @rgknox and also discussion in #729.

### Expectation of Answer Changes:
This will change answers if activated. If we don't activate it, it should be bit for bit.  Activating the new respiration model is via the parameter file flag `fates_maintresp_model `.


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
not yet run through test suite.

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

