### PR TITLE
Fix error with large size initialisation in nocomp mode

### DIFF
--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -61,6 +61,7 @@ module EDInitMod
   use FatesInterfaceTypesMod         , only : nlevage
 
   use FatesAllometryMod         , only : h2d_allom
+  use FatesAllometryMod         , only : h_allom
   use FatesAllometryMod         , only : bagw_allom
   use FatesAllometryMod         , only : bbgw_allom
   use FatesAllometryMod         , only : bleaf
@@ -851,6 +852,14 @@ contains
       patch_in%tallest  => null()
       patch_in%shortest => null()
 
+      ! if any pfts are starting with large  size  then the whole  site needs a spread of 0
+      do pft = 1, numpft
+         if (EDPftvarcon_inst%initd(pft) < 0.0_r8) then   
+            site_in%spread = init_spread_inventory
+         end if
+      end do
+
+      
       ! Manage interactions of fixed biogeog (site level filter) and nocomp (patch level filter)
       ! Need to cover all potential biogeog x nocomp combinations
       ! 1. biogeog = false. nocomp = false: all PFTs on (DEFAULT)
@@ -980,8 +989,15 @@ contains
                   ! Calculate the leaf biomass from allometry
                   ! (calculates a maximum first, then applies canopy trim)
                   call bleaf(dbh, pft, crown_damage, canopy_trim, efleaf_coh,  &
-                     c_leaf)
+                       c_leaf)
 
+                  ! calculate crown area of the cohort
+                  call carea_allom(dbh, cohort_n, init_spread_inventory, pft, crown_damage,       &
+                       c_area)
+
+                  ! calculate height from diameter
+                  call h_allom(dbh, pft, hite)
+ 
                else
                   write(fates_log(),*) 'Negative fates_recruit_init_density can only be used in no comp mode'
                   call endrun(msg=errMsg(sourcefile, __LINE__))


### PR DESCRIPTION
Fixes #1071. Initialisation by dbh was failing in no comp mode because height was not being  initialised. This PR adds a call to h_allom so that trees can be demoted in canopy_structure if site spread has been updated in the first time step. 

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
nocomop initialisation by dbh should now run, rather than result in an error. 

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the in-code documentation .AND. (the [technical note](https://github.com/NGEET/fates-docs) .OR. the wiki) accordingly.
- [ x] I have read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/master/CONTRIBUTING.md) document.
- [ ] FATES PASS/FAIL regression tests were run
- [ ] If answers were expected to change, evaluation was performed and provided


### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

CTSM (or) E3SM (specify which) test hash-tag:

CTSM (or) E3SM (specify which) baseline hash-tag:

FATES baseline hash-tag:

Test Output:

Compiles and runs on Perlmutter with https://github.com/glemieux/E3SM/tree/lnd/fates-refactor E3SM branch and latest FATES commit. 

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

