### PR TITLE
restart fix to soil heterotrophic respiration

### DIFF
--- a/biogeophys/EDAccumulateFluxesMod.F90
+++ b/biogeophys/EDAccumulateFluxesMod.F90
@@ -64,6 +64,11 @@ contains
 
        ifp = 0
 
+       ! This is essentially a copy of the boundary condition
+       ! that fates holds on to, unmodified, used for restart
+       ! purposes
+       sites(s)%soil_het_resp = bc_in(s)%tot_het_resp
+       
        cpatch => sites(s)%oldest_patch
        do while (associated(cpatch))                 
           if(cpatch%nocomp_pft_label.ne.nocomp_bareground)then

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -307,6 +307,7 @@ contains
     site_in%imort_abg_flux(:,:) = 0._r8
     site_in%fmort_abg_flux(:,:) = 0._r8
 
+    site_in%soil_het_resp = 0._r8
 
     ! fusoin-induced growth flux of individuals
     site_in%growthflux_fusion(:,:) = 0._r8

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -256,6 +256,9 @@ module EDTypesMod
      ! Total area of patches in each age bin [m2]
      real(r8), allocatable :: area_by_age(:)
 
+     ! Soil (heterotrophic) respiration from the host model [gC/m2/s]
+     real(r8) :: soil_het_resp 
+     
      ! Nutrient relevant 
      real(r8), allocatable :: rec_l2fr(:,:) ! A running mean of the l2fr's for the newly
                                             ! recruited, pft x canopy_layer

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -4504,8 +4504,8 @@ end subroutine flush_hvars
 
          io_si  = sites(s)%h_gid
 
-         hio_nep_si(io_si) = -bc_in(s)%tot_het_resp * kg_per_g
-         hio_hr_si(io_si)  =  bc_in(s)%tot_het_resp * kg_per_g
+         hio_nep_si(io_si) = -sites(s)%soil_het_resp * kg_per_g
+         hio_hr_si(io_si)  =  sites(s)%soil_het_resp * kg_per_g
 
          ipa = 0
          

--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -97,6 +97,8 @@ module FatesRestartInterfaceMod
   integer :: ir_gdd_si
   integer :: ir_snow_depth_si
   integer :: ir_trunk_product_si
+  integer :: ir_soil_het_resp_si
+  
   integer :: ir_ncohort_pa
   integer :: ir_canopy_layer_co
   integer :: ir_canopy_layer_yesterday_co
@@ -703,7 +705,11 @@ contains
          units='kgC/m2', flushval = flushzero, &
          hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_trunk_product_si )
 
-
+    call this%set_restart_var(vname='fates_soil_het_resp_site', vtype=site_r8, &
+         long_name='Soil heterotrophic respiration', &
+         units='gC/m2/s', flushval = flushzero, &
+         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_soil_het_resp_si)
+    
     ! -----------------------------------------------------------------------------------
     ! Variables stored within cohort vectors
     ! Note: Some of these are multi-dimensional variables in the patch/site dimension
@@ -1989,6 +1995,7 @@ contains
            rio_gdd_si                  => this%rvars(ir_gdd_si)%r81d, &
            rio_snow_depth_si           => this%rvars(ir_snow_depth_si)%r81d, &
            rio_trunk_product_si        => this%rvars(ir_trunk_product_si)%r81d, &
+           rio_soil_het_resp_si        => this%rvars(ir_soil_het_resp_si)%r81d, &
            rio_ncohort_pa              => this%rvars(ir_ncohort_pa)%int1d, &
            rio_fcansno_pa              => this%rvars(ir_fcansno_pa)%r81d, &
            rio_solar_zenith_flag_pa    => this%rvars(ir_solar_zenith_flag_pa)%int1d, &
@@ -2570,6 +2577,8 @@ contains
           rio_trunk_product_si(io_idx_si) = sites(s)%resources_management%trunk_product_site
           ! set numpatches for this column
 
+          rio_soil_het_resp_si(io_idx_si) = sites(s)%soil_het_resp
+
           rio_npatch_si(io_idx_si)  = patchespersite
 
           do i = 1,nclmax
@@ -2927,6 +2936,7 @@ contains
           rio_gdd_si                  => this%rvars(ir_gdd_si)%r81d, &
           rio_snow_depth_si           => this%rvars(ir_snow_depth_si)%r81d, &
           rio_trunk_product_si        => this%rvars(ir_trunk_product_si)%r81d, &
+          rio_soil_het_resp_si        => this%rvars(ir_soil_het_resp_si)%r81d, &
           rio_ncohort_pa              => this%rvars(ir_ncohort_pa)%int1d, &
           rio_fcansno_pa              => this%rvars(ir_fcansno_pa)%r81d, &
           rio_solar_zenith_flag_pa    => this%rvars(ir_solar_zenith_flag_pa)%int1d, &
@@ -3541,6 +3551,7 @@ contains
           sites(s)%acc_NI         = rio_acc_ni_si(io_idx_si)
           sites(s)%snow_depth     = rio_snow_depth_si(io_idx_si)
           sites(s)%resources_management%trunk_product_site = rio_trunk_product_si(io_idx_si)
+          sites(s)%soil_het_resp  = rio_soil_het_resp_si(io_idx_si)
 
        end do
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

FATES tracks a small set of diagnostics that rely on soil heterotrophic respiration, such as NEP.  Previously, our history diagnostics had used the bc_in structure to fill these diagnostics. However, we have been having trouble with these variables on restarts, because when restarting the fates history, the bc_in field has not bee initialized yet by the host. The fix here is for FATES to remember soil heterotrophic respiration at the site level, include this in the restart, and use this value to fill the diagnostics as well.  

Fixes #1106 
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->
@glemieux 

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

B4B

This should have no noticeable impact on memory usage, and should be b4b (ctsm) and b4b with fix (e3sm).  Note, this was not a problam with ctsm because the API is different, and we likely found a way to fill the bc_in variable earlier in the restart sequence.


### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [x] The documentation has been assessed to determine if updates are necessary (NOT NECESSARY)

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

