### PR TITLE
Add termination mortality to FATES_MORTALITY_CFLUX_PF history variable

### DIFF
--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -760,14 +760,13 @@ contains
                                   currentSite%imort_carbonflux(currentCohort%pft) = &
                                        currentSite%imort_carbonflux(currentCohort%pft) + &
                                        (nc%n * ED_val_understorey_death / hlm_freq_day ) * &
-                                       total_c * g_per_kg * days_per_sec * years_per_day * ha_per_m2
+                                       total_c * days_per_sec * years_per_day * ha_per_m2
 
                                   currentSite%imort_abg_flux(currentCohort%size_class, currentCohort%pft) = &
                                        currentSite%imort_abg_flux(currentCohort%size_class, currentCohort%pft) + &
                                        (nc%n * ED_val_understorey_death / hlm_freq_day ) * &
                                        ( (sapw_c + struct_c + store_c) * prt_params%allom_agb_frac(currentCohort%pft) + &
-                                       leaf_c ) * &
-                                       g_per_kg * days_per_sec * years_per_day * ha_per_m2
+                                       leaf_c ) * days_per_sec * years_per_day * ha_per_m2
 
 
                                   ! Step 2:  Apply survivor ship function based on the understory death fraction
@@ -1020,7 +1019,14 @@ contains
                                        currentSite%imort_carbonflux(currentCohort%pft) + &
                                        (nc%n * currentPatch%fract_ldist_not_harvested * &
                                        logging_coll_under_frac/ hlm_freq_day ) * &
-                                       total_c * g_per_kg * days_per_sec * years_per_day * ha_per_m2
+                                       total_c * days_per_sec * years_per_day * ha_per_m2
+
+                                  currentSite%imort_abg_flux(currentCohort%size_class, currentCohort%pft) = &
+                                       currentSite%imort_abg_flux(currentCohort%size_class, currentCohort%pft) + &
+                                       (nc%n * currentPatch%fract_ldist_not_harvested * &
+                                       logging_coll_under_frac/ hlm_freq_day ) * &
+                                       ( ( sapw_c + struct_c + store_c) * prt_params%allom_agb_frac(currentCohort%pft) + &
+                                       leaf_c ) * days_per_sec * years_per_day * ha_per_m2
 
 
                                   ! Step 2:  Apply survivor ship function based on the understory death fraction

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -843,10 +843,10 @@ module EDTypesMod
                                                        ! were terminated this timestep, on size x pft
 
      real(r8), allocatable :: term_carbonflux_canopy(:)  ! carbon flux from live to dead pools associated 
-                                                         ! with termination mortality, per canopy level
+                                                         ! with termination mortality, per canopy level. [kg C/ha/day]
      real(r8), allocatable :: term_carbonflux_ustory(:)  ! carbon flux from live to dead pools associated 
-                                                         ! with termination mortality, per canopy level    
-     real(r8), allocatable :: imort_carbonflux(:)        ! biomass of individuals killed due to impact mortality per year. [kgC/ha/day]
+                                                         ! with termination mortality, per canopy level.  [kg C/ha/day]    
+     real(r8), allocatable :: imort_carbonflux(:)        ! biomass of individuals killed due to impact mortality per year. [gC/m2/sec]
      real(r8), allocatable :: fmort_carbonflux_canopy(:) ! biomass of canopy indivs killed due to fire per year. [gC/m2/sec]
      real(r8), allocatable :: fmort_carbonflux_ustory(:) ! biomass of understory indivs killed due to fire per year [gC/m2/sec] 
 

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -843,15 +843,15 @@ module EDTypesMod
                                                        ! were terminated this timestep, on size x pft
 
      real(r8), allocatable :: term_carbonflux_canopy(:)  ! carbon flux from live to dead pools associated 
-                                                         ! with termination mortality, per canopy level. [kg C/ha/day]
+                                                         ! with termination mortality, per canopy level. [kgC/ha/day]
      real(r8), allocatable :: term_carbonflux_ustory(:)  ! carbon flux from live to dead pools associated 
-                                                         ! with termination mortality, per canopy level.  [kg C/ha/day]    
-     real(r8), allocatable :: imort_carbonflux(:)        ! biomass of individuals killed due to impact mortality per year. [gC/m2/sec]
+                                                         ! with termination mortality, per canopy level.  [kgC/ha/day]    
+     real(r8), allocatable :: imort_carbonflux(:)        ! biomass of individuals killed due to impact mortality per year. [kgC/m2/sec]
      real(r8), allocatable :: fmort_carbonflux_canopy(:) ! biomass of canopy indivs killed due to fire per year. [gC/m2/sec]
      real(r8), allocatable :: fmort_carbonflux_ustory(:) ! biomass of understory indivs killed due to fire per year [gC/m2/sec] 
 
      real(r8), allocatable :: term_abg_flux(:,:)          ! aboveground biomass lost due to termination mortality x size x pft
-     real(r8), allocatable :: imort_abg_flux(:,:)         ! aboveground biomass lost due to impact mortality x size x pft
+     real(r8), allocatable :: imort_abg_flux(:,:)         ! aboveground biomass lost due to impact mortality x size x pft [kgC/m2/sec]
      real(r8), allocatable :: fmort_abg_flux(:,:)         ! aboveground biomass lost due to fire mortality x size x pft
 
 
@@ -880,7 +880,7 @@ module EDTypesMod
      real(r8), allocatable :: fmort_rate_ustory_damage(:,:,:) ! number of individuals per damage class that die from fire - ustory
      real(r8), allocatable :: fmort_cflux_canopy_damage(:,:) ! cflux per damage class that die from fire - canopy
      real(r8), allocatable :: fmort_cflux_ustory_damage(:,:) ! cflux per damage class that die from fire - ustory
-     real(r8), allocatable :: imort_cflux_damage(:,:)         ! carbon flux from impact mortality by damage class
+     real(r8), allocatable :: imort_cflux_damage(:,:)         ! carbon flux from impact mortality by damage class [kgC/m2/sec]
      real(r8), allocatable :: term_cflux_canopy_damage(:,:)          ! carbon flux from termination mortality by damage class
      real(r8), allocatable :: term_cflux_ustory_damage(:,:)          ! carbon flux from termination mortality by damage class
 

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -3843,13 +3843,13 @@ end subroutine flush_hvars
       
       ! treat carbon flux from imort the same way
       hio_understory_mortality_carbonflux_si(io_si) = hio_understory_mortality_carbonflux_si(io_si) + &
-         sum(sites(s)%imort_carbonflux(:)) / g_per_kg
+         sum(sites(s)%imort_carbonflux(:)) 
 
       do i_pft = 1, numpft
          hio_mortality_carbonflux_si_pft(io_si,i_pft) = hio_mortality_carbonflux_si_pft(io_si,i_pft) + &
               (sites(s)%fmort_carbonflux_canopy(i_pft) + &
-              sites(s)%fmort_carbonflux_ustory(i_pft) + &
-              sites(s)%imort_carbonflux(i_pft) ) / g_per_kg  + & 
+              sites(s)%fmort_carbonflux_ustory(i_pft) ) / g_per_kg + &
+              sites(s)%imort_carbonflux(i_pft) + & 
               sites(s)%term_carbonflux_ustory(i_pft) * days_per_sec * ha_per_m2 + &
               sites(s)%term_carbonflux_canopy(i_pft) * days_per_sec * ha_per_m2 
    
@@ -3862,8 +3862,8 @@ end subroutine flush_hvars
             i_scpf = (i_pft-1)*nlevsclass + i_scls
             hio_abg_mortality_cflux_si_scpf(io_si,i_scpf) = hio_abg_mortality_cflux_si_scpf(io_si,i_scpf) + &
                  (sites(s)%fmort_abg_flux(i_scls,i_pft) / g_per_kg ) + &
-                 (sites(s)%imort_abg_flux(i_scls,i_pft) / g_per_kg) + &
-                 (sites(s)%term_abg_flux(i_scls,i_pft)  * days_per_sec * ha_per_m2 ) ! jfn
+                 sites(s)%imort_abg_flux(i_scls,i_pft)  +  &
+                 (sites(s)%term_abg_flux(i_scls,i_pft)  * days_per_sec * ha_per_m2 ) 
          end do
       end do
 

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -3849,7 +3849,9 @@ end subroutine flush_hvars
          hio_mortality_carbonflux_si_pft(io_si,i_pft) = hio_mortality_carbonflux_si_pft(io_si,i_pft) + &
               (sites(s)%fmort_carbonflux_canopy(i_pft) + &
               sites(s)%fmort_carbonflux_ustory(i_pft) + &
-              sites(s)%imort_carbonflux(i_pft) ) / g_per_kg  ! cdk
+              sites(s)%imort_carbonflux(i_pft) ) / g_per_kg  + & ! cdk
+              sites(s)%term_carbonflux_ustory(i_pft) * days_per_sec * ha_per_m2 + &
+              sites(s)%term_carbonflux_canopy(i_pft) * days_per_sec * ha_per_m2 
    
          hio_firemortality_carbonflux_si_pft(io_si,i_pft) = sites(s)%fmort_carbonflux_canopy(i_pft) / g_per_kg
       end do
@@ -6716,7 +6718,7 @@ end subroutine update_history_hifrq
          upfreq=1, ivar=ivar, initialize=initialize_variables,                 &
          index=ih_firemortality_carbonflux_si_pft)
 
-    call this%set_history_var(vname='FATES_MORTALITY_HYDRAULIC_CFLUX_PF', units='kg m-2 s-1',    &
+    call this%set_history_var(vname='FATES_MORTALITY_HYDRO_CFLUX_PF', units='kg m-2 s-1',    &
          long='PFT-level flux of biomass carbon from live to dead pool from hydraulic failure mortality', &
          use_default='active', avgflag='A', vtype=site_pft_r8, hlms='CLM:ALM', &
          upfreq=1, ivar=ivar, initialize=initialize_variables,                 &

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -3849,7 +3849,7 @@ end subroutine flush_hvars
          hio_mortality_carbonflux_si_pft(io_si,i_pft) = hio_mortality_carbonflux_si_pft(io_si,i_pft) + &
               (sites(s)%fmort_carbonflux_canopy(i_pft) + &
               sites(s)%fmort_carbonflux_ustory(i_pft) + &
-              sites(s)%imort_carbonflux(i_pft) ) / g_per_kg  + & ! cdk
+              sites(s)%imort_carbonflux(i_pft) ) / g_per_kg  + & 
               sites(s)%term_carbonflux_ustory(i_pft) * days_per_sec * ha_per_m2 + &
               sites(s)%term_carbonflux_canopy(i_pft) * days_per_sec * ha_per_m2 
    


### PR DESCRIPTION
This PR adds termination mortality carbon flux to the history variable FATES_MORTALITY_CFLUX_PF. It also shortens the name of FATES_MORTALITY_HYDRAULIC_CFLUX_PF to FATES_MORTALITY_HYDRO_CLFUX_PF since the former was too long and wasn't being read properly by the HLM (runs compile but then give an error message about the variable not being found). 

### Collaborators:


### Expectation of Answer Changes:
The FATES_MORTALITY_CFLUX_PF variable will change. Everything else should be b4b. 

### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ X] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ X] If answers were expected to change, evaluation was performed and provided


### Test Results:
CTSM (or) E3SM (specify which) baseline hash-tag: E3SM b645be3aa2

FATES baseline hash-tag: 1c7ec096

Test Output: 
Main branch compared with branch with termination carbon flux added to total carbon flux. This was a global run with default parameter files - grid cell shown is BCI (lat=9.15, lon=-79.85). 



![termfix](https://user-images.githubusercontent.com/10586303/234083581-a32e145a-aa41-4131-ad15-80a88f0c43b4.png)

