### PR TITLE
Make sure that the bareground patch is being labeled with `patchno` of zero

### DIFF
--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -10,6 +10,7 @@ module EDCanopyStructureMod
   use FatesConstantsMod     , only : tinyr8
   use FatesConstantsMod     , only : nearzero
   use FatesConstantsMod     , only : rsnbl_math_prec
+  use FatesConstantsMod     , only : nocomp_bareground
   use FatesGlobals          , only : fates_log
   use EDPftvarcon           , only : EDPftvarcon_inst
   use PRTParametersMod      , only : prt_params
@@ -1369,7 +1370,7 @@ contains
              endif
 
              ! adding checks for SP and NOCOMP modes.
-             if(currentPatch%nocomp_pft_label.eq.0)then
+             if(currentPatch%nocomp_pft_label.eq.nocomp_bareground)then
                 write(fates_log(),*) 'cohorts in barepatch',currentPatch%total_canopy_area,currentPatch%nocomp_pft_label
                 call endrun(msg=errMsg(sourcefile, __LINE__))
              end if
@@ -1828,7 +1829,7 @@ contains
        c = fcolumn(s)
        do while(associated(currentPatch))
 
-          if(currentPatch%nocomp_pft_label.ne.0)then  ! ignore the bare-ground-PFT patch entirely for these BC outs
+          if(currentPatch%nocomp_pft_label.ne.nocomp_bareground)then  ! ignore the bare-ground-PFT patch entirely for these BC outs
 
              ifp = ifp+1
 
@@ -1970,7 +1971,7 @@ contains
           currentPatch => sites(s)%oldest_patch
           ifp = 0
           do while(associated(currentPatch))
-             if(currentPatch%nocomp_pft_label.ne.0)then ! for vegetated patches only
+             if(currentPatch%nocomp_pft_label.ne.nocomp_bareground)then ! for vegetated patches only
                 ifp = ifp+1
                 bc_out(s)%canopy_fraction_pa(ifp) = bc_out(s)%canopy_fraction_pa(ifp)/total_patch_area
              endif ! veg patch

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -2027,7 +2027,7 @@ contains
     real(r8), intent(in) :: age                  ! notional age of this patch in years
     real(r8), intent(in) :: areap                ! initial area of this patch in m2. 
     integer, intent(in)  :: label                ! anthropogenic disturbance label
-    integer, intent(in)  :: nocomp_pft
+    integer, intent(in)  :: nocomp_pft           ! no competition mode pft label
 
 
     ! Until bc's are pointed to by sites give veg a default temp [K]

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -39,6 +39,7 @@ module EDPatchDynamicsMod
   use EDTypesMod           , only : AREA_INV
   use FatesConstantsMod    , only : rsnbl_math_prec
   use FatesConstantsMod    , only : fates_tiny
+  use FatesConstantsMod    , only : nocomp_bareground
   use FatesInterfaceTypesMod    , only : hlm_use_planthydro
   use FatesInterfaceTypesMod    , only : hlm_numSWb
   use FatesInterfaceTypesMod    , only : bc_in_type
@@ -1286,7 +1287,7 @@ contains
       patchno = 1
       currentPatch => currentSite%oldest_patch
       do while(associated(currentPatch))
-        if(currentPatch%nocomp_pft_label.eq.0)then
+        if(currentPatch%nocomp_pft_label.eq.nocomp_bareground)then
          ! for bareground patch, we make the patch number 0
          ! we also do not count this in the veg. patch numbering scheme.
           currentPatch%patchno = 0

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -1282,7 +1282,7 @@ contains
        currentPatch => currentPatch%younger
     enddo
 
-    if(hlm_use_sp.eq.itrue)then
+    if(hlm_use_fixed_biogeog.eq.itrue .and. hlm_use_nocomp.eq.itrue)then
       patchno = 1
       currentPatch => currentSite%oldest_patch
       do while(associated(currentPatch))

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -23,6 +23,7 @@ module EDPhysiologyMod
   use FatesInterfaceTypesMod, only    : hlm_use_tree_damage
   use FatesConstantsMod, only    : r8 => fates_r8
   use FatesConstantsMod, only    : nearzero
+  use FatesConstantsMod, only    : nocomp_bareground
   use EDPftvarcon      , only    : EDPftvarcon_inst
   use PRTParametersMod , only    : prt_params
   use EDPftvarcon      , only    : GetDecompyFrac
@@ -2668,7 +2669,7 @@ contains
     catanf(t1) = 11.75_r8 +(29.7_r8 / pi) * atan( pi * 0.031_r8  * ( t1 - 15.4_r8 ))
     catanf_30 = catanf(30._r8)
 
-    if(currentPatch%nocomp_pft_label.ne.0)then
+    if(currentPatch%nocomp_pft_label.ne.nocomp_bareground)then
 
        ! Use the hlm temp and moisture decomp fractions by default
        if ( use_hlm_soil_scalar ) then

--- a/biogeophys/EDAccumulateFluxesMod.F90
+++ b/biogeophys/EDAccumulateFluxesMod.F90
@@ -13,6 +13,7 @@ module EDAccumulateFluxesMod
   use FatesGlobals, only      : fates_log
   use shr_log_mod , only      : errMsg => shr_log_errMsg
   use FatesConstantsMod , only : r8 => fates_r8
+  use FatesConstantsMod , only : nocomp_bareground
 
 
   implicit none
@@ -64,7 +65,7 @@ contains
 
        cpatch => sites(s)%oldest_patch
        do while (associated(cpatch))                 
-          if(cpatch%nocomp_pft_label.ne.0)then
+          if(cpatch%nocomp_pft_label.ne.nocomp_bareground)then
              ifp = ifp+1
 
              if( bc_in(s)%filter_photo_pa(ifp) == 3 ) then

--- a/biogeophys/EDBtranMod.F90
+++ b/biogeophys/EDBtranMod.F90
@@ -8,6 +8,7 @@ module EDBtranMod
   use EDPftvarcon       , only : EDPftvarcon_inst
   use FatesConstantsMod , only : tfrz => t_water_freeze_k_1atm 
   use FatesConstantsMod , only : itrue,ifalse,nearzero
+  use FatesConstantsMod , only : nocomp_bareground
   use EDTypesMod        , only : ed_site_type,       &
        ed_patch_type,      &
        ed_cohort_type,     &
@@ -138,7 +139,7 @@ contains
        ifp = 0
        cpatch => sites(s)%oldest_patch
        do while (associated(cpatch))                 
-          if(cpatch%nocomp_pft_label.ne.0)then ! only for veg patches
+          if(cpatch%nocomp_pft_label.ne.nocomp_bareground)then ! only for veg patches
              ifp=ifp+1
 
              ! THIS SHOULD REALLY BE A COHORT LOOP ONCE WE HAVE rootfr_ft FOR COHORTS (RGK)

--- a/biogeophys/EDSurfaceAlbedoMod.F90
+++ b/biogeophys/EDSurfaceAlbedoMod.F90
@@ -15,6 +15,7 @@ module EDSurfaceRadiationMod
   use FatesConstantsMod , only : r8 => fates_r8
   use FatesConstantsMod , only : itrue
   use FatesConstantsMod , only : pi_const
+  use FatesConstantsMod , only : nocomp_bareground
   use FatesInterfaceTypesMod , only : bc_in_type
   use FatesInterfaceTypesMod , only : bc_out_type
   use FatesInterfaceTypesMod , only : hlm_numSWb
@@ -100,7 +101,7 @@ contains
        ifp = 0
        currentpatch => sites(s)%oldest_patch
        do while (associated(currentpatch))
-          if(currentpatch%nocomp_pft_label.ne.0)then
+          if(currentpatch%nocomp_pft_label.ne.nocomp_bareground)then
              ! do not do albedo calculations for bare ground patch in SP mode
              ! and (more impotantly) do not iterate ifp or it will mess up the indexing wherein
              ! ifp=1 is the first vegetated patch.
@@ -1147,7 +1148,7 @@ subroutine ED_SunShadeFracs(nsites, sites,bc_in,bc_out)
      cpatch => sites(s)%oldest_patch
 
      do while (associated(cpatch))
-        if(cpatch%nocomp_pft_label.ne.0)then !only for veg patches
+        if(cpatch%nocomp_pft_label.ne.nocomp_bareground)then !only for veg patches
            ! do not do albedo calculations for bare ground patch in SP mode
            ! and (more impotantly) do not iterate ifp or it will mess up the indexing wherein
            ! ifp=1 is the first vegetated patch.

--- a/biogeophys/FatesPlantHydraulicsMod.F90
+++ b/biogeophys/FatesPlantHydraulicsMod.F90
@@ -42,6 +42,7 @@ module FatesPlantHydraulicsMod
   use FatesConstantsMod, only : cm3_per_m3
   use FatesConstantsMod, only : kg_per_g
   use FatesConstantsMod, only : fates_unset_r8
+  use FatesConstantsMod, only : nocomp_bareground
 
   use EDParamsMod       , only : hydr_kmax_rsurf1
   use EDParamsMod       , only : hydr_kmax_rsurf2
@@ -2546,7 +2547,7 @@ subroutine hydraulics_bc ( nsites, sites, bc_in, bc_out, dtime)
      ifp = 0
      cpatch => sites(s)%oldest_patch
      do while (associated(cpatch))
-        if(cpatch%nocomp_pft_label.ne.0)then
+        if(cpatch%nocomp_pft_label.ne.nocomp_bareground)then
            ifp = ifp + 1
 
            ! ----------------------------------------------------------------------------

--- a/biogeophys/FatesPlantRespPhotosynthMod.F90
+++ b/biogeophys/FatesPlantRespPhotosynthMod.F90
@@ -31,6 +31,7 @@ module FATESPlantRespPhotosynthMod
   use FatesConstantsMod, only : rgas_J_K_mol
   use FatesConstantsMod, only : fates_unset_r8
   use FatesConstantsMod, only : tfrz => t_water_freeze_k_1atm
+  use FatesConstantsMod, only : nocomp_bareground
   use FatesInterfaceTypesMod, only : hlm_use_planthydro
   use FatesInterfaceTypesMod, only : hlm_parteh_mode
   use FatesInterfaceTypesMod, only : numpft
@@ -324,7 +325,7 @@ contains
        ifp = 0
        currentpatch => sites(s)%oldest_patch
        do while (associated(currentpatch))
-          if(currentpatch%nocomp_pft_label.ne.0)then
+          if(currentpatch%nocomp_pft_label.ne.nocomp_bareground)then
              ifp   = ifp+1
              NCL_p = currentPatch%NCL_p
 

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -87,7 +87,7 @@ contains
     type (ed_patch_type), pointer :: currentPatch
 
     !zero fire things
-    currentPatch => currentSite%oldest_patch
+    currentPatch => currentSite%youngest_patch
     do while(associated(currentPatch))
        currentPatch%frac_burnt = 0.0_r8
        currentPatch%fire       = 0

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -8,6 +8,7 @@
   use FatesConstantsMod     , only : r8 => fates_r8
   use FatesConstantsMod     , only : itrue, ifalse
   use FatesConstantsMod     , only : pi_const
+  use FatesConstantsMod     , only : nocomp_bareground
   use FatesInterfaceTypesMod     , only : hlm_masterproc ! 1= master process, 0=not master process
   use EDTypesMod            , only : numWaterMem
   use FatesGlobals          , only : fates_log
@@ -185,7 +186,7 @@ contains
     currentPatch => currentSite%oldest_patch; 
     do while(associated(currentPatch))  
 
-       if(currentPatch%nocomp_pft_label .ne. 0)then
+       if(currentPatch%nocomp_pft_label .ne. nocomp_bareground)then
 
        litt_c => currentPatch%litter(element_pos(carbon12_element))
        
@@ -375,7 +376,7 @@ contains
     currentPatch=>currentSite%oldest_patch;  
     do while(associated(currentPatch))
 
-       if(currentPatch%nocomp_pft_label .ne. 0)then
+       if(currentPatch%nocomp_pft_label .ne. nocomp_bareground)then
        
        currentPatch%total_tree_area = 0.0_r8
        total_grass_area = 0.0_r8
@@ -416,7 +417,7 @@ contains
     currentPatch=>currentSite%oldest_patch;
 
     do while(associated(currentPatch))       
-       if(currentPatch%nocomp_pft_label .ne. 0)then
+       if(currentPatch%nocomp_pft_label .ne. nocomp_bareground)then
 
        currentPatch%total_tree_area = min(currentPatch%total_tree_area,currentPatch%area)
        ! effect_wspeed in units m/min      
@@ -462,7 +463,7 @@ contains
 
     do while(associated(currentPatch))
 
-       if(currentPatch%nocomp_pft_label .ne. 0)then
+       if(currentPatch%nocomp_pft_label .ne. nocomp_bareground)then
               
        ! remove mineral content from net fuel load per Thonicke 2010 for ir calculation
        currentPatch%sum_fuel  = currentPatch%sum_fuel * (1.0_r8 - SF_val_miner_total) !net of minerals
@@ -598,7 +599,7 @@ contains
 
     do while(associated(currentPatch))
 
-       if(currentPatch%nocomp_pft_label .ne. 0)then
+       if(currentPatch%nocomp_pft_label .ne. nocomp_bareground)then
 
        currentPatch%burnt_frac_litter(:) = 1.0_r8       
        ! Calculate fraction of litter is burnt for all classes. 
@@ -746,7 +747,7 @@ contains
     currentPatch => currentSite%oldest_patch;  
     do while(associated(currentPatch))
 
-       if(currentPatch%nocomp_pft_label .ne. 0)then
+       if(currentPatch%nocomp_pft_label .ne. nocomp_bareground)then
 
        !  ---initialize patch parameters to zero---
        currentPatch%FI         = 0._r8
@@ -885,7 +886,7 @@ contains
     currentPatch => currentSite%oldest_patch;  
     do while(associated(currentPatch)) 
 
-       if(currentPatch%nocomp_pft_label .ne. 0)then
+       if(currentPatch%nocomp_pft_label .ne. nocomp_bareground)then
        
        tree_ag_biomass = 0.0_r8
        if (currentPatch%fire == 1) then
@@ -943,7 +944,7 @@ contains
 
     do while(associated(currentPatch)) 
 
-       if(currentPatch%nocomp_pft_label .ne. 0)then
+       if(currentPatch%nocomp_pft_label .ne. nocomp_bareground)then
        if (currentPatch%fire == 1) then
 
           currentCohort=>currentPatch%tallest
@@ -1012,7 +1013,7 @@ contains
 
     do while(associated(currentPatch)) 
 
-       if(currentPatch%nocomp_pft_label .ne. 0)then
+       if(currentPatch%nocomp_pft_label .ne. nocomp_bareground)then
 
        if (currentPatch%fire == 1) then
           currentCohort => currentPatch%tallest;
@@ -1065,7 +1066,7 @@ contains
 
     do while(associated(currentPatch)) 
 
-       if(currentPatch%nocomp_pft_label .ne. 0)then
+       if(currentPatch%nocomp_pft_label .ne. nocomp_bareground)then
 
        if (currentPatch%fire == 1) then 
           currentCohort => currentPatch%tallest

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -153,7 +153,7 @@ contains
 
     iofp = currentPatch%patchno
     
-    temp_in_C  = currentSite%currentPatch%tveg24%GetMean() - tfrz
+    temp_in_C  = currentPatch%tveg24%GetMean() - tfrz
     rainfall   = bc_in%precip24_pa(iofp)*sec_per_day
     rh         = bc_in%relhumid24_pa(iofp)
     

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -168,7 +168,7 @@ contains
     allocate(site_in%dz_soil(site_in%nlevsoil))
     allocate(site_in%z_soil(site_in%nlevsoil))
 
-    if (hlm_use_nocomp .eq. itrue) then
+    if (hlm_use_nocomp .eq. itrue .and. hlm_use_fixed_biogeog .eq. itrue) then
        allocate(site_in%area_pft(0:numpft))
     else  ! SP and nocomp require a bare-ground patch.
        allocate(site_in%area_pft(1:numpft))  
@@ -384,6 +384,7 @@ contains
           sites(s)%acc_NI     = acc_NI
           sites(s)%NF         = 0.0_r8
           sites(s)%NF_successful  = 0.0_r8
+          sites(s)%area_pft(:) = 0.0_r8
 
           do ft =  1,numpft
              sites(s)%rec_l2fr(ft,:) = prt_params%allom_l2fr(ft)
@@ -399,7 +400,6 @@ contains
              ! where pft_areafrac is the area of land in each HLM PFT and (from surface dataset)
              ! hlm_pft_map is the area of that land in each FATES PFT (from param file)
 
-             sites(s)%area_pft(1:numpft) = 0._r8
              do hlm_pft = 1,size( EDPftvarcon_inst%hlm_pft_map,2)
                 do fates_pft = 1,numpft ! loop round all fates pfts for all hlm pfts
                    sites(s)%area_pft(fates_pft) = sites(s)%area_pft(fates_pft) + &
@@ -453,8 +453,6 @@ contains
 
                 if(sumarea.lt.area)then !make some bare ground
                    sites(s)%area_pft(0) = area - sumarea
-                else
-                   sites(s)%area_pft(0) = 0.0_r8
                 end if
              end if !sp mode
           end if !fixed biogeog

--- a/main/EDMainMod.F90
+++ b/main/EDMainMod.F90
@@ -208,7 +208,15 @@ contains
 
 
     if (hlm_use_ed_st3.eq.ifalse.and.hlm_use_sp.eq.ifalse) then   ! Bypass if ST3
-       call fire_model(currentSite, bc_in)
+       
+       ! Check that the site doesn't consist solely of a single bareground patch.
+       ! If so, skip the fire model.  Since the bareground patch should be the
+       ! oldest patch per set_patchno, we check that the youngest patch isn't zero.
+       ! If there are multiple patches on the site, the bareground patch is avoided
+       ! at the level of the fire_model subroutines.
+       if (currentSite%youngest_patch%patchno .ne. 0) then 
+          call fire_model(currentSite, bc_in)
+       end if
 
        ! Calculate disturbance and mortality based on previous timestep vegetation.
        ! disturbance_rates calls logging mortality and other mortalities, Yi Xu

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -441,6 +441,9 @@ module EDTypesMod
                                                                  ! leaf photosynthesis acclimation timescale [K]
 
      integer  ::  nocomp_pft_label                               ! Where nocomp is active, use this label for patch ID.
+                                                                 ! Each patch ID corresponds to a pft number since each
+                                                                 ! patch has only one pft.  Bareground patches are given
+                                                                 ! a zero integer as a label.
                                                                  ! If nocomp is not active this is set to unset.
                                                                  ! This is set in create_patch as an argument
                                                                  ! to that procedure.

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -440,7 +440,10 @@ module EDTypesMod
      class(rmean_type), pointer :: tveg_lpa                      ! Running mean of vegetation temperature at the
                                                                  ! leaf photosynthesis acclimation timescale [K]
 
-     integer  ::  nocomp_pft_label                               ! where nocomp is active, use this label for patch ID.   
+     integer  ::  nocomp_pft_label                               ! Where nocomp is active, use this label for patch ID.
+                                                                 ! If nocomp is not active this is set to unset.
+                                                                 ! This is set in create_patch as an argument
+                                                                 ! to that procedure.
 
 
      ! LEAF ORGANIZATION

--- a/main/FatesConstantsMod.F90
+++ b/main/FatesConstantsMod.F90
@@ -35,6 +35,8 @@ module FatesConstantsMod
   integer, parameter, public :: primaryforest = 1
   integer, parameter, public :: secondaryforest = 2
 
+  ! Bareground label for no competition mode
+  integer, parameter, public :: nocomp_bareground = 0
 
   ! Flags specifying how phosphorous uptake and turnover interacts
   ! with the host model.

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -4273,7 +4273,7 @@ end subroutine flush_hvars
          canopy_area_by_age(1:nlevage) = 0._r8
          
          ! Calculate the site-level total vegetated area (i.e. non-bareground)
-         if (hlm_use_nocomp .eq. itrue) then
+         if (hlm_use_nocomp .eq. itrue .and. hlm_use_fixed_biogeog .eq. itrue) then
             site_area_veg = area - sites(s)%area_pft(0)
          else
             site_area_veg = area

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -52,6 +52,7 @@ module FatesHistoryInterfaceMod
   use FatesInterfaceTypesMod        , only : hlm_model_day
   use FatesInterfaceTypesMod        , only : nlevcoage
   use FatesInterfaceTypesMod        , only : hlm_use_nocomp
+  use FatesInterfaceTypesMod        , only : hlm_use_fixed_biogeog
   use FatesAllometryMod             , only : CrownDepth
   use FatesAllometryMod             , only : bstore_allom
   use FatesAllometryMod             , only : set_root_fraction

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -4274,10 +4274,9 @@ end subroutine flush_hvars
          canopy_area_by_age(1:nlevage) = 0._r8
          
          ! Calculate the site-level total vegetated area (i.e. non-bareground)
+         site_area_veg = area
          if (hlm_use_nocomp .eq. itrue .and. hlm_use_fixed_biogeog .eq. itrue) then
             site_area_veg = area - sites(s)%area_pft(0)
-         else
-            site_area_veg = area
          end if
 
          cpatch => sites(s)%oldest_patch


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
Fixes #973.    

This PR includes the main fix for the issue #973 and includes some additional code clean up.

The main fix is encapsulated in b5cadd5703f37920b1c19d656d4603f691e021cb, which makes sure that the patch number is set correctly for bare ground patches in all nocomp+fbg modes (which is inclusive of sp mode).  

In troubleshooting this bug, it was noted that we only ever set the bareground patch area for fbg + nocomp modes.  Previously we had been allocating and checking for bareground patches as long as nocomp was set, which was fine although technically too permissive.  As such, I've restricted the allocation and check to match the cases in which we set the bareground area (i.e. fbg + nocomp and sp mode).  

Finally, this update required adding checks around and within the fire model as the current ncar test mods allow spitfire to be on in scalar lightning mode for all reduced complexity modes, excepting sp mode.

### Collaborators:
@JessicaNeedham

### Expectation of Answer Changes:
Should be b4b, except for the fbg+nocomp testmod.

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:

CTSM (or) E3SM (specify which) test hash-tag: 
- e3sm: 8d5d9ec327 (locally merged from https://github.com/E3SM-Project/E3SM/pull/5106/commits/3730a54295a0fe8d85af20bc176b586acd800929)
- ctsm: [ctsm5.1.dev115](https://github.com/ESCOMP/CTSM/releases/tag/ctsm5.1.dev115)

CTSM (or) E3SM (specify which) baseline hash-tag: 
- ctsm: [ctsm5.1.dev115](https://github.com/ESCOMP/CTSM/releases/tag/ctsm5.1.dev115)

FATES baseline hash-tag: [sci.1.61.0_api.25.0.0](https://github.com/NGEET/fates/releases/tag/sci.1.61.0_api.25.0.0)

Test Output:

E3SM passing case:
```
/global/homes/g/glemieux/cori-scratch/e3sm-cases/issue793test_shijie_nocomp_tempC-nodiag.fates-sci.1.61.0_api.25.0.0-v2.1.0-C8d5d9ec327-F8131daee.intel/
```

CTSM regression tests:
`/glade/u/home/glemieux/scratch/ctsm-tests/tests_pr976-fates`

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

