### PR TITLE
Initialization of NPP moving average for N fixation in E3SM

### DIFF
--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -265,6 +265,10 @@ contains
        call site_in%flux_diags(el)%ZeroFluxDiags()
     end do
 
+    ! This will be initialized in FatesSoilBGCFluxMod:PrepCH4BCs()
+    ! It checks to see if the value is below -9000. If it is,
+    ! it will assume the first value of the smoother is set
+    site_in%ema_npp = -9999.9_r8
 
     ! termination and recruitment info
     site_in%term_nindivs_canopy(:,:) = 0._r8

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -620,8 +620,7 @@ contains
          bc_out%rootfr_pa(0,1:nlevsoil_in)=1._r8/real(nlevsoil_in,r8)
       end if
 
-      bc_out%ema_npp = nan
-      
+      bc_out%ema_npp = -9999.9_r8
       
       ! Fates -> BGC fragmentation mass fluxes
       select case(hlm_parteh_mode) 

--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -255,7 +255,8 @@ module FatesRestartInterfaceMod
   integer :: ir_fmortcflux_usto_sicdsc
   integer :: ir_crownarea_cano_si
   integer :: ir_crownarea_usto_si
-
+  integer :: ir_emanpp_si
+  
 
   ! Hydraulic indices
   integer :: ir_hydro_th_ag_covec
@@ -1404,6 +1405,11 @@ contains
          units='m2/ha/year', flushval = flushzero, &
          hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_crownarea_usto_si)
 
+    call this%set_restart_var(vname='fates_emanpp', vtype=site_r8, &
+         long_name='smoothed NPP (exp. moving avg) at the site level (for fixation)', &
+         units='kg/m2/yr', flushval = flushzero, &
+         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_emanpp_si)
+    
    call this%DefineRMeanRestartVar(vname='fates_tveg24patch',vtype=cohort_r8, &
         long_name='24-hour patch veg temp', &
         units='K', initialize=initialize_variables,ivar=ivar, index = ir_tveg24_pa)
@@ -1997,7 +2003,8 @@ contains
            rio_fmortcflux_cano_sicdsc  => this%rvars(ir_fmortcflux_cano_sicdsc)%r81d, &
            rio_fmortcflux_usto_sicdsc  => this%rvars(ir_fmortcflux_usto_sicdsc)%r81d, &
            rio_crownarea_cano_damage_si=> this%rvars(ir_crownarea_cano_si)%r81d, &
-           rio_crownarea_usto_damage_si=> this%rvars(ir_crownarea_usto_si)%r81d)
+           rio_crownarea_usto_damage_si=> this%rvars(ir_crownarea_usto_si)%r81d, &
+           rio_emanpp_si               => this%rvars(ir_emanpp_si)%r81d)
       
        totalCohorts = 0
 
@@ -2380,13 +2387,14 @@ contains
              end do
 
               rio_demorate_sisc(io_idx_si_sc) = sites(s)%demotion_rate(i_scls)
-             rio_promrate_sisc(io_idx_si_sc) = sites(s)%promotion_rate(i_scls)
+              rio_promrate_sisc(io_idx_si_sc) = sites(s)%promotion_rate(i_scls)
 
              io_idx_si_sc = io_idx_si_sc + 1
           end do
+          
           rio_termcarea_cano_si(io_idx_si)  = sites(s)%term_crownarea_canopy
           rio_termcarea_usto_si(io_idx_si)  = sites(s)%term_crownarea_ustory
-          
+          rio_emanpp_si(io_idx_si)          = sites(s)%ema_npp
 
           ! this only copies live portions of transitions - but that's ok because the mortality
           ! bit only needs to be added for history outputs
@@ -2892,6 +2900,7 @@ contains
           rio_fmortcflux_usto_sicdsc  => this%rvars(ir_fmortcflux_usto_sicdsc)%r81d, &
           rio_crownarea_cano_damage_si=> this%rvars(ir_crownarea_cano_si)%r81d, &
           rio_crownarea_usto_damage_si=> this%rvars(ir_crownarea_usto_si)%r81d, &
+          rio_emanpp_si               => this%rvars(ir_emanpp_si)%r81d, &
           rio_imortcflux_sipft        => this%rvars(ir_imortcflux_sipft)%r81d, &
           rio_fmortcflux_cano_sipft   => this%rvars(ir_fmortcflux_cano_sipft)%r81d, &
           rio_fmortcflux_usto_sipft   => this%rvars(ir_fmortcflux_usto_sipft)%r81d, &
@@ -3349,12 +3358,13 @@ contains
 
              sites(s)%crownarea_canopy_damage = rio_crownarea_cano_damage_si(io_idx_si)
              sites(s)%crownarea_ustory_damage = rio_crownarea_usto_damage_si(io_idx_si)
-
+             
+             
           end if
 
+          sites(s)%ema_npp                 = rio_emanpp_si(io_idx_si)
           sites(s)%term_crownarea_canopy    = rio_termcarea_cano_si(io_idx_si)
           sites(s)%term_crownarea_ustory    = rio_termcarea_usto_si(io_idx_si)
-
           sites(s)%imort_crownarea          = rio_imortcarea_si(io_idx_si)
           sites(s)%fmort_crownarea_canopy  = rio_fmortcarea_cano_si(io_idx_si)
           sites(s)%fmort_crownarea_ustory  = rio_fmortcarea_usto_si(io_idx_si)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

This set of changes initializes EMA NPP correctly, which is used for nitrogen fixation. It also adds a restart term.  This is a fix.  E3SM tests have been failing in debug mode because a nan is being used.

Fixes: #1039

<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

### Collaborators:

@glemieux 

<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

