### PR TITLE
Prevent negative values of Rdark 

### DIFF
--- a/biogeophys/FatesPlantRespPhotosynthMod.F90
+++ b/biogeophys/FatesPlantRespPhotosynthMod.F90
@@ -2178,7 +2178,15 @@ subroutine LeafLayerMaintenanceRespiration_Atkin_etal_2017(lnc_top, &
    ! r_0 currently put into the EDPftvarcon_inst%dev_arbitrary_pft
    ! all figs in Atkin et al 2017 stop at zero Celsius so we will assume acclimation is fixed below that
    r_0 = EDPftvarcon_inst%maintresp_leaf_atkin2017_baserate(ft)
-   r_t_ref = nscaler * (r_0 + r_1 * lnc_top + r_2 * max(0._r8, (tgrowth - tfrz) ))
+   r_t_ref = max( 0._r8, nscaler * (r_0 + r_1 * lnc_top + r_2 * max(0._r8, (tgrowth - tfrz) )) )
+   
+   if (r_t_ref .eq. 0._r8) then
+      write(fates_log(),*) 'Rdark has is negative at this temperature and has'
+      write(fates_log(),*) 'therefore been capped at 0.'
+      write(fates_log(),*) 'See LeafLayerMaintenanceRespiration_Atkin_etal_2017'
+      write(fates_log(),*) 'tgrowth : ', tgrowth
+      write(fates_log(),*) 'pft      : ', ft
+   end if
 
    lmr = r_t_ref * exp(b * (veg_tempk - tfrz - TrefC) + c * ((veg_tempk-tfrz)**2 - TrefC**2))
 

--- a/biogeophys/FatesPlantRespPhotosynthMod.F90
+++ b/biogeophys/FatesPlantRespPhotosynthMod.F90
@@ -22,7 +22,7 @@ module FATESPlantRespPhotosynthMod
 
   use FatesGlobals,      only : endrun => fates_endrun
   use FatesGlobals,      only : fates_log
-  use FatesGlobals,      only : FatesWarn,N2S,A2S
+  use FatesGlobals,      only : FatesWarn,N2S,A2S,I2S
   use FatesConstantsMod, only : r8 => fates_r8
   use FatesConstantsMod, only : itrue
   use FatesConstantsMod, only : nearzero
@@ -2181,11 +2181,8 @@ subroutine LeafLayerMaintenanceRespiration_Atkin_etal_2017(lnc_top, &
    r_t_ref = max( 0._r8, nscaler * (r_0 + r_1 * lnc_top + r_2 * max(0._r8, (tgrowth - tfrz) )) )
    
    if (r_t_ref .eq. 0._r8) then
-      write(fates_log(),*) 'Rdark has is negative at this temperature and has'
-      write(fates_log(),*) 'therefore been capped at 0.'
-      write(fates_log(),*) 'See LeafLayerMaintenanceRespiration_Atkin_etal_2017'
-      write(fates_log(),*) 'tgrowth : ', tgrowth
-      write(fates_log(),*) 'pft      : ', ft
+      warn_msg = 'Rdark is negative at this temperature and is capped at 0. tgrowth (C): '//trim(N2S(tgrowth-tfrz))//' pft: '//trim(I2S(ft))
+      call FatesWarn(warn_msg,index=4)            
    end if
 
    lmr = r_t_ref * exp(b * (veg_tempk - tfrz - TrefC) + c * ((veg_tempk-tfrz)**2 - TrefC**2))

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -1718,6 +1718,8 @@ contains
     use FatesConstantsMod  , only : fates_check_param_set
     use FatesConstantsMod  , only : itrue, ifalse
     use FatesConstantsMod, only : tfrz => t_water_freeze_k_1atm
+    use FatesConstantsMod, only : lmr_r_1
+    use FatesConstantsMod, only : lmr_r_2
     use EDParamsMod        , only : logging_mechanical_frac, logging_collateral_frac
     use EDParamsMod        , only : logging_direct_frac,logging_export_frac
     use EDParamsMod        , only : radiation_model
@@ -1738,13 +1740,6 @@ contains
      integer  :: fates_pft  ! used in fixed biogeog mode
 
      real(r8) :: sumarea    ! area of PFTs in nocomp mode.
-
-
-     ! Parameters - used to check lmr base rate  r_0 parameter 
-     ! values from Atkin et al., 2017 https://doi.org/10.1007/978-3-319-68703-2_6
-     ! and Heskel et al., 2016 https://doi.org/10.1073/pnas.1520282113
-     real(r8), parameter :: r_1 = 0.2061_r8     ! (umol CO2/m**2/s / (gN/(m2 leaf)))
-     real(r8), parameter :: r_2 = -0.0402_r8    ! (umol CO2/m**2/s/degree C)
      real(r8) :: neg_lmr_temp ! temperature at which lmr would got negative 
      real(r8) :: r_0 ! base respiartion rate, PFT-dependent
      real(r8) :: lnc_top ! leaf nitrogen content at top of canopy
@@ -2059,7 +2054,7 @@ contains
         ! r_t_ref = nscaler * (r_0 + r_1 * lnc_top + r_2 * max(0._r8, (tgrowth - tfrz) ))
 
         ! find temperature at which whole term is negative
-        neg_lmr_temp = ( -1._r8 * (  r_0  + r_1 * lnc_top ) ) / r_2
+        neg_lmr_temp = ( -1._r8 * (  r_0  + lmr_r_1 * lnc_top ) ) / lmr_r_2
 
         write(fates_log(),*)  'PFT  ',  ipft
         write(fates_log(),*)  'will have  negative Rdark at ', neg_lmr_temp, 'degrees C' 

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -2042,14 +2042,11 @@ contains
      ! given their parameters
      !------------------------------------------------------------------------------------
      do ipft = 1,npft
-
         
         r_0 = EDPftvarcon_inst%maintresp_leaf_atkin2017_baserate(ipft)
 
-        ! jfn -  this should be prt_params%nitr_stoich_p1(ipft, prt_params%organ_param_id(leaf_organ))
-        ! but that was giving errors during compile
-        lnc_top = prt_params%nitr_stoich_p1(ipft, 1) / prt_params%slatop(ipft)
-
+        lnc_top = prt_params%nitr_stoich_p1(ipft, prt_params%organ_param_id(leaf_organ))
+        
         ! From LeafLayerMaintenanceRespiration_Atkin_etal_2017
         ! r_t_ref = nscaler * (r_0 + r_1 * lnc_top + r_2 * max(0._r8, (tgrowth - tfrz) ))
 

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -2050,7 +2050,9 @@ contains
 
         
         r_0 = EDPftvarcon_inst%maintresp_leaf_atkin2017_baserate(ipft)
-        
+
+        ! jfn -  this should be prt_params%nitr_stoich_p1(ipft, prt_params%organ_param_id(leaf_organ))
+        ! but that was giving errors during compile
         lnc_top = prt_params%nitr_stoich_p1(ipft, 1) / prt_params%slatop(ipft)
 
         ! From LeafLayerMaintenanceRespiration_Atkin_etal_2017

--- a/main/FatesConstantsMod.F90
+++ b/main/FatesConstantsMod.F90
@@ -316,4 +316,17 @@ integer, parameter, public :: isemi_stress_decid = 2 ! If the PFT is stress (dro
   ! PI
   real(fates_r8), parameter, public :: pi_const = 3.14159265359_fates_r8
 
+  ! Rdark constants from Atkin et al., 2017 https://doi.org/10.1007/978-3-319-68703-2_6
+  ! and Heskel et al., 2016 https://doi.org/10.1073/pnas.1520282113
+  real(fates_r8), parameter, public :: lmr_b = 0.1012_fates_r8       ! (degrees C**-1)
+
+  real(fates_r8), parameter, public :: lmr_c = -0.0005_fates_r8      ! (degrees C**-2)
+
+  real(fates_r8), parameter, public :: lmr_TrefC = 25._fates_r8      ! (degrees C)
+
+  real(fates_r8), parameter, public :: lmr_r_1 = 0.2061_fates_r8     ! (umol CO2/m**2/s / (gN/(m2 leaf))) 
+
+  real(fates_r8), parameter, public :: lmr_r_2 = -0.0402_fates_r8    ! (umol CO2/m**2/s/degree C)
+  
+  
 end module FatesConstantsMod

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -1940,8 +1940,8 @@ contains
 
       call FatesReportPFTParams(masterproc)
       call FatesReportParams(masterproc)
-      call FatesCheckParams(masterproc)    ! Check general fates parameters
       call PRTDerivedParams()              ! Update PARTEH derived constants
+      call FatesCheckParams(masterproc)    ! Check general fates parameters
       call PRTCheckParams(masterproc)      ! Check PARTEH parameters
       call SpitFireCheckParams(masterproc)
       


### PR DESCRIPTION
This PR addresses issue #1083. Rdark is now wrapped in a cap that prevents it from being less than zero and a warning is issued when temperatures result in this cap being reached. When parameters are read in, we check to see what temperatures will lead to negative Rdark for each PFT, given PFT specific slatop, nitrogen stoichiometry and mr base rate parameters.  

### Collaborators:
Discussed today at  the FATES software meeting with @glemieux @rgknox @ckoven @adrifoster @mpaiao @jenniferholm 

### Expectation of Answer Changes:
This will  be non bfb in simulations where temperatures are exceeding around ~35 degrees C and the maintenance respiration base rate parameters  are low. 

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [X] The in-code documentation has been updated with descriptive comments
- [X] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update: https://github.com/NGEET/fates-docs/issues/45
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:* E3SM  glemieux_repo/lnd/fates-refactor b8be65d66

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*
On Perlmutter a quick test with 0.7 * default r_0  parameters gave: 

PFT             1                                                                                                              
 will have  negative Rdark at    42.326181592039802      degrees C                                                              
 with these values of slatop, nitrogen stoichiometry and                                                                        
 maintresp_leaf_atkin2017_baserate.                                                                                             
 See LeafLayerMaintenanceRespiration_Atkin_etal_2017 in                                                                         
 FatesPlantRespPhotosynthMod                                                                                                    
 PFT             2                                                                                                              
 will have  negative Rdark at    50.890547263681590      degrees C                                                              
 with these values of slatop, nitrogen stoichiometry and                                                                        
 maintresp_leaf_atkin2017_baserate.                                                                                             
 See LeafLayerMaintenanceRespiration_Atkin_etal_2017 in                                                                         
 FatesPlantRespPhotosynthMod                                                                                                    
 PFT             3                                                                                                              
 will have  negative Rdark at    33.231343283582092      degrees C                                                              
 with these values of slatop, nitrogen stoichiometry and                                                                        
 maintresp_leaf_atkin2017_baserate.                                                                                             
 See LeafLayerMaintenanceRespiration_Atkin_etal_2017 in                                                                         
 FatesPlantRespPhotosynthMod                                                                                                    
 PFT             4                                                                                                              
 will have  negative Rdark at    46.242537313432834      degrees C                                                              
 with these values of slatop, nitrogen stoichiometry and                                                                        
 maintresp_leaf_atkin2017_baserate.                                                                                             
 See LeafLayerMaintenanceRespiration_Atkin_etal_2017 in                                                                         
 FatesPlantRespPhotosynthMod                                                                                                    
 PFT             5                                                                                                              
 will have  negative Rdark at    36.273631840796021      degrees C                                                              
 with these values of slatop, nitrogen stoichiometry and                                                                        
 maintresp_leaf_atkin2017_baserate.                                                                                             
 See LeafLayerMaintenanceRespiration_Atkin_etal_2017 in                                                                         
 FatesPlantRespPhotosynthMod      
PFT             6                                                                                                              
 will have  negative Rdark at    36.273631840796021      degrees C                                                              
 with these values of slatop, nitrogen stoichiometry and                                                                        
 maintresp_leaf_atkin2017_baserate.                                                                                             
 See LeafLayerMaintenanceRespiration_Atkin_etal_2017 in                                                                         
 FatesPlantRespPhotosynthMod                                                                                                    
 PFT             7                                                                                                              
 will have  negative Rdark at    47.879166666666670      degrees C                                                              
 with these values of slatop, nitrogen stoichiometry and                                                                        
 maintresp_leaf_atkin2017_baserate.                                                                                             
 See LeafLayerMaintenanceRespiration_Atkin_etal_2017 in                                                                         
 FatesPlantRespPhotosynthMod                                                                                                    
 PFT             8                                                                                                              
 will have  negative Rdark at    41.826616915422882      degrees C                                                              
 with these values of slatop, nitrogen stoichiometry and                                                                        
 maintresp_leaf_atkin2017_baserate.                                                                                             
 See LeafLayerMaintenanceRespiration_Atkin_etal_2017 in                                                                         
 FatesPlantRespPhotosynthMod                                                                                                    
 PFT             9                                                                                                              
 will have  negative Rdark at    41.826616915422882      degrees C                                                              
 with these values of slatop, nitrogen stoichiometry and                                                                        
 maintresp_leaf_atkin2017_baserate.                                                                                             
 See LeafLayerMaintenanceRespiration_Atkin_etal_2017 in                                                                         
 FatesPlantRespPhotosynthMod                                                                                                    
 PFT            10                                                                                                              
 will have  negative Rdark at    43.928358208955231      degrees C                                                              
 with these values of slatop, nitrogen stoichiometry and                                                                        
 maintresp_leaf_atkin2017_baserate.                                                                                             
 See LeafLayerMaintenanceRespiration_Atkin_etal_2017 in                                                                         
 FatesPlantRespPhotosynthMod                                                                                                    
 PFT            11                                                                                                              
 will have  negative Rdark at    43.928358208955231      degrees C                                                              
 with these values of slatop, nitrogen stoichiometry and                                                                        
 maintresp_leaf_atkin2017_baserate.                                                                                             
 See LeafLayerMaintenanceRespiration_Atkin_etal_2017 in                                                                         
 FatesPlantRespPhotosynthMod                                                                                                    
 PFT            12                                                                                                              
 will have  negative Rdark at    45.067661691542291      degrees C                                                              
 with these values of slatop, nitrogen stoichiometry and                                                                        
 maintresp_leaf_atkin2017_baserate.                                                                                             
 See LeafLayerMaintenanceRespiration_Atkin_etal_2017 in                                                                         
 FatesPlantRespPhotosynthMod 