### PR TITLE
Check fates_rad_leaf_xl values

### DIFF
--- a/biogeophys/EDSurfaceAlbedoMod.F90
+++ b/biogeophys/EDSurfaceAlbedoMod.F90
@@ -363,7 +363,9 @@ contains
     cosz = max(0.001_r8, currentPatch%solar_zenith_angle ) !copied from previous radiation code...
     do ft = 1,numpft
        sb = (90._r8 - (acos(cosz)*180._r8/pi_const)) * (pi_const / 180._r8)
-       chil = xl(ft) !min(max(xl(ft), -0.4_r8), 0.6_r8 )
+       !chil should be between -0.6 and 0.4
+       !   Bonan (2019) doi:10.1017/9781107339217 pg. 238
+       chil = min(max(xl(ft), -0.4_r8), 0.6_r8 )
        if ( abs(chil) <= 0.01_r8) then
           chil  = 0.01_r8
        end if

--- a/biogeophys/EDSurfaceAlbedoMod.F90
+++ b/biogeophys/EDSurfaceAlbedoMod.F90
@@ -363,12 +363,13 @@ contains
     cosz = max(0.001_r8, currentPatch%solar_zenith_angle ) !copied from previous radiation code...
     do ft = 1,numpft
        sb = (90._r8 - (acos(cosz)*180._r8/pi_const)) * (pi_const / 180._r8)
-       !chil should be between -0.6 and 0.4
+       !chil should be between -0.4 and 0.6
        !   Bonan (2019) doi:10.1017/9781107339217 pg. 238
        chil = min(max(xl(ft), -0.4_r8), 0.6_r8 )
-       if ( abs(chil) <= 0.01_r8) then
-          chil  = 0.01_r8
-       end if
+       ! chil being close to zero shouldn't affect things
+       !if ( abs(chil) <= 0.01_r8) then
+       !   chil  = 0.01_r8
+       !end if
        phi1b(ft) = 0.5_r8 - 0.633_r8*chil - 0.330_r8*chil*chil
        phi2b(ft) = 0.877_r8 * (1._r8 - 2._r8*phi1b(ft)) !0 = horiz leaves, 1 - vert leaves.
        gdir = phi1b(ft) + phi2b(ft) * sin(sb)

--- a/biogeophys/EDSurfaceAlbedoMod.F90
+++ b/biogeophys/EDSurfaceAlbedoMod.F90
@@ -367,7 +367,7 @@ contains
        !if ( abs(chil) <= 0.01_r8) then
        !   chil  = 0.01_r8
        !end if
-       phi1b(ft) = 0.5_r8 - 0.633_r8*chil - 0.330_r8*chil*chil
+       phi1b(ft) = 0.5_r8 - 0.633_r8*xl(ft) - 0.330_r8*xl(ft)*xl(ft)
        phi2b(ft) = 0.877_r8 * (1._r8 - 2._r8*phi1b(ft)) !0 = horiz leaves, 1 - vert leaves.
        gdir = phi1b(ft) + phi2b(ft) * sin(sb)
        !how much direct light penetrates a singleunit of lai?

--- a/biogeophys/EDSurfaceAlbedoMod.F90
+++ b/biogeophys/EDSurfaceAlbedoMod.F90
@@ -363,9 +363,6 @@ contains
     cosz = max(0.001_r8, currentPatch%solar_zenith_angle ) !copied from previous radiation code...
     do ft = 1,numpft
        sb = (90._r8 - (acos(cosz)*180._r8/pi_const)) * (pi_const / 180._r8)
-       !chil should be between -0.4 and 0.6
-       !   Bonan (2019) doi:10.1017/9781107339217 pg. 238
-       chil = min(max(xl(ft), -0.4_r8), 0.6_r8 )
        ! chil being close to zero shouldn't affect things
        !if ( abs(chil) <= 0.01_r8) then
        !   chil  = 0.01_r8

--- a/biogeophys/EDSurfaceAlbedoMod.F90
+++ b/biogeophys/EDSurfaceAlbedoMod.F90
@@ -265,7 +265,6 @@ contains
     integer  :: fp,iv,s      ! array indices
     integer  :: ib               ! waveband number
     real(r8) :: cosz             ! 0.001 <= coszen <= 1.000
-    real(r8) :: chil
     real(r8) :: gdir
 
 
@@ -363,10 +362,6 @@ contains
     cosz = max(0.001_r8, currentPatch%solar_zenith_angle ) !copied from previous radiation code...
     do ft = 1,numpft
        sb = (90._r8 - (acos(cosz)*180._r8/pi_const)) * (pi_const / 180._r8)
-       ! chil being close to zero shouldn't affect things
-       !if ( abs(chil) <= 0.01_r8) then
-       !   chil  = 0.01_r8
-       !end if
        phi1b(ft) = 0.5_r8 - 0.633_r8*xl(ft) - 0.330_r8*xl(ft)*xl(ft)
        phi2b(ft) = 0.877_r8 * (1._r8 - 2._r8*phi1b(ft)) !0 = horiz leaves, 1 - vert leaves.
        gdir = phi1b(ft) + phi2b(ft) * sin(sb)

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -1641,8 +1641,6 @@ contains
         call endrun(msg=errMsg(sourcefile, __LINE__))
      end select
 
- 
-
      ! logging parameters, make sure they make sense
      if ( (logging_mechanical_frac + logging_collateral_frac + logging_direct_frac) .gt. 1._r8) then
         write(fates_log(),*) 'the sum of logging_mechanical_frac + logging_collateral_frac + logging_direct_frac'
@@ -1674,6 +1672,14 @@ contains
 
      do ipft = 1,npft
 
+
+      ! xl must be between -0.6 and 0.4 according to Bonan (2019) doi:10.1017/9781107339217 pg. 238
+      !-----------------------------------------------------------------------------------
+      if (EDPftvarcon_inst%xl(ipft) < -0.6 .or. EDPftvarcon_inst%xl(ipft) > 0.4) then
+        write(fates_log(),*) 'fates_rad_leaf_xl for pft ', ipft, ' is outside the allowed range of -0.6 to 0.4'
+        write(fates_log(),*) 'Aborting'
+        call endrun(msg=errMsg(sourcefile, __LINE__))
+      end if 
 
         ! Check that parameter ranges for age-dependent mortality make sense
         !-----------------------------------------------------------------------------------

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -1672,9 +1672,9 @@ contains
 
      do ipft = 1,npft
 
-        ! xl must be between -0.6 and 0.4 according to Bonan (2019) doi:10.1017/9781107339217 pg. 238
+        ! xl must be between -0.4 and 0.6 according to Bonan (2019) doi:10.1017/9781107339217 pg. 238
         !-----------------------------------------------------------------------------------
-        if (EDPftvarcon_inst%xl(ipft) < -0.6 .or. EDPftvarcon_inst%xl(ipft) > 0.4) then
+        if (EDPftvarcon_inst%xl(ipft) < -0.4 .or. EDPftvarcon_inst%xl(ipft) > 0.6) then
           write(fates_log(),*) 'fates_rad_leaf_xl for pft ', ipft, ' is outside the allowed range of -0.6 to 0.4'
           write(fates_log(),*) 'Aborting'
           call endrun(msg=errMsg(sourcefile, __LINE__))

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -1672,14 +1672,13 @@ contains
 
      do ipft = 1,npft
 
-
-      ! xl must be between -0.6 and 0.4 according to Bonan (2019) doi:10.1017/9781107339217 pg. 238
-      !-----------------------------------------------------------------------------------
-      if (EDPftvarcon_inst%xl(ipft) < -0.6 .or. EDPftvarcon_inst%xl(ipft) > 0.4) then
-        write(fates_log(),*) 'fates_rad_leaf_xl for pft ', ipft, ' is outside the allowed range of -0.6 to 0.4'
-        write(fates_log(),*) 'Aborting'
-        call endrun(msg=errMsg(sourcefile, __LINE__))
-      end if 
+        ! xl must be between -0.6 and 0.4 according to Bonan (2019) doi:10.1017/9781107339217 pg. 238
+        !-----------------------------------------------------------------------------------
+        if (EDPftvarcon_inst%xl(ipft) < -0.6 .or. EDPftvarcon_inst%xl(ipft) > 0.4) then
+          write(fates_log(),*) 'fates_rad_leaf_xl for pft ', ipft, ' is outside the allowed range of -0.6 to 0.4'
+          write(fates_log(),*) 'Aborting'
+          call endrun(msg=errMsg(sourcefile, __LINE__))
+        end if 
 
         ! Check that parameter ranges for age-dependent mortality make sense
         !-----------------------------------------------------------------------------------


### PR DESCRIPTION
Checks the value of `fates_rad_leaf_xl` to be within the correct bounds (-0.6 to 0.4) according to Bonan (2019) doi:10.1017/9781107339217; pg 238 

### Description:
Checks the values of `fates_rad_leaf_xl` in `EDPftvarcon:FatesCheckParams` to ensure they are within allowed bounds. Warns user and fails if not. I also un-commented the check in `EDSurfaceAlbedoMod:PatchNormanRadiation`. I know @rgknox suggested leaving this off since we fail if the parameter inputs are outside of this range, but it seemed safer to do this as well?

Fixes issue #1001

### Collaborators:
@JessicaNeedham @rgknox 

### Expectation of Answer Changes:
none

### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:


CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:


