### PR TITLE
Clean inventory initialization files

### DIFF
--- a/main/FatesInventoryInitMod.F90
+++ b/main/FatesInventoryInitMod.F90
@@ -168,10 +168,12 @@ contains
       character(len=patchname_strlen), allocatable :: patch_name_vec(:)    ! vector of patch ID strings
       real(r8)                                     :: basal_area_postf     ! basal area before fusion (m2/ha)
       real(r8)                                     :: basal_area_pref      ! basal area after fusion (m2/ha)
-      real(r8)                                     :: min_patch_age
-      real(r8)                                     :: max_patch_age
-      real(r8)                                     :: min_cohort_dbh
-      real(r8)                                     :: max_cohort_dbh
+      real(r8)                                     :: n_pref
+      real(r8)                                     :: n_postf
+ !     real(r8)                                     :: min_patch_age
+!      real(r8)                                     :: max_patch_age
+!      real(r8)                                     :: min_cohort_dbh
+!     real(r8)                                     :: max_cohort_dbh
       
 
       ! I. Load the inventory list file, do some file handle checks
@@ -406,137 +408,139 @@ contains
          deallocate(patch_pointer_vec,patch_name_vec)
 
          
-         ! if all patches are identical in age and biomass then don't change the order of the LL
-         min_patch_age  = 0._r8
-         max_patch_age  = 0._r8
-         min_cohort_dbh = 100000._r8
-         max_cohort_dbh = 0._r8
+         ! ! if all patches are identical in age and biomass then don't change the order of the LL
+         ! min_patch_age  = 0._r8
+         ! max_patch_age  = 0._r8
+         ! min_cohort_dbh = 100000._r8
+         ! max_cohort_dbh = 0._r8
 
-         ! get min and max patch age and cohort dbh
-         currentpatch => sites(s)%youngest_patch
-         do while(associated(currentpatch))
+         ! ! get min and max patch age and cohort dbh
+         ! currentpatch => sites(s)%youngest_patch
+         ! do while(associated(currentpatch))
 
-            if ( currentpatch%age > max_patch_age ) then
-               max_patch_age = currentpatch%age
-            else if ( currentpatch%age <  min_patch_age ) then
-               min_patch_age = currentpatch%age
-            end if
+         !    if ( currentpatch%age > max_patch_age ) then
+         !       max_patch_age = currentpatch%age
+         !    else if ( currentpatch%age <  min_patch_age ) then
+         !       min_patch_age = currentpatch%age
+         !    end if
 
-            currentcohort => currentpatch%tallest
-            do while(associated(currentcohort))
+         !    currentcohort => currentpatch%tallest
+         !    do while(associated(currentcohort))
 
-               if ( currentcohort%dbh > max_cohort_dbh ) then
-                  max_cohort_dbh = currentcohort%dbh
-               else if ( currentcohort%dbh <  min_cohort_dbh ) then
-                  min_cohort_dbh = currentcohort%dbh
-               end if
+         !       if ( currentcohort%dbh > max_cohort_dbh ) then
+         !          max_cohort_dbh = currentcohort%dbh
+         !       else if ( currentcohort%dbh <  min_cohort_dbh ) then
+         !          min_cohort_dbh = currentcohort%dbh
+         !       end if
 
-               currentcohort => currentcohort%shorter
-            end do
-            currentPatch => currentpatch%older
-         enddo
+         !       currentcohort => currentcohort%shorter
+         !    end do
+         !    currentPatch => currentpatch%older
+         ! enddo
 
-         if  (debug_inv) then
-            write(fates_log(),*)  'min patch age', min_patch_age
-            write(fates_log(),*)  'max patch age', max_patch_age
-            write(fates_log(),*)  'min cohort dbh', min_cohort_dbh
-            write(fates_log(),*)  'max cohort dbh', max_cohort_dbh
-         end if
+         ! if  (debug_inv) then
+         !    write(fates_log(),*)  'min patch age', min_patch_age
+         !    write(fates_log(),*)  'max patch age', max_patch_age
+         !    write(fates_log(),*)  'min cohort dbh', min_cohort_dbh
+         !    write(fates_log(),*)  'max cohort dbh', max_cohort_dbh
+         ! end if
          
-         if ( min_patch_age .eq. max_patch_age .and. min_cohort_dbh .eq. max_cohort_dbh ) then
+         ! if ( min_patch_age .eq. max_patch_age .and. min_cohort_dbh .eq. max_cohort_dbh ) then
 
-            if(debug_inv)then
-               write(fates_log(), *) 'All patches and cohorts are identical'
-            end if
+         !    if(debug_inv)then
+         !       write(fates_log(), *) 'All patches and cohorts are identical'
+         !    end if
 
             
-            ! now that we've read in the patch and cohort info, check to see if there is any real age info
-         else if ( abs(sites(s)%youngest_patch%age - sites(s)%oldest_patch%age) <= nearzero .and. &
-              associated(sites(s)%youngest_patch%older) ) then
+         !    ! now that we've read in the patch and cohort info, check to see if there is any real age info
+         ! else if ( abs(sites(s)%youngest_patch%age - sites(s)%oldest_patch%age) <= nearzero .and. &
+         !      associated(sites(s)%youngest_patch%older) ) then
 
-            ! so there are at least two patches and the oldest and youngest are the same age.
-            ! this means that sorting by age wasn't very useful.  try sorting by total biomass instead
+         !    ! so there are at least two patches and the oldest and youngest are the same age.
+         !    ! this means that sorting by age wasn't very useful.  try sorting by total biomass instead
 
-            ! first calculate the biomass in each patch.  simplest way is to use the patch fusion criteria
-            currentpatch => sites(s)%youngest_patch
-            do while(associated(currentpatch))
-               call patch_pft_size_profile(currentPatch)
-               currentPatch => currentpatch%older
-            enddo
+         !    ! first calculate the biomass in each patch.  simplest way is to use the patch fusion criteria
+         !    currentpatch => sites(s)%youngest_patch
+         !    do while(associated(currentpatch))
+         !       call patch_pft_size_profile(currentPatch)
+         !       currentPatch => currentpatch%older
+         !    enddo
 
-            ! now we need to sort them.
-            ! first generate a new head of the linked list.
-            head_of_unsorted_patch_list => sites(s)%youngest_patch%older
+         !    ! now we need to sort them.
+         !    ! first generate a new head of the linked list.
+         !    head_of_unsorted_patch_list => sites(s)%youngest_patch%older
 
-            ! reset the site-level patch linked list, keeping only the youngest patch.
-            sites(s)%youngest_patch%older => null()
-            sites(s)%youngest_patch%younger => null()
-            sites(s)%oldest_patch   => sites(s)%youngest_patch
+         !    ! reset the site-level patch linked list, keeping only the youngest patch.
+         !    sites(s)%youngest_patch%older => null()
+         !    sites(s)%youngest_patch%younger => null()
+         !    sites(s)%oldest_patch   => sites(s)%youngest_patch
 
-            ! loop through each patch in the unsorted LL, peel it off,
-            ! and insert it into the new, sorted LL
-            do while(associated(head_of_unsorted_patch_list))
+         !    ! loop through each patch in the unsorted LL, peel it off,
+         !    ! and insert it into the new, sorted LL
+         !    do while(associated(head_of_unsorted_patch_list))
 
-               ! first keep track of the next patch in the old (unsorted) linked list
-               next_in_unsorted_patch_list => head_of_unsorted_patch_list%older
+         !       ! first keep track of the next patch in the old (unsorted) linked list
+         !       next_in_unsorted_patch_list => head_of_unsorted_patch_list%older
 
-               ! check the two end-cases
+         !       ! check the two end-cases
 
-               ! Youngest Patch
-               if(sum(head_of_unsorted_patch_list%pft_agb_profile(:,:)) <= &
-                    sum(sites(s)%youngest_patch%pft_agb_profile(:,:)))then
-                  head_of_unsorted_patch_list%older                  => sites(s)%youngest_patch
-                  head_of_unsorted_patch_list%younger                => null()
-                  sites(s)%youngest_patch%younger => head_of_unsorted_patch_list
-                  sites(s)%youngest_patch         => head_of_unsorted_patch_list
+         !       ! Youngest Patch
+         !       if(sum(head_of_unsorted_patch_list%pft_agb_profile(:,:)) <= &
+         !            sum(sites(s)%youngest_patch%pft_agb_profile(:,:)))then
+         !          head_of_unsorted_patch_list%older                  => sites(s)%youngest_patch
+         !          head_of_unsorted_patch_list%younger                => null()
+         !          sites(s)%youngest_patch%younger => head_of_unsorted_patch_list
+         !          sites(s)%youngest_patch         => head_of_unsorted_patch_list
 
-                  ! Oldest Patch
-               else if(sum(head_of_unsorted_patch_list%pft_agb_profile(:,:)) > &
-                    sum(sites(s)%oldest_patch%pft_agb_profile(:,:)))then
-                  head_of_unsorted_patch_list%older              => null()
-                  head_of_unsorted_patch_list%younger            => sites(s)%oldest_patch
-                  sites(s)%oldest_patch%older => head_of_unsorted_patch_list
-                  sites(s)%oldest_patch       => head_of_unsorted_patch_list
+         !          ! Oldest Patch
+         !       else if(sum(head_of_unsorted_patch_list%pft_agb_profile(:,:)) > &
+         !            sum(sites(s)%oldest_patch%pft_agb_profile(:,:)))then
+         !          head_of_unsorted_patch_list%older              => null()
+         !          head_of_unsorted_patch_list%younger            => sites(s)%oldest_patch
+         !          sites(s)%oldest_patch%older => head_of_unsorted_patch_list
+         !          sites(s)%oldest_patch       => head_of_unsorted_patch_list
 
-                  ! Somewhere in the middle
-               else
-                  currentpatch => sites(s)%youngest_patch
-                  do while(associated(currentpatch))
-                     olderpatch => currentpatch%older
-                     if(associated(currentpatch%older)) then
-                        if(sum(head_of_unsorted_patch_list%pft_agb_profile(:,:)) >= &
-                             sum(currentpatch%pft_agb_profile(:,:)) .and. &
-                             sum(head_of_unsorted_patch_list%pft_agb_profile(:,:)) < &
-                             sum(olderpatch%pft_agb_profile(:,:))) then
-                           ! Set the new patches pointers
-                           head_of_unsorted_patch_list%older   => currentpatch%older
-                           head_of_unsorted_patch_list%younger => currentpatch
-                           ! Fix the patch's older pointer
-                           currentpatch%older => head_of_unsorted_patch_list
-                           ! Fix the older patch's younger pointer
-                           olderpatch%younger => head_of_unsorted_patch_list
-                           ! Exit the loop once head sorted to avoid later re-sort
-                           exit
-                        end if
-                     end if
-                     currentPatch => olderpatch
-                  enddo
-               end if
+         !          ! Somewhere in the middle
+         !       else
+         !          currentpatch => sites(s)%youngest_patch
+         !          do while(associated(currentpatch))
+         !             olderpatch => currentpatch%older
+         !             if(associated(currentpatch%older)) then
+         !                if(sum(head_of_unsorted_patch_list%pft_agb_profile(:,:)) >= &
+         !                     sum(currentpatch%pft_agb_profile(:,:)) .and. &
+         !                     sum(head_of_unsorted_patch_list%pft_agb_profile(:,:)) < &
+         !                     sum(olderpatch%pft_agb_profile(:,:))) then
+         !                   ! Set the new patches pointers
+         !                   head_of_unsorted_patch_list%older   => currentpatch%older
+         !                   head_of_unsorted_patch_list%younger => currentpatch
+         !                   ! Fix the patch's older pointer
+         !                   currentpatch%older => head_of_unsorted_patch_list
+         !                   ! Fix the older patch's younger pointer
+         !                   olderpatch%younger => head_of_unsorted_patch_list
+         !                   ! Exit the loop once head sorted to avoid later re-sort
+         !                   exit
+         !                end if
+         !             end if
+         !             currentPatch => olderpatch
+         !          enddo
+         !       end if
 
-               ! now work through to the next element in the unsorted linked list
-               head_of_unsorted_patch_list => next_in_unsorted_patch_list
-            end do
-         endif
+         !       ! now work through to the next element in the unsorted linked list
+         !       head_of_unsorted_patch_list => next_in_unsorted_patch_list
+         !    end do
+         ! endif
 
          ! Report Basal Area (as a check on if things were read in)
          ! ------------------------------------------------------------------------------
          basal_area_pref = 0.0_r8
+         n_pref = 0.0_r8
          currentpatch => sites(s)%youngest_patch
          do while(associated(currentpatch))
             currentcohort => currentpatch%tallest
             do while(associated(currentcohort))
                basal_area_pref = basal_area_pref + &
-                     currentcohort%n*0.25*((currentcohort%dbh/100.0_r8)**2.0_r8)*pi_const
+                    currentcohort%n*0.25*((currentcohort%dbh/100.0_r8)**2.0_r8)*pi_const
+               n_pref = n_pref + currentcohort%n
                currentcohort => currentcohort%shorter
             end do
             currentPatch => currentpatch%older
@@ -546,6 +550,7 @@ contains
          write(fates_log(),*) 'Basal Area from inventory, BEFORE fusion'
          write(fates_log(),*) 'Lat: ',sites(s)%lat,' Lon: ',sites(s)%lon
          write(fates_log(),*) basal_area_pref,' [m2/ha]'
+         write(fates_log(),*) 'number of plants:  ', n_pref
          write(fates_log(),*) '-------------------------------------------------------'
                   
          ! Update the patch index numbers and fuse the cohorts in the patches
@@ -583,12 +588,14 @@ contains
          ! ----------------------------------------------------------------------------------------
          !call canopy_structure(sites(s),bc_in(s))
          basal_area_postf = 0.0_r8
+         n_postf = 0.0_r8
          currentpatch => sites(s)%youngest_patch
          do while(associated(currentpatch))
             currentcohort => currentpatch%tallest
             do while(associated(currentcohort))
                basal_area_postf = basal_area_postf + &
                      currentcohort%n*0.25*((currentcohort%dbh/100.0_r8)**2.0_r8)*pi_const
+               n_postf = n_postf + currentcohort%n
                currentcohort => currentcohort%shorter
             end do
             
@@ -601,6 +608,7 @@ contains
          write(fates_log(),*) 'Basal Area from inventory, AFTER fusion'
          write(fates_log(),*) 'Lat: ',sites(s)%lat,' Lon: ',sites(s)%lon
          write(fates_log(),*) basal_area_postf,' [m2/ha]'
+         write(fates_log(),*) 'jfn n  post f :', n_postf
          write(fates_log(),*) '-------------------------------------------------------'
 
          ! If this is flagged as true, the post-fusion inventory will be written to file
@@ -1077,9 +1085,11 @@ contains
          if( c_dbh> 0._r8)then
             temp_cohort%dbh         = c_dbh
             call h_allom(c_dbh,temp_cohort%pft,temp_cohort%height)
+            write(fates_log(),*) 'jfn - using dbh'
          else
             temp_cohort%height  = c_height
             call h2d_allom(c_height,temp_cohort%pft,temp_cohort%dbh)
+            write(fates_log(),*) 'jfn - using height'
          end if
             
          temp_cohort%canopy_trim = 1.0_r8

--- a/main/FatesInventoryInitMod.F90
+++ b/main/FatesInventoryInitMod.F90
@@ -843,6 +843,7 @@ contains
       ! time	(year)     year of measurement
       ! patch	(string)   patch id string associated with this cohort
       ! dbh	(cm)       diameter at breast height
+      ! height  (m)        height of vegetation in m. Currently not used. 
       ! pft     (integer)  the plant functional type index (must be consistent with param file)
       ! n 	(/m2)      The plant number density
       ! --------------------------------------------------------------------------------------------
@@ -874,6 +875,7 @@ contains
       real(r8)                                    :: c_time        ! Time patch was recorded
       character(len=patchname_strlen)             :: p_name        ! The patch associated with this cohort
       real(r8)                                    :: c_dbh         ! diameter at breast height (cm)
+      real(r8)                                    :: c_height      ! tree height (m)
       integer                                     :: c_pft         ! plant functional type index
       real(r8)                                    :: c_nplant      ! plant density (/m2)
       real(r8)                                    :: site_spread   ! initial guess of site spread
@@ -914,11 +916,11 @@ contains
 
      
       read(css_file_unit,fmt=*,iostat=ios) c_time, p_name, c_dbh, &
-            c_pft, c_nplant
+            c_height, c_pft, c_nplant
 
       if( debug_inv) then
          write(*,fmt=wr_fmt) &
-              c_time, p_name, c_dbh, c_pft, c_nplant
+              c_time, p_name, c_dbh, c_height, c_pft, c_nplant
       end if
 
       if (ios/=0) return
@@ -935,7 +937,7 @@ contains
       if(.not.matched_patch)then
          write(fates_log(), *) 'could not match a cohort with a patch'
          write(fates_log(),fmt=wr_fmt) &
-               c_time, p_name, c_dbh, c_pft, c_nplant
+               c_time, p_name, c_dbh, c_height, c_pft, c_nplant
          call endrun(msg=errMsg(sourcefile, __LINE__))
       end if
 
@@ -1242,7 +1244,7 @@ contains
        open(unit=css_file_out,file=trim(css_name_out), status='UNKNOWN',action='WRITE',form='FORMATTED')
 
        write(pss_file_out,*) 'time patch trk age area'
-       write(css_file_out,*) 'time patch cohort dbh pft nplant'
+       write(css_file_out,*) 'time patch cohort dbh height pft nplant'
 
        ipatch=0
        currentpatch => currentSite%youngest_patch

--- a/main/FatesInventoryInitMod.F90
+++ b/main/FatesInventoryInitMod.F90
@@ -29,6 +29,7 @@ module FatesInventoryInitMod
    use FatesConstantsMod, only : r8 => fates_r8
    use FatesConstantsMod, only : pi_const
    use FatesConstantsMod, only : itrue
+   use FatesConstantsMod, only : nearzero
    use FatesGlobals     , only : endrun => fates_endrun
    use FatesGlobals     , only : fates_log
    use EDParamsMod      , only : regeneration_model

--- a/main/FatesInventoryInitMod.F90
+++ b/main/FatesInventoryInitMod.F90
@@ -168,9 +168,7 @@ contains
       character(len=patchname_strlen), allocatable :: patch_name_vec(:)    ! vector of patch ID strings
       real(r8)                                     :: basal_area_postf     ! basal area before fusion (m2/ha)
       real(r8)                                     :: basal_area_pref      ! basal area after fusion (m2/ha)
-      real(r8)                                     :: n_pref
-      real(r8)                                     :: n_postf
-
+    
       ! I. Load the inventory list file, do some file handle checks
       ! ------------------------------------------------------------------------------------------
 
@@ -405,14 +403,12 @@ contains
          ! Report Basal Area (as a check on if things were read in)
          ! ------------------------------------------------------------------------------
          basal_area_pref = 0.0_r8
-         n_pref = 0.0_r8
          currentpatch => sites(s)%youngest_patch
          do while(associated(currentpatch))
             currentcohort => currentpatch%tallest
             do while(associated(currentcohort))
                basal_area_pref = basal_area_pref + &
                     currentcohort%n*0.25*((currentcohort%dbh/100.0_r8)**2.0_r8)*pi_const
-               n_pref = n_pref + currentcohort%n
                currentcohort => currentcohort%shorter
             end do
             currentPatch => currentpatch%older
@@ -422,7 +418,6 @@ contains
          write(fates_log(),*) 'Basal Area from inventory, BEFORE fusion'
          write(fates_log(),*) 'Lat: ',sites(s)%lat,' Lon: ',sites(s)%lon
          write(fates_log(),*) basal_area_pref,' [m2/ha]'
-         write(fates_log(),*) 'number of plants:  ', n_pref
          write(fates_log(),*) '-------------------------------------------------------'
                   
          ! Update the patch index numbers and fuse the cohorts in the patches
@@ -460,14 +455,12 @@ contains
          ! ----------------------------------------------------------------------------------------
          !call canopy_structure(sites(s),bc_in(s))
          basal_area_postf = 0.0_r8
-         n_postf = 0.0_r8
          currentpatch => sites(s)%youngest_patch
          do while(associated(currentpatch))
             currentcohort => currentpatch%tallest
             do while(associated(currentcohort))
                basal_area_postf = basal_area_postf + &
                      currentcohort%n*0.25*((currentcohort%dbh/100.0_r8)**2.0_r8)*pi_const
-               n_postf = n_postf + currentcohort%n
                currentcohort => currentcohort%shorter
             end do
             
@@ -480,7 +473,6 @@ contains
          write(fates_log(),*) 'Basal Area from inventory, AFTER fusion'
          write(fates_log(),*) 'Lat: ',sites(s)%lat,' Lon: ',sites(s)%lon
          write(fates_log(),*) basal_area_postf,' [m2/ha]'
-         write(fates_log(),*) 'jfn n  post f :', n_postf
          write(fates_log(),*) '-------------------------------------------------------'
 
          ! If this is flagged as true, the post-fusion inventory will be written to file

--- a/main/FatesInventoryInitMod.F90
+++ b/main/FatesInventoryInitMod.F90
@@ -1195,7 +1195,7 @@ contains
        open(unit=css_file_out,file=trim(css_name_out), status='UNKNOWN',action='WRITE',form='FORMATTED')
 
        write(pss_file_out,*) 'time patch trk age area'
-       write(css_file_out,*) 'time patch cohort dbh height pft nplant'
+       write(css_file_out,*) 'time patch dbh height pft nplant'
 
        ipatch=0
        currentpatch => currentSite%youngest_patch

--- a/main/FatesInventoryInitMod.F90
+++ b/main/FatesInventoryInitMod.F90
@@ -170,11 +170,6 @@ contains
       real(r8)                                     :: basal_area_pref      ! basal area after fusion (m2/ha)
       real(r8)                                     :: n_pref
       real(r8)                                     :: n_postf
- !     real(r8)                                     :: min_patch_age
-!      real(r8)                                     :: max_patch_age
-!      real(r8)                                     :: min_cohort_dbh
-!     real(r8)                                     :: max_cohort_dbh
-      
 
       ! I. Load the inventory list file, do some file handle checks
       ! ------------------------------------------------------------------------------------------
@@ -406,129 +401,6 @@ contains
          call shr_file_freeUnit(css_file_unit)
 
          deallocate(patch_pointer_vec,patch_name_vec)
-
-         
-         ! ! if all patches are identical in age and biomass then don't change the order of the LL
-         ! min_patch_age  = 0._r8
-         ! max_patch_age  = 0._r8
-         ! min_cohort_dbh = 100000._r8
-         ! max_cohort_dbh = 0._r8
-
-         ! ! get min and max patch age and cohort dbh
-         ! currentpatch => sites(s)%youngest_patch
-         ! do while(associated(currentpatch))
-
-         !    if ( currentpatch%age > max_patch_age ) then
-         !       max_patch_age = currentpatch%age
-         !    else if ( currentpatch%age <  min_patch_age ) then
-         !       min_patch_age = currentpatch%age
-         !    end if
-
-         !    currentcohort => currentpatch%tallest
-         !    do while(associated(currentcohort))
-
-         !       if ( currentcohort%dbh > max_cohort_dbh ) then
-         !          max_cohort_dbh = currentcohort%dbh
-         !       else if ( currentcohort%dbh <  min_cohort_dbh ) then
-         !          min_cohort_dbh = currentcohort%dbh
-         !       end if
-
-         !       currentcohort => currentcohort%shorter
-         !    end do
-         !    currentPatch => currentpatch%older
-         ! enddo
-
-         ! if  (debug_inv) then
-         !    write(fates_log(),*)  'min patch age', min_patch_age
-         !    write(fates_log(),*)  'max patch age', max_patch_age
-         !    write(fates_log(),*)  'min cohort dbh', min_cohort_dbh
-         !    write(fates_log(),*)  'max cohort dbh', max_cohort_dbh
-         ! end if
-         
-         ! if ( min_patch_age .eq. max_patch_age .and. min_cohort_dbh .eq. max_cohort_dbh ) then
-
-         !    if(debug_inv)then
-         !       write(fates_log(), *) 'All patches and cohorts are identical'
-         !    end if
-
-            
-         !    ! now that we've read in the patch and cohort info, check to see if there is any real age info
-         ! else if ( abs(sites(s)%youngest_patch%age - sites(s)%oldest_patch%age) <= nearzero .and. &
-         !      associated(sites(s)%youngest_patch%older) ) then
-
-         !    ! so there are at least two patches and the oldest and youngest are the same age.
-         !    ! this means that sorting by age wasn't very useful.  try sorting by total biomass instead
-
-         !    ! first calculate the biomass in each patch.  simplest way is to use the patch fusion criteria
-         !    currentpatch => sites(s)%youngest_patch
-         !    do while(associated(currentpatch))
-         !       call patch_pft_size_profile(currentPatch)
-         !       currentPatch => currentpatch%older
-         !    enddo
-
-         !    ! now we need to sort them.
-         !    ! first generate a new head of the linked list.
-         !    head_of_unsorted_patch_list => sites(s)%youngest_patch%older
-
-         !    ! reset the site-level patch linked list, keeping only the youngest patch.
-         !    sites(s)%youngest_patch%older => null()
-         !    sites(s)%youngest_patch%younger => null()
-         !    sites(s)%oldest_patch   => sites(s)%youngest_patch
-
-         !    ! loop through each patch in the unsorted LL, peel it off,
-         !    ! and insert it into the new, sorted LL
-         !    do while(associated(head_of_unsorted_patch_list))
-
-         !       ! first keep track of the next patch in the old (unsorted) linked list
-         !       next_in_unsorted_patch_list => head_of_unsorted_patch_list%older
-
-         !       ! check the two end-cases
-
-         !       ! Youngest Patch
-         !       if(sum(head_of_unsorted_patch_list%pft_agb_profile(:,:)) <= &
-         !            sum(sites(s)%youngest_patch%pft_agb_profile(:,:)))then
-         !          head_of_unsorted_patch_list%older                  => sites(s)%youngest_patch
-         !          head_of_unsorted_patch_list%younger                => null()
-         !          sites(s)%youngest_patch%younger => head_of_unsorted_patch_list
-         !          sites(s)%youngest_patch         => head_of_unsorted_patch_list
-
-         !          ! Oldest Patch
-         !       else if(sum(head_of_unsorted_patch_list%pft_agb_profile(:,:)) > &
-         !            sum(sites(s)%oldest_patch%pft_agb_profile(:,:)))then
-         !          head_of_unsorted_patch_list%older              => null()
-         !          head_of_unsorted_patch_list%younger            => sites(s)%oldest_patch
-         !          sites(s)%oldest_patch%older => head_of_unsorted_patch_list
-         !          sites(s)%oldest_patch       => head_of_unsorted_patch_list
-
-         !          ! Somewhere in the middle
-         !       else
-         !          currentpatch => sites(s)%youngest_patch
-         !          do while(associated(currentpatch))
-         !             olderpatch => currentpatch%older
-         !             if(associated(currentpatch%older)) then
-         !                if(sum(head_of_unsorted_patch_list%pft_agb_profile(:,:)) >= &
-         !                     sum(currentpatch%pft_agb_profile(:,:)) .and. &
-         !                     sum(head_of_unsorted_patch_list%pft_agb_profile(:,:)) < &
-         !                     sum(olderpatch%pft_agb_profile(:,:))) then
-         !                   ! Set the new patches pointers
-         !                   head_of_unsorted_patch_list%older   => currentpatch%older
-         !                   head_of_unsorted_patch_list%younger => currentpatch
-         !                   ! Fix the patch's older pointer
-         !                   currentpatch%older => head_of_unsorted_patch_list
-         !                   ! Fix the older patch's younger pointer
-         !                   olderpatch%younger => head_of_unsorted_patch_list
-         !                   ! Exit the loop once head sorted to avoid later re-sort
-         !                   exit
-         !                end if
-         !             end if
-         !             currentPatch => olderpatch
-         !          enddo
-         !       end if
-
-         !       ! now work through to the next element in the unsorted linked list
-         !       head_of_unsorted_patch_list => next_in_unsorted_patch_list
-         !    end do
-         ! endif
 
          ! Report Basal Area (as a check on if things were read in)
          ! ------------------------------------------------------------------------------
@@ -1085,11 +957,9 @@ contains
          if( c_dbh> 0._r8)then
             temp_cohort%dbh         = c_dbh
             call h_allom(c_dbh,temp_cohort%pft,temp_cohort%height)
-            write(fates_log(),*) 'jfn - using dbh'
          else
             temp_cohort%height  = c_height
             call h2d_allom(c_height,temp_cohort%pft,temp_cohort%dbh)
-            write(fates_log(),*) 'jfn - using height'
          end if
             
          temp_cohort%canopy_trim = 1.0_r8
@@ -1313,9 +1183,9 @@ contains
            ilon_sign = 'W'
        end if
 
-       write(pss_name_out,'(A8,I2.2,A1,I5.5,A1,A1,I3.3,A1,I5.5,A1,A4)') &
+       write(pss_name_out,'(A8, I2.2, A1, I5.5, A1)') &
              'pss_out_',ilat_int,'.',ilat_dec,ilat_sign,'_',ilon_int,'.',ilon_dec,ilon_sign,'.txt'
-       write(css_name_out,'(A8,I2.2,A1,I5.5,A1,A1,I3.3,A1,I5.5,A1,A4)') &
+       write(css_name_out,'(A8, I2.2,  A1, A1, I3.3, A1)') &
              'css_out_',ilat_int,'.',ilat_dec,ilat_sign,'_',ilon_int,'.',ilon_dec,ilon_sign,'.txt'
 
        pss_file_out       = shr_file_getUnit()
@@ -1334,16 +1204,14 @@ contains
 
            write(patch_str,'(A7,i4.4,A)') '<patch_',ipatch,'>'
 
-           write(pss_file_out,*) '0000 ',trim(patch_str),' 2 ',currentPatch%age,currentPatch%area/AREA, &
-                 '0.0000    0.0000    0.0000    0.0000    0.0000    0.0000    0.0000    0.0000'
+           write(pss_file_out,*) '0000 ',trim(patch_str),' 2 ',currentPatch%age,currentPatch%area/AREA
 
            icohort=0
            currentcohort => currentpatch%tallest
            do while(associated(currentcohort))
                icohort=icohort+1
-               write(cohort_str,'(A7,i4.4,A)') '<coh_',icohort,'>'
-               write(css_file_out,*) '0000 ',trim(patch_str),' ',trim(cohort_str), &
-                     currentCohort%dbh,0.0,currentCohort%pft,currentCohort%n/currentPatch%area,0.0,0.0,0.0
+               write(css_file_out,*) '0000 ',trim(patch_str), &
+                     currentCohort%dbh,currentCohort%height,currentCohort%pft,currentCohort%n/currentPatch%area
 
                currentcohort => currentcohort%shorter
            end do

--- a/main/FatesInventoryInitMod.F90
+++ b/main/FatesInventoryInitMod.F90
@@ -842,7 +842,6 @@ contains
       ! FILE FORMAT:
       ! time	(year)     year of measurement
       ! patch	(string)   patch id string associated with this cohort
-      ! index	(integer)  cohort index
       ! dbh	(cm)       diameter at breast height
       ! pft     (integer)  the plant functional type index (must be consistent with param file)
       ! n 	(/m2)      The plant number density
@@ -874,7 +873,6 @@ contains
       class(prt_vartypes), pointer                :: prt_obj
       real(r8)                                    :: c_time        ! Time patch was recorded
       character(len=patchname_strlen)             :: p_name        ! The patch associated with this cohort
-      character(len=cohortname_strlen)            :: c_name        ! cohort index
       real(r8)                                    :: c_dbh         ! diameter at breast height (cm)
       integer                                     :: c_pft         ! plant functional type index
       real(r8)                                    :: c_nplant      ! plant density (/m2)
@@ -915,12 +913,12 @@ contains
       integer,  parameter :: recruitstatus = 0
 
      
-      read(css_file_unit,fmt=*,iostat=ios) c_time, p_name, c_name, c_dbh, &
+      read(css_file_unit,fmt=*,iostat=ios) c_time, p_name, c_dbh, &
             c_pft, c_nplant
 
       if( debug_inv) then
          write(*,fmt=wr_fmt) &
-              c_time, p_name, c_name, c_dbh, c_pft, c_nplant
+              c_time, p_name, c_dbh, c_pft, c_nplant
       end if
 
       if (ios/=0) return
@@ -937,7 +935,7 @@ contains
       if(.not.matched_patch)then
          write(fates_log(), *) 'could not match a cohort with a patch'
          write(fates_log(),fmt=wr_fmt) &
-               c_time, p_name, c_name, c_dbh, c_pft, c_nplant
+               c_time, p_name, c_dbh, c_pft, c_nplant
          call endrun(msg=errMsg(sourcefile, __LINE__))
       end if
 

--- a/tools/ed2_to_fates_inventory_init.py
+++ b/tools/ed2_to_fates_inventory_init.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+### This script takes a ED2 style inventory init file and converts it to a file compatible with FATES.
+# It accepts the following flags:
+# --type : patch or cohort
+# --fin : input filename
+# --fout : output file name
+
+import argparse
+import pandas as pd
+import sys
+
+def main():
+    parser = argparse.ArgumentParser(description='Parse command line arguments to this script.')
+    #
+    parser.add_argument('--type', dest='fatestype', type=str, help="patch or cohort. Required.", required=True)
+    parser.add_argument('--fin', dest='fnamein', type=str, help="Input filename.  Required.", required=True)
+    parser.add_argument('--fout', dest='fnameout', type=str, help="Output filename.  Required.", required=True) 
+
+    args = parser.parse_args()
+
+    # open the input data
+    dsin = pd.read_csv(args.fnamein, delim_whitespace=True)
+
+    # if patch file delete unnecessary patch columns
+    if args.fatestype == 'patch' :
+        keep_col = ['time', 'patch', 'trk', 'age', 'area']
+        newds = dsin[keep_col]
+        
+
+    # if cohort file delete unnecessary cohort columns
+    elif args.fatestype == 'cohort' :
+        keep_col = ['time', 'patch', 'dbh', 'pft', 'nplant']
+        newds = dsin[keep_col]
+        
+    else :
+        print("type must be one of patch or cohort")
+
+
+    newds.to_csv(args.fnameout , index=False, sep=' ')    
+# ========================================================================================================
+# This is the actual call to main
+
+if __name__ == "__main__":
+    main()
+    

--- a/tools/ed2_to_fates_inventory_init.py
+++ b/tools/ed2_to_fates_inventory_init.py
@@ -2,9 +2,7 @@
 
 ### This script takes a ED2 style inventory init file and converts it to a file compatible with FATES.
 # It accepts the following flags:
-# --type : patch or cohort
 # --fin : input filename
-# --fout : output file name
 
 import argparse
 import pandas as pd
@@ -13,23 +11,28 @@ import sys
 def main():
     parser = argparse.ArgumentParser(description='Parse command line arguments to this script.')
     #
-    parser.add_argument('--type', dest='fatestype', type=str, help="patch or cohort. Required.", required=True)
     parser.add_argument('--fin', dest='fnamein', type=str, help="Input filename.  Required.", required=True)
-    parser.add_argument('--fout', dest='fnameout', type=str, help="Output filename.  Required.", required=True) 
-
+  
     args = parser.parse_args()
+
+    # is it a pss or css file?
+    filetype  = args.fnamein.split('.')[1]
+
+    # make the new file name
+    base_filename = args.fnamein.split('.')[0]
+    output_filename = f"{base_filename}_{'fates'}.{filetype}"
 
     # open the input data
     dsin = pd.read_csv(args.fnamein, delim_whitespace=True)
 
     # if patch file delete unnecessary patch columns
-    if args.fatestype == 'patch' :
+    if filetype == 'pss' :
         keep_col = ['time', 'patch', 'trk', 'age', 'area']
         newds = dsin[keep_col]
         
 
     # if cohort file delete unnecessary cohort columns
-    elif args.fatestype == 'cohort' :
+    elif filetype == 'css' :
         keep_col = ['time', 'patch', 'dbh', 'pft', 'nplant']
         newds = dsin[keep_col]
         
@@ -37,7 +40,7 @@ def main():
         print("type must be one of patch or cohort")
 
 
-    newds.to_csv(args.fnameout , index=False, sep=' ')    
+    newds.to_csv(output_filename, index=False, sep=' ')    
 # ========================================================================================================
 # This is the actual call to main
 

--- a/tools/ed2_to_fates_inventory_init.py
+++ b/tools/ed2_to_fates_inventory_init.py
@@ -33,11 +33,11 @@ def main():
 
     # if cohort file delete unnecessary cohort columns
     elif filetype == 'css' :
-        keep_col = ['time', 'patch', 'dbh', 'pft', 'nplant']
+        keep_col = ['time', 'patch', 'dbh', 'height', 'pft', 'nplant']
         newds = dsin[keep_col]
         
     else :
-        print("type must be one of patch or cohort")
+        print("file type must be one of patch (pss) or cohort (css)")
 
 
     newds.to_csv(output_filename, index=False, sep=' ')    


### PR DESCRIPTION
This PR address issue #1062  and removes unnecessary columns from the inventory initialisation files. As  discussed in #1062 these extra columns are confusing to new users. As part of work on the NGEET FATES tutorial I want to simplify running with inventory data. 

Specifically, I removed water, fsc (fast soil carbon), stsc  (structural soil carbon), stsl (structural soil lignin), ssc (slow soil carbon), psc (passive soil carbon), msn (mineralized soil nitrogen), and fsn (fast soil nitrogen) from the patch file. From the cohort file I removed avgRG (average radial growth), balive (live biomass per individual of the cohort), bdead (the dead biomass per indiv of the cohort), cohort (unused string) and height. 

I was a bit unsure of height -  the code currently doesn’t use it and instead calculates height from DBH. It would be possible to update it to handle a case where the file only had height, and use the height to calculate DBH. But I’m not sure how many sites would have only height - maybe remote sensing data? I’ve removed it for now but could add it back in if people think it might be useful. 

As suggested by @adrifoster  I made a python script that takes an ED file (pss or css) and creates a new file in the new FATES format. The new file will have _fates appended to the file name.


### Collaborators:
@adrifoster identified the issue and suggested a path forward. Discussed with @glemieux. 

### Expectation of Answer Changes:
This should be bfb in runs with inventory initialisation both on and off as the only information removed from the inventory files was not being used anyway. 

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [X] The in-code documentation has been updated with descriptive comments
- [X] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [x] FATES PASS/FAIL regression tests were run
- [x] Evaluation of test results for answer changes was performed and results provided

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:  no updates needed
- [User's Guide](https://github.com/NGEET/fates-users-guide) update:   https://github.com/NGEET/fates-users-guide/pull/48

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

Test suite  not run but  code compiles and runs with inventory init on Perlmutter. 

*CTSM (or) E3SM (specify which) test hash-tag:* b8be65d

*CTSM (or) E3SM (specify which) baseline hash-tag:* 

*FATES baseline hash-tag:* a3048a6

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

