### PR TITLE
Fix EDInitMod.F90 initialisation of drought deciduous variables

### DIFF
--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -917,11 +917,6 @@ contains
                 temp_cohort%n           =  temp_cohort%n * sum(site_in%use_this_pft)
              endif
 
-             ! Retrieve drop fraction of non-leaf tissues for phenology initialisation
-             fnrt_drop_fraction = prt_params%phen_fnrt_drop_fraction(temp_cohort%pft)
-             stem_drop_fraction = prt_params%phen_stem_drop_fraction(temp_cohort%pft)
-
-
 
              !  h,dbh,leafc,n from SP values or from small initial size.
              if(hlm_use_sp.eq.itrue)then

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -847,6 +847,10 @@ contains
           temp_cohort%canopy_trim = 1.0_r8
           temp_cohort%crowndamage = 1  ! Assume no damage to begin with
 
+          ! Retrieve drop fraction of non-leaf tissues for phenology initialisation
+          fnrt_drop_fraction = prt_params%phen_fnrt_drop_fraction(pft)
+          stem_drop_fraction = prt_params%phen_stem_drop_fraction(pft)
+
 
           ! Initialise phenology variables.
           spmode_case: select case (hlm_use_sp)


### PR DESCRIPTION
This fixes two local variables were not initialised before the first time being used.

<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

During the merge of PR #958 and the mainline, many lines of code had changed the order, and this caused `fnrt_drop_fraction` and `stem_drop_fraction` to be used before they were initialised. Thanks @adrifoster for spotting it!

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

@adrifoster @glemieux 

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

