### PR TITLE
fix typo in tools/FatesPFTIndexSwapper.py

### DIFF
--- a/tools/FatesPFTIndexSwapper.py
+++ b/tools/FatesPFTIndexSwapper.py
@@ -85,7 +85,7 @@ def interp_args(argv):
     input_fname = "none"
     output_fname = "none"
     donor_pft_indices = -9
-    donot_pft_indices_str = ''
+    donor_pft_indices_str = ''
     histflag = True
     try:
         opts, args = getopt.getopt(argv, 'h',["fin=","fout=","pft-indices=","nohist"])


### PR DESCRIPTION
Tiny bugfix to correct a typo in tools/FatesPFTIndexSwapper.py that is preventing an interpretable error message to be written.

Right now if you call `FatesPFTIndexSwapper.py` without the argument `pft-indices`, instead of giving an error message saying that that argument needs to be set, it crashes with an error message that says that variable `donor_pft_indices_str` is not set. This change fixes that, so it should give a clearer / more actionable error message.

### Description:
fix one typo in the line that puts in an initial value into a variable

### Collaborators:
Mingjie Shi discovered this issue.

### Expectation of Answer Changes:
None

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
Not tested, but only affects python tool, which isn't part of test suite.
