### PR TITLE
Define new fates_param_reader_type type to abstract HLM-side param I/O

### DIFF
--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -70,8 +70,6 @@ module FatesInterfaceMod
    use SFParamsMod               , only : SpitFireRegisterParams, SpitFireReceiveParams
    use PRTInitParamsFATESMod     , only : PRTRegisterParams, PRTReceiveParams
    use FatesSynchronizedParamsMod, only : FatesSynchronizedParamsInst
-   ! TODO(jpalex): remove this direct reference to HLM code.
-   use CLMFatesParamInterfaceMod , only : HLM_FatesReadParameters => FatesReadParameters
    use EDParamsMod               , only : p_uptake_mode
    use EDParamsMod               , only : n_uptake_mode
    use EDTypesMod                , only : ed_site_type
@@ -750,21 +748,14 @@ contains
       logical,                    intent(in) :: use_fates    ! Is fates turned on?
       integer,                    intent(in) :: surf_numpft  ! Number of PFTs in surface dataset
       integer,                    intent(in) :: surf_numcft  ! Number of CFTs in surface dataset
-      ! TODO(jpalex): make non-optional once all HLMs pass it in.
-      class(fates_param_reader_type), optional, intent(in) :: param_reader ! HLM-provided param file reader
+      class(fates_param_reader_type), intent(in) :: param_reader ! HLM-provided param file reader
   
       integer :: fates_numpft  ! Number of PFTs tracked in FATES
       
       if (use_fates) then
          
          ! Self explanatory, read the fates parameter file
-         if (present(param_reader)) then
-           ! new, Fates-side.
-           call FatesReadParameters(param_reader)
-         else
-           ! old, HLM-side.
-           call HLM_FatesReadParameters()
-         end if
+         call FatesReadParameters(param_reader)
 
          fates_numpft = size(prt_params%wood_density,dim=1)
          

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -64,9 +64,16 @@ module FatesInterfaceMod
    use EDParamsMod               , only : ED_val_history_ageclass_bin_edges
    use EDParamsMod               , only : ED_val_history_height_bin_edges
    use EDParamsMod               , only : ED_val_history_coageclass_bin_edges
-   use CLMFatesParamInterfaceMod , only : FatesReadParameters
-   use EDParamsMod                , only : p_uptake_mode
-   use EDParamsMod                , only : n_uptake_mode
+   use FatesParametersInterface  , only : fates_param_reader_type
+   use FatesParametersInterface  , only : fates_parameters_type
+   use EDParamsMod               , only : FatesRegisterParams, FatesReceiveParams
+   use SFParamsMod               , only : SpitFireRegisterParams, SpitFireReceiveParams
+   use PRTInitParamsFATESMod     , only : PRTRegisterParams, PRTReceiveParams
+   use FatesSynchronizedParamsMod, only : FatesSynchronizedParamsInst
+   ! TODO(jpalex): remove this direct reference to HLM code.
+   use CLMFatesParamInterfaceMod , only : HLM_FatesReadParameters => FatesReadParameters
+   use EDParamsMod               , only : p_uptake_mode
+   use EDParamsMod               , only : n_uptake_mode
    use EDTypesMod                , only : ed_site_type
    use FatesConstantsMod         , only : prescribed_p_uptake
    use FatesConstantsMod         , only : prescribed_n_uptake
@@ -173,6 +180,8 @@ module FatesInterfaceMod
    public :: set_bcs
    public :: UpdateFatesRMeansTStep
    public :: InitTimeAveragingGlobals
+
+   private :: FatesReadParameters
    
 contains
 
@@ -726,7 +735,7 @@ contains
 
     ! ===================================================================================
     
-    subroutine SetFatesGlobalElements1(use_fates,surf_numpft,surf_numcft)
+    subroutine SetFatesGlobalElements1(use_fates,surf_numpft,surf_numcft,param_reader)
 
        ! --------------------------------------------------------------------------------
        !
@@ -741,13 +750,21 @@ contains
       logical,                    intent(in) :: use_fates    ! Is fates turned on?
       integer,                    intent(in) :: surf_numpft  ! Number of PFTs in surface dataset
       integer,                    intent(in) :: surf_numcft  ! Number of CFTs in surface dataset
+      ! TODO(jpalex): make non-optional once all HLMs pass it in.
+      class(fates_param_reader_type), optional, intent(in) :: param_reader ! HLM-provided param file reader
   
       integer :: fates_numpft  ! Number of PFTs tracked in FATES
       
       if (use_fates) then
          
          ! Self explanatory, read the fates parameter file
-         call FatesReadParameters()
+         if (present(param_reader)) then
+           ! new, Fates-side.
+           call FatesReadParameters(param_reader)
+         else
+           ! old, HLM-side.
+           call HLM_FatesReadParameters()
+         end if
 
          fates_numpft = size(prt_params%wood_density,dim=1)
          
@@ -2142,5 +2159,42 @@ subroutine SeedlingParPatch(cpatch, &
   return
 end subroutine SeedlingParPatch
 
+  !-----------------------------------------------------------------------
+  ! TODO(jpalex): this belongs in FatesParametersInterface.F90, but would require
+  ! untangling the dependencies of the *RegisterParams methods below.
+  subroutine FatesReadParameters(param_reader)
+    implicit none
+   
+    class(fates_param_reader_type), intent(in) :: param_reader ! HLM-provided param file reader
 
+    character(len=32)  :: subname = 'FatesReadParameters'
+    class(fates_parameters_type), allocatable :: fates_params
+    logical :: is_host_file
+
+    if ( hlm_masterproc == itrue ) then
+      write(fates_log(), *) 'FatesParametersInterface.F90::'//trim(subname)//' :: CLM reading ED/FATES '//' parameters '
+    end if
+
+    allocate(fates_params)
+    call fates_params%Init()   ! fates_params class, in FatesParameterInterfaceMod
+    call FatesRegisterParams(fates_params)  !EDParamsMod, only operates on fates_params class
+    call SpitFireRegisterParams(fates_params) !SpitFire Mod, only operates of fates_params class
+    call PRTRegisterParams(fates_params)     ! PRT mod, only operates on fates_params class
+    call FatesSynchronizedParamsInst%RegisterParams(fates_params) !Synchronized params class in Synchronized params mod, only operates on fates_params class
+
+    is_host_file = .false.
+    call param_reader%Read(is_host_file, fates_params)
+
+    is_host_file = .true.
+    call param_reader%Read(is_host_file, fates_params)
+
+    call FatesReceiveParams(fates_params)
+    call SpitFireReceiveParams(fates_params)
+    call PRTReceiveParams(fates_params)
+    call FatesSynchronizedParamsInst%ReceiveParams(fates_params)
+
+    call fates_params%Destroy()
+    deallocate(fates_params)
+
+ end subroutine FatesReadParameters
 end module FatesInterfaceMod

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -2169,7 +2169,6 @@ end subroutine SeedlingParPatch
 
     character(len=32)  :: subname = 'FatesReadParameters'
     class(fates_parameters_type), allocatable :: fates_params
-    logical :: is_host_file
 
     if ( hlm_masterproc == itrue ) then
       write(fates_log(), *) 'FatesParametersInterface.F90::'//trim(subname)//' :: CLM reading ED/FATES '//' parameters '
@@ -2182,11 +2181,7 @@ end subroutine SeedlingParPatch
     call PRTRegisterParams(fates_params)     ! PRT mod, only operates on fates_params class
     call FatesSynchronizedParamsInst%RegisterParams(fates_params) !Synchronized params class in Synchronized params mod, only operates on fates_params class
 
-    is_host_file = .false.
-    call param_reader%Read(is_host_file, fates_params)
-
-    is_host_file = .true.
-    call param_reader%Read(is_host_file, fates_params)
+    call param_reader%Read(fates_params)
 
     call FatesReceiveParams(fates_params)
     call SpitFireReceiveParams(fates_params)

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -2391,38 +2391,38 @@ end subroutine DetermineGridCellNeighbors
 
 ! ======================================================================================
      
-  !-----------------------------------------------------------------------
-  ! TODO(jpalex): this belongs in FatesParametersInterface.F90, but would require
-  ! untangling the dependencies of the *RegisterParams methods below.
-  subroutine FatesReadParameters(param_reader)
-    implicit none
-   
-    class(fates_param_reader_type), intent(in) :: param_reader ! HLM-provided param file reader
+!-----------------------------------------------------------------------
+! TODO(jpalex): this belongs in FatesParametersInterface.F90, but would require
+! untangling the dependencies of the *RegisterParams methods below.
+subroutine FatesReadParameters(param_reader)
+  implicit none
+  
+  class(fates_param_reader_type), intent(in) :: param_reader ! HLM-provided param file reader
 
-    character(len=32)  :: subname = 'FatesReadParameters'
-    class(fates_parameters_type), allocatable :: fates_params
+  character(len=32)  :: subname = 'FatesReadParameters'
+  class(fates_parameters_type), allocatable :: fates_params
 
-    if ( hlm_masterproc == itrue ) then
-      write(fates_log(), *) 'FatesParametersInterface.F90::'//trim(subname)//' :: CLM reading ED/FATES '//' parameters '
-    end if
+  if ( hlm_masterproc == itrue ) then
+    write(fates_log(), *) 'FatesParametersInterface.F90::'//trim(subname)//' :: CLM reading ED/FATES '//' parameters '
+  end if
 
-    allocate(fates_params)
-    call fates_params%Init()   ! fates_params class, in FatesParameterInterfaceMod
-    call FatesRegisterParams(fates_params)  !EDParamsMod, only operates on fates_params class
-    call SpitFireRegisterParams(fates_params) !SpitFire Mod, only operates of fates_params class
-    call PRTRegisterParams(fates_params)     ! PRT mod, only operates on fates_params class
-    call FatesSynchronizedParamsInst%RegisterParams(fates_params) !Synchronized params class in Synchronized params mod, only operates on fates_params class
+  allocate(fates_params)
+  call fates_params%Init()   ! fates_params class, in FatesParameterInterfaceMod
+  call FatesRegisterParams(fates_params)  !EDParamsMod, only operates on fates_params class
+  call SpitFireRegisterParams(fates_params) !SpitFire Mod, only operates of fates_params class
+  call PRTRegisterParams(fates_params)     ! PRT mod, only operates on fates_params class
+  call FatesSynchronizedParamsInst%RegisterParams(fates_params) !Synchronized params class in Synchronized params mod, only operates on fates_params class
 
-    call param_reader%Read(fates_params)
+  call param_reader%Read(fates_params)
 
-    call FatesReceiveParams(fates_params)
-    call SpitFireReceiveParams(fates_params)
-    call PRTReceiveParams(fates_params)
-    call FatesSynchronizedParamsInst%ReceiveParams(fates_params)
+  call FatesReceiveParams(fates_params)
+  call SpitFireReceiveParams(fates_params)
+  call PRTReceiveParams(fates_params)
+  call FatesSynchronizedParamsInst%ReceiveParams(fates_params)
 
-    call fates_params%Destroy()
-    deallocate(fates_params)
+  call fates_params%Destroy()
+  deallocate(fates_params)
 
  end subroutine FatesReadParameters
- 
+
 end module FatesInterfaceMod

--- a/main/FatesParametersInterface.F90
+++ b/main/FatesParametersInterface.F90
@@ -83,6 +83,35 @@ module FatesParametersInterface
      
   end type fates_parameters_type
 
+  ! Abstract class (to be implemented by host land models) to read in
+  ! parameter values.
+  type, abstract, public :: fates_param_reader_type
+   contains
+     ! Public functions
+     procedure(Read_interface), public, deferred :: Read
+
+  end type fates_param_reader_type
+
+  abstract interface
+   subroutine Read_interface(this, is_host_file, fates_params )
+    !
+    ! !DESCRIPTION:
+    ! Read 'fates_params' parameters from appropriate filename given 'is_host_file'.
+    !
+    ! USES
+    import :: fates_param_reader_type
+    import :: fates_parameters_type
+    ! !ARGUMENTS:
+    class(fates_param_reader_type) :: this
+    logical, intent(in) :: is_host_file
+    class(fates_parameters_type), intent(inout) :: fates_params
+    !-----------------------------------------------------------------------
+
+    end subroutine Read_interface
+
+  !-----------------------------------------------------------------------
+  end interface
+
 contains
 
   !-----------------------------------------------------------------------

--- a/main/FatesParametersInterface.F90
+++ b/main/FatesParametersInterface.F90
@@ -93,17 +93,17 @@ module FatesParametersInterface
   end type fates_param_reader_type
 
   abstract interface
-   subroutine Read_interface(this, is_host_file, fates_params )
+   subroutine Read_interface(this, fates_params )
     !
     ! !DESCRIPTION:
-    ! Read 'fates_params' parameters from appropriate filename given 'is_host_file'.
+    ! Read 'fates_params' parameters from (HLM-provided) storage. Note this ignores
+    ! the legacy parameter_type.sync_with_host setting.
     !
     ! USES
     import :: fates_param_reader_type
     import :: fates_parameters_type
     ! !ARGUMENTS:
     class(fates_param_reader_type) :: this
-    logical, intent(in) :: is_host_file
     class(fates_parameters_type), intent(inout) :: fates_params
     !-----------------------------------------------------------------------
 


### PR DESCRIPTION
Also copy FatesReadParameters() over from CTSM. (The HLM-side ones can be deleted after they switch over to using this new one, coming next).

### Description:
FATES should not call the HLM, but currently it calls an HLM-side FatesReadParameters() which calls an HLM-side ParametersFromNetCDF() method to actually read the parameters from disk.  

With this change, FATES now has its own copy of FatesReadParameters() which takes in an HLM-provided 'fates_param_reader_type' to read the parameters from disk.  Its existing SetFatesGlobalElements1() method now takes in an optional fates_param_reader_type. Nobody passes this optional param in, yet.

Upcoming PR's will modify the HLM's to construct and pass in instances of fates_param_reader_type (which will basically call the HLM-side ParametersFromNetCDF() method), and then remove the old code path.

Associated CTSM PR: https://github.com/ESCOMP/CTSM/pull/2198
Associated E3SM PR: https://github.com/E3SM-Project/E3SM/pull/6027

[Issue ESCOMP/CTSM/2006](https://github.com/ESCOMP/CTSM/issues/2006)

### Collaborators:
adrifoster@

### Expectation of Answer Changes:
No-op; this adds a code path that isn't yet used by any HLM.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [x] The in-code documentation has been updated with descriptive comments
- [x] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [x] FATES PASS/FAIL regression tests were run
- [x] Evaluation of test results for answer changes was performed and results provided

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update: https://github.com/NGEET/fates-users-guide/issues/54
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->
*CTSM (or) E3SM (specify which) test hash-tag:*
*CTSM (or) E3SM (specify which) baseline hash-tag:*
CTSM ctsm5.1.dev142

*FATES baseline hash-tag:*
fates-sci.1.67.5_api.27.0.0

*Test Output:*
(I ran the 'fates' test suite)

> sh /glade/scratch/jpalex/tests_1011-184611ch/cs.status.fails

1011-184611ch_gnu: 3 tests
    FAIL ERS_Lm13.f10_f10_mg37.I2000Clm50Fates.cheyenne_gnu.clm-FatesCold COMPARE_base_rest (EXPECTED FAILURE)

 
1011-184611ch_int: 34 tests
    PEND ERP_P72x2_Ld30.f45_f45_mg37.I2000Clm50FatesRs.cheyenne_intel.clm-mimicsFatesCold SHAREDLIB_BUILD (EXPECTED FAILURE)
    FAIL ERS_D_Ld5.1x1_brazil.I2000Clm50FatesCruRsGs.cheyenne_intel.clm-FatesColdHydro COMPARE_base_rest (EXPECTED FAILURE)
    FAIL ERS_Lm12.1x1_brazil.I2000Clm50FatesCruRsGs.cheyenne_intel.clm-FatesFireLightningPopDens COMPARE_base_rest (EXPECTED FAILURE)
    FAIL ERS_Lm13.f45_f45_mg37.I2000Clm50Fates.cheyenne_intel.clm-FatesColdNoComp COMPARE_base_rest (EXPECTED FAILURE)


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

