### PR TITLE
Add `timesince` attribute to correct "YEAR" calculation for landuse data tool

### DIFF
--- a/tools/luh2/luh2.py
+++ b/tools/luh2/luh2.py
@@ -64,7 +64,7 @@ def main():
     # Note that the time variable from the LUH2 data is 'years since ...' so we need to
     # add the input data year
     if (not "YEAR" in list(regrid_luh2.variables)):
-        regrid_luh2["YEAR"] = regrid_luh2.time + regrid_luh2.timesince
+        regrid_luh2["YEAR"] = regrid_luh2.time + ds_luh2.timesince
         regrid_luh2["LONGXY"] = ds_regrid_target["LONGXY"] # TO DO: double check if this is strictly necessary
         regrid_luh2["LATIXY"] = ds_regrid_target["LATIXY"] # TO DO: double check if this is strictly necessary
 

--- a/tools/luh2/luh2.py
+++ b/tools/luh2/luh2.py
@@ -59,10 +59,12 @@ def main():
 
     # Add additional required variables for the host land model
     # Add 'YEAR' as a variable.
-    # This is an old requirement of the HLM and should simply be a copy of the `time` dimension
     # If we are merging, we might not need to do this, so check to see if its there already
+    # This is a requirement of the HLM dyn_subgrid module and should be the actual year.
+    # Note that the time variable from the LUH2 data is 'years since ...' so we need to
+    # add the input data year
     if (not "YEAR" in list(regrid_luh2.variables)):
-        regrid_luh2["YEAR"] = regrid_luh2.time
+        regrid_luh2["YEAR"] = regrid_luh2.time + regrid_luh2.timesince
         regrid_luh2["LONGXY"] = ds_regrid_target["LONGXY"] # TO DO: double check if this is strictly necessary
         regrid_luh2["LATIXY"] = ds_regrid_target["LATIXY"] # TO DO: double check if this is strictly necessary
 

--- a/tools/luh2/luh2.py
+++ b/tools/luh2/luh2.py
@@ -72,6 +72,12 @@ def main():
     if (not 'lsmlat' in list(regrid_luh2.dims)):
         regrid_luh2 = regrid_luh2.rename_dims({'lat':'lsmlat','lon':'lsmlon'})
 
+    # Reapply the coordinate attributes.  This is a workaround for an xarray bug (#8047)
+    # Currently only need time
+    regrid_luh2.time.attrs = ds_luh2.time.attrs
+    regrid_luh2.lat.attrs = ds_luh2.lat.attrs
+    regrid_luh2.lon.attrs = ds_luh2.lon.attrs
+
     # Merge existing regrided luh2 file with merge input target
     # TO DO: check that the grid resolution 
     # We could do this with an append during the write phase instead of the merge

--- a/tools/luh2/luh2.sh
+++ b/tools/luh2/luh2.sh
@@ -42,7 +42,7 @@ echo -e"storage status:\n"
 du -h ${OUTPUT_LOC}
 
 # Regrid the luh2 transitions data using the saved regridder weights file and merge into previous regrid output
-python luh2.py  -b ${START} -e ${END} -l ${TRANSITIONS} -s ${STATIC} -r ${REGRID_TARGET} -w ${REGRIDDER} \
+python luh2.py  -b ${START} -e ${END}-1 -l ${TRANSITIONS} -s ${STATIC} -r ${REGRID_TARGET} -w ${REGRIDDER} \
                 -m ${OUTPUT_LOC}/states_regrid.nc -o ${OUTPUT_LOC}/states_trans_regrid.nc
 echo -e"storage status:\n"
 du -h ${OUTPUT_LOC}

--- a/tools/luh2/luh2.sh
+++ b/tools/luh2/luh2.sh
@@ -42,7 +42,7 @@ echo -e"storage status:\n"
 du -h ${OUTPUT_LOC}
 
 # Regrid the luh2 transitions data using the saved regridder weights file and merge into previous regrid output
-python luh2.py  -b ${START} -e ${END}-1 -l ${TRANSITIONS} -s ${STATIC} -r ${REGRID_TARGET} -w ${REGRIDDER} \
+python luh2.py  -b ${START} -e ${END} -l ${TRANSITIONS} -s ${STATIC} -r ${REGRID_TARGET} -w ${REGRIDDER} \
                 -m ${OUTPUT_LOC}/states_regrid.nc -o ${OUTPUT_LOC}/states_trans_regrid.nc
 echo -e"storage status:\n"
 du -h ${OUTPUT_LOC}

--- a/tools/luh2/luh2mod.py
+++ b/tools/luh2/luh2mod.py
@@ -30,7 +30,7 @@ def PrepDataset(input_dataset,start=None,stop=None,merge_flag=False):
     # 'years since' style format.
     if(not(dstype in ('static','regrid'))):
 
-        if (dstype == 'LUH2'):
+        if ('LUH2' in dstype):
             # Get the units to determine the file time
             # It is expected that the units of time is 'years since ...'
             time_since_array = input_dataset.time.units.split()
@@ -80,7 +80,7 @@ def PrepDataset(input_dataset,start=None,stop=None,merge_flag=False):
 def PrepDataset_ESMF(input_dataset,dsflag,dstype):
 
     if (dsflag):
-        if(dstype == "LUH2"):
+        if("LUH2" in dstype):
             print("PrepDataset: LUH2")
             input_dataset = BoundsVariableFixLUH2(input_dataset)
         elif(dstype == "surface"):
@@ -142,15 +142,18 @@ def CheckDataset(input_dataset):
     dsflag = False
     dsvars = list(input_dataset.variables)
     if('primf' in dsvars or
-       'primf_to_secdn' in dsvars or
        any('irrig' in subname for subname in dsvars)):
-        dstype = 'LUH2'
+        if ('primf_to_secdn' in dsvars):
+            dstype = 'LUH2_transitions'
+        else:
+            dstype = 'LUH2'
+
         dsflag = True
-        print("LUH2")
+        # print("LUH2")
     elif('natpft' in dsvars):
         dstype = 'surface'
         dsflag = True
-        print("Surface")
+        # print("Surface")
     elif('icwtr' in dsvars):
         dstype = 'static'
         dsflag = True

--- a/tools/luh2/luh2mod.py
+++ b/tools/luh2/luh2mod.py
@@ -141,7 +141,7 @@ def CheckDataset(input_dataset):
 
     dsflag = False
     dsvars = list(input_dataset.variables)
-    if('primf' in dsvars or
+    if(any('primf' in subname for subname in dsvars) or
        any('irrig' in subname for subname in dsvars)):
         if ('primf_to_secdn' in dsvars):
             dstype = 'LUH2_transitions'

--- a/tools/luh2/luh2mod.py
+++ b/tools/luh2/luh2mod.py
@@ -202,7 +202,7 @@ def RegridLoop(ds_to_regrid, regridder):
     for i in range(varlen-1):
 
         # Skip time variable
-        if (ds_varnames[i] != "time"):
+        if (not "time" in ds_varnames[i]):
 
             # Only regrid variables that match the lat/lon shape.
             if (ds_to_regrid[ds_varnames[i]][0].shape == (ds_to_regrid.lat.shape[0], ds_to_regrid.lon.shape[0])):

--- a/tools/luh2/luh2mod.py
+++ b/tools/luh2/luh2mod.py
@@ -66,6 +66,9 @@ def PrepDataset(input_dataset,start=None,stop=None,merge_flag=False):
             # the start/stop is out of range
             input_dataset = input_dataset.sel(time=slice(years_since_start,years_since_stop))
 
+            # Save the timesince as a variable for future use
+            input_dataset["timesince"] = time_since
+
         # Correct the necessary variables for both datasets
         # We don't need to Prep the incoming dataset if it's being opened to merge
         if(not merge_flag):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
Fixes an error in how the `YEAR` variable on the output dataset is calculated.  
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
Not answer changing to the fates results.
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [x] The in-code documentation has been updated with descriptive comments
- [x] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [x] FATES PASS/FAIL regression tests were run
- [x] Evaluation of test results for answer changes was performed and results provided

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

