### PR TITLE
Split associate statement to avoid NAG compiler line continuation issue

### DIFF
--- a/biogeochem/FatesAllometryMod.F90
+++ b/biogeochem/FatesAllometryMod.F90
@@ -905,9 +905,9 @@ contains
     real(r8),intent(in)           :: canopy_trim
     real(r8),intent(out)          :: sapw_area   ! cross section area of
                                                  ! plant sapwood at reference [m2]
-    real(r8),intent(out)          :: bsap        ! plant leaf biomass [kgC]
-    real(r8),intent(out),optional :: dbsapdd     ! change leaf biomass
-                                                 !  per d [kgC/cm]
+    real(r8),intent(out)          :: bsap        ! sapwood biomass [kgC]
+    real(r8),intent(out),optional :: dbsapdd     ! change in sapwood biomass
+                                                 ! per d [kgC/cm]
 
     real(r8) :: h         ! Plant height [m]
     real(r8) :: dhdd

--- a/biogeochem/FatesAllometryMod.F90
+++ b/biogeochem/FatesAllometryMod.F90
@@ -553,7 +553,7 @@ contains
     integer(i4),intent(in) :: ipft          ! PFT index
     integer(i4),intent(in) :: crowndamage   ! crown damage class [1: undamaged, >1: damaged]
     real(r8),intent(in)    :: canopy_trim   ! trimming function
-    real(r8),intent(out)   :: bl            ! plant leaf biomass [kg]
+    real(r8),intent(out)   :: bl            ! plant leaf biomass [kgC]
     real(r8),intent(out),optional :: dbldd  ! change leaf bio per diameter [kgC/cm]
     
     real(r8) :: blmax

--- a/main/EDParamsMod.F90
+++ b/main/EDParamsMod.F90
@@ -38,39 +38,38 @@ module EDParamsMod
                                                       ! 1=non-acclimating, 2=Kumarathunge et al., 2019
    
    real(r8),protected, public :: fates_mortality_disturbance_fraction ! the fraction of canopy mortality that results in disturbance
-   real(r8),protected, public :: ED_val_comp_excln
-   real(r8),protected, public :: ED_val_vai_top_bin_width
-   real(r8),protected, public :: ED_val_vai_width_increase_factor
-   real(r8),protected, public :: ED_val_nignitions
-   real(r8),protected, public :: ED_val_understorey_death
-   real(r8),protected, public :: ED_val_cwd_fcel
-   real(r8),protected, public :: ED_val_cwd_flig
-   real(r8),protected, public :: maintresp_nonleaf_baserate
-   real(r8),protected, public :: ED_val_phen_drought_threshold
-   real(r8),protected, public :: ED_val_phen_doff_time
-   real(r8),protected, public :: ED_val_phen_a
-   real(r8),protected, public :: ED_val_phen_b
-   real(r8),protected, public :: ED_val_phen_c
-   real(r8),protected, public :: ED_val_phen_chiltemp
-   real(r8),protected, public :: ED_val_phen_mindayson
-   real(r8),protected, public :: ED_val_phen_ncolddayslim
-   real(r8),protected, public :: ED_val_phen_coldtemp
-   real(r8),protected, public :: ED_val_cohort_size_fusion_tol
-   real(r8),protected, public :: ED_val_cohort_age_fusion_tol
-   real(r8),protected, public :: ED_val_patch_fusion_tol
-   real(r8),protected, public :: ED_val_canopy_closure_thresh ! site-level canopy closure point where trees take on forest (narrow) versus savannah (wide) crown allometry
-   integer,protected, public  :: stomatal_model  !switch for choosing between stomatal conductance models, 1 for Ball-Berry, 2 for Medlyn
+   real(r8),protected, public :: ED_val_comp_excln                    ! weighting factor for canopy layer exclusion and promotion
+   real(r8),protected, public :: ED_val_vai_top_bin_width             ! width in VAI units of uppermost leaf+stem layer scattering element
+   real(r8),protected, public :: ED_val_vai_width_increase_factor     ! factor by which each leaf+stem scattering element increases in VAI width
+   real(r8),protected, public :: ED_val_nignitions                    ! number of annual ignitions per square km
+   real(r8),protected, public :: ED_val_understorey_death             ! fraction of plants in understorey cohort impacted by overstorey tree-fall
+   real(r8),protected, public :: ED_val_cwd_fcel                      ! Cellulose fraction for CWD
+   real(r8),protected, public :: ED_val_cwd_flig                      ! Lignin fraction of coarse woody debris
+   real(r8),protected, public :: maintresp_nonleaf_baserate           ! Base maintenance respiration rate for plant tissues
+   real(r8),protected, public :: ED_val_phen_drought_threshold        ! threshold for drought phenology
+   real(r8),protected, public :: ED_val_phen_doff_time                ! day threshold compared against days since leaves became off-allometry
+   real(r8),protected, public :: ED_val_phen_a                        ! GDD accumulation function, intercept parameter: gdd_thesh = a + b exp(c*ncd)
+   real(r8),protected, public :: ED_val_phen_b                        ! GDD accumulation function, multiplier parameter: gdd_thesh = a + b exp(c*ncd)
+   real(r8),protected, public :: ED_val_phen_c                        ! GDD accumulation function, exponent parameter: gdd_thesh = a + b exp(c*ncd)
+   real(r8),protected, public :: ED_val_phen_chiltemp                 ! chilling day counting threshold for vegetation
+   real(r8),protected, public :: ED_val_phen_mindayson                ! day threshold compared against days since leaves became on-allometry
+   real(r8),protected, public :: ED_val_phen_ncolddayslim             ! day threshold exceedance for temperature leaf-drop
+   real(r8),protected, public :: ED_val_phen_coldtemp                 ! vegetation temperature exceedance that flags a cold-day for leaf-drop
+   real(r8),protected, public :: ED_val_cohort_size_fusion_tol        ! minimum fraction in difference in dbh between cohorts
+   real(r8),protected, public :: ED_val_cohort_age_fusion_tol         ! minimum fraction in differece in cohort age between cohorts
+   real(r8),protected, public :: ED_val_patch_fusion_tol              ! minimum fraction in difference in profiles between patches
+   real(r8),protected, public :: ED_val_canopy_closure_thresh         ! site-level canopy closure point where trees take on forest (narrow) versus savannah (wide) crown allometry
+   integer,protected, public  :: stomatal_model                       ! switch for choosing between stomatal conductance models, 1 for Ball-Berry, 2 for Medlyn
    
    logical,protected, public :: active_crown_fire        ! flag, 1=active crown fire 0=no active crown fire
    character(len=param_string_length),parameter :: fates_name_active_crown_fire = "fates_fire_active_crown_fire"
-
 
    real(r8), protected, public :: cg_strikes             ! fraction of cloud to ground lightning strikes (0-1)
    character(len=param_string_length),parameter :: fates_name_cg_strikes="fates_fire_cg_strikes"
 
    ! empirical curvature parameters for ac, aj photosynthesis co-limitation, c3 and c4 plants respectively
-   real(r8),protected,public  :: theta_cj_c3
-   real(r8),protected,public  :: theta_cj_c4
+   real(r8),protected,public  :: theta_cj_c3    ! Empirical curvature parameter for ac, aj photosynthesis co-limitation in c3 plants
+   real(r8),protected,public  :: theta_cj_c4    ! Empirical curvature parameter for ac, aj photosynthesis co-limitation in c4 plants
    
    real(r8),protected,public  :: q10_mr     ! Q10 for respiration rate (for soil fragmenation and plant respiration)    (unitless)
    real(r8),protected,public  :: q10_froz   ! Q10 for frozen-soil respiration rates (for soil fragmentation)            (unitless)
@@ -78,7 +77,7 @@ module EDParamsMod
    ! Unassociated pft dimensioned free parameter that developers can use for testing arbitrary new hypotheses
    ! (THIS PARAMETER IS UNUSED, FEEL FREE TO USE IT FOR WHATEVER PURPOSE YOU LIKE. WE CAN
    !  HELP MIGRATE YOUR USAGE OF THE PARMETER TO A PERMANENT HOME LATER)
-   real(r8),protected,public  :: dev_arbitrary 
+   real(r8),protected,public  :: dev_arbitrary  ! Unassociated free parameter that developers can use for testing arbitrary new hypotheses
    character(len=param_string_length),parameter,public :: name_dev_arbitrary = "fates_dev_arbitrary"
    
    ! parameters whose size is defined in the parameter file

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -87,31 +87,31 @@ module EDPftvarcon
      real(r8), allocatable :: maintresp_leaf_ryan1991_baserate(:)  ! leaf maintenance respiration per Ryan et al 1991
 
      real(r8), allocatable :: bmort(:)
-     real(r8), allocatable :: mort_ip_size_senescence(:)  ! inflection point of dbh dependent senescence
-     real(r8), allocatable :: mort_r_size_senescence(:) ! rate of change in mortality with dbh
-     real(r8), allocatable :: mort_ip_age_senescence(:) ! inflection point of age dependent senescence
-     real(r8), allocatable :: mort_r_age_senescence(:) ! rate of change in mortality with age
-     real(r8), allocatable :: mort_scalar_coldstress(:)
-     real(r8), allocatable :: mort_scalar_cstarvation(:)
-     real(r8), allocatable :: mort_scalar_hydrfailure(:)
-     real(r8), allocatable :: hf_sm_threshold(:)
-     real(r8), allocatable :: hf_flc_threshold(:)
-     real(r8), allocatable :: vcmaxha(:)
-     real(r8), allocatable :: jmaxha(:)
-     real(r8), allocatable :: vcmaxhd(:)
-     real(r8), allocatable :: jmaxhd(:)
-     real(r8), allocatable :: vcmaxse(:)
-     real(r8), allocatable :: jmaxse(:)
+     real(r8), allocatable :: mort_ip_size_senescence(:) ! inflection point of dbh dependent senescence
+     real(r8), allocatable :: mort_r_size_senescence(:)  ! rate of change in mortality with dbh
+     real(r8), allocatable :: mort_ip_age_senescence(:)  ! inflection point of age dependent senescence
+     real(r8), allocatable :: mort_r_age_senescence(:)   ! rate of change in mortality with age
+     real(r8), allocatable :: mort_scalar_coldstress(:)  ! maximum mortality rate from cold stress
+     real(r8), allocatable :: mort_scalar_cstarvation(:) ! maximum mortality rate from carbon starvation
+     real(r8), allocatable :: mort_scalar_hydrfailure(:) ! maximum mortality rate from hydraulic failure
+     real(r8), allocatable :: hf_sm_threshold(:)         ! soil moisture (btran units) at which drought mortality begins for non-hydraulic model
+     real(r8), allocatable :: hf_flc_threshold(:)        ! plant fractional loss of conductivity at which drought mortality begins for hydraulic model
+     real(r8), allocatable :: vcmaxha(:)                 ! activation energy for vcmax
+     real(r8), allocatable :: jmaxha(:)                  ! activation energy for jmax
+     real(r8), allocatable :: vcmaxhd(:)                 ! deactivation energy for vcmax
+     real(r8), allocatable :: jmaxhd(:)                  ! deactivation energy for jmax
+     real(r8), allocatable :: vcmaxse(:)                 ! entropy term for vcmax
+     real(r8), allocatable :: jmaxse(:)                  ! entropy term for jmax
      real(r8), allocatable :: germination_rate(:)        ! Fraction of seed mass germinating per year (yr-1)
      real(r8), allocatable :: seed_decay_rate(:)         ! Fraction of seed mass (both germinated and
                                                          ! ungerminated), decaying per year    (yr-1)
 
      real(r8), allocatable :: trim_limit(:)              ! Limit to reductions in leaf area w stress (m2/m2)
      real(r8), allocatable :: trim_inc(:)                ! Incremental change in trimming function   (m2/m2)
-     real(r8), allocatable :: rhol(:, :)
-     real(r8), allocatable :: rhos(:, :)
-     real(r8), allocatable :: taul(:, :)
-     real(r8), allocatable :: taus(:, :)
+     real(r8), allocatable :: rhol(:, :)                 ! Leaf reflectance; second dim: 1 = vis, 2 = nir
+     real(r8), allocatable :: rhos(:, :)                 ! Stem reflectance; second dim: 1 = vis, 2 = nir
+     real(r8), allocatable :: taul(:, :)                 ! Leaf transmittance; second dim: 1 = vis, 2 = nir
+     real(r8), allocatable :: taus(:, :)                 ! Stem transmittance; second dim: 1 = vis, 2 = nir
 
      ! Fire Parameters (No PFT vector capabilities in their own routines)
      ! See fire/SFParamsMod.F90 for bulk of fire parameters

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -2473,8 +2473,10 @@ end subroutine flush_hvars
                hio_mortality_canopy_si_scag         => this%hvars(ih_mortality_canopy_si_scag)%r82d, &
                hio_mortality_understory_si_scag     => this%hvars(ih_mortality_understory_si_scag)%r82d, &
                hio_site_cstatus_si                  => this%hvars(ih_site_cstatus_si)%r81d, &
-               hio_site_dstatus_si                  => this%hvars(ih_site_dstatus_si)%r81d, &
-               hio_gdd_si                           => this%hvars(ih_gdd_si)%r81d, &
+               hio_site_dstatus_si                  => this%hvars(ih_site_dstatus_si)%r81d )
+
+    ! Split up the associate statement as the nag compiler has a limit on line continuation  
+    associate( hio_gdd_si                           => this%hvars(ih_gdd_si)%r81d, &
                hio_site_ncolddays_si                => this%hvars(ih_site_ncolddays_si)%r81d, &
                hio_site_nchilldays_si               => this%hvars(ih_site_nchilldays_si)%r81d, &
                hio_cleafoff_si                      => this%hvars(ih_cleafoff_si)%r81d, &
@@ -4323,6 +4325,7 @@ end subroutine flush_hvars
 
    enddo siteloop ! site loop
 
+   end associate
    end associate
 
    return

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -1464,7 +1464,7 @@ contains
            (hlm_use_cohort_age_tracking .eq.0 ) ) then
            write(fates_log(),*) 'Age dependent mortality cannot be on if'
            write(fates_log(),*) 'cohort age tracking is off.'
-           write(fates_log(),*) 'Set hlm_use_cohort_age_tracking = .true.'
+           write(fates_log(),*) 'Set use_fates_cohort_age_tracking = .true.'
            write(fates_log(),*) 'in FATES namelist options'
            write(fates_log(),*) 'Aborting'
            call endrun(msg=errMsg(sourcefile, __LINE__))
@@ -1488,7 +1488,7 @@ contains
 
          if ( hlm_use_inventory_init.eq.1  .and. hlm_use_cohort_age_tracking .eq.1) then
             write(fates_log(), *) 'Fates inventory init cannot be used with age dependent mortality'
-            write(fates_log(), *) 'Set hlm_use_cohort_age_tracking to 0 or turn off inventory init'
+            write(fates_log(), *) 'Set use_fates_cohort_age_tracking to 0 or turn off inventory init'
             call endrun(msg=errMsg(sourcefile, __LINE__))
          end if
          
@@ -1636,7 +1636,7 @@ contains
          
         if(hlm_use_fixed_biogeog.eq.unset_int) then
            if(fates_global_verbose()) then
-             write(fates_log(), *) 'switch for fixed biogeog unset: him_use_fixed_biogeog, exiting'
+             write(fates_log(), *) 'switch for fixed biogeog unset: hlm_use_fixed_biogeog, exiting'
            end if
            call endrun(msg=errMsg(sourcefile, __LINE__))
          end if


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->
Fixes #1010 by splitting the `associate` statement up into multiple `associate` calls.  The split was made at what appears to be the maximum number of line continuations that the nag compiler will allow. 

Also includes simple b4b updates for the following: 
- fixes #969 
- fixes #968 
- fixes #902 
- fixed #437 

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->
@ekluzek 

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->
Should be B4B


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [x] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->
TBD

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

