### PR TITLE
Initialize `crowndamage` for Satellite Phenology mode

### DIFF
--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -808,8 +808,11 @@ contains
 
              temp_cohort%canopy_trim = 1.0_r8
 
-             !  h,dbh,leafc,n from SP values or from small initial size.
+             ! Assume no damage to begin with - since we assume no damage
+             ! we do not need to initialise branch frac just yet. 
+             temp_cohort%crowndamage = 1
 
+             !  h,dbh,leafc,n from SP values or from small initial size.
              if(hlm_use_sp.eq.itrue)then
                 init = itrue
                 ! At this point, we do not know the bc_in values of tlai tsai and htop,
@@ -820,10 +823,6 @@ contains
              else
                 temp_cohort%hite        = EDPftvarcon_inst%hgt_min(pft)
                 
-                ! Assume no damage to begin with - since we assume no damage
-                ! we do not need to initialise branch frac just yet. 
-                temp_cohort%crowndamage = 1
-
                 ! Calculate the plant diameter from height
                 call h2d_allom(temp_cohort%hite,pft,temp_cohort%dbh)
 


### PR DESCRIPTION
### Description:
This PR addresses #937, which was discovered while investigating a separate issue using elm-fates on perlmutter.  Note that the `gnu` compiler is the default compiler for perlmutter (`intel` is not available).

### Collaborators:
@JessicaNeedham 

### Expectation of Answer Changes:
No changes expected

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

