### PR TITLE
Turn off hydraulic failure mortality in frozen soils

### DIFF
--- a/biogeochem/EDMortalityFunctionsMod.F90
+++ b/biogeochem/EDMortalityFunctionsMod.F90
@@ -158,7 +158,7 @@ contains
           endif
        else
           if( ( btran_ft(cohort_in%pft) <= hf_sm_threshold ) .and. &
-               ( ( minval(bc_in%t_soisno_sl) - tfrz ) >= soil_tfrz_thresh ) ) then 
+               ( ( minval(bc_in%t_soisno_sl) - tfrz ) > soil_tfrz_thresh ) ) then 
              hmort = EDPftvarcon_inst%mort_scalar_hydrfailure(cohort_in%pft)
           else
              hmort = 0.0_r8

--- a/biogeochem/EDMortalityFunctionsMod.F90
+++ b/biogeochem/EDMortalityFunctionsMod.F90
@@ -59,7 +59,7 @@ contains
     use FatesConstantsMod,      only : tfrz => t_water_freeze_k_1atm
     use FatesConstantsMod,      only : fates_check_param_set
     use DamageMainMod,          only : GetDamageMortality
-    use EDParamsmod,            only : tsoil_thresh_hmort
+    use EDParamsmod,            only : soil_tfrz_thresh
     
     type (fates_cohort_type), intent(in) :: cohort_in 
     type (bc_in_type), intent(in) :: bc_in
@@ -157,8 +157,8 @@ contains
              hmort = 0.0_r8
           endif
        else
-          if(btran_ft(cohort_in%pft) <= hf_sm_threshold .and. &
-               minval(bc_in%t_soisno_sl) - tfrz .ge. tsoil_thresh_hmort )then 
+          if( ( btran_ft(cohort_in%pft) <= hf_sm_threshold ) .and. &
+               ( ( minval(bc_in%t_soisno_sl) - tfrz ) >= soil_tfrz_thresh ) ) then 
              hmort = EDPftvarcon_inst%mort_scalar_hydrfailure(cohort_in%pft)
           else
              hmort = 0.0_r8

--- a/biogeochem/EDMortalityFunctionsMod.F90
+++ b/biogeochem/EDMortalityFunctionsMod.F90
@@ -48,7 +48,7 @@ module EDMortalityFunctionsMod
 
 contains
 
-  subroutine mortality_rates( cohort_in,bc_in,btran_ft, mean_temp,             &
+  subroutine mortality_rates( cohort_in,bc_in, btran_ft, mean_temp,             &
       cmort,hmort,bmort, frmort,smort,asmort,dgmort )
 
     ! ============================================================================
@@ -56,9 +56,10 @@ contains
     !  background and freezing and size and age dependent senescence
     ! ============================================================================
     
-    use FatesConstantsMod,  only : tfrz => t_water_freeze_k_1atm 
-    use FatesConstantsMod,  only : fates_check_param_set
-    use DamageMainMod,      only : GetDamageMortality
+    use FatesConstantsMod,      only : tfrz => t_water_freeze_k_1atm
+    use FatesConstantsMod,      only : fates_check_param_set
+    use DamageMainMod,          only : GetDamageMortality
+    use EDParamsmod,            only : tsoil_thresh_hmort
     
     type (fates_cohort_type), intent(in) :: cohort_in 
     type (bc_in_type), intent(in) :: bc_in
@@ -156,9 +157,12 @@ contains
              hmort = 0.0_r8
           endif
        else
-          if(btran_ft(cohort_in%pft) <= hf_sm_threshold)then 
+          if(btran_ft(cohort_in%pft) <= hf_sm_threshold .and. &
+               minval(bc_in%t_soisno_sl) - tfrz .ge. tsoil_thresh_hmort )then 
              hmort = EDPftvarcon_inst%mort_scalar_hydrfailure(cohort_in%pft)
           else
+             write(fates_log(),*) 'jfn soil frozen - no hmort'
+             write(fates_log(),*) 'jfn min soil temp - ', minval(bc_in%t_soisno_sl) - tfrz
              hmort = 0.0_r8
           endif
        endif

--- a/biogeochem/EDMortalityFunctionsMod.F90
+++ b/biogeochem/EDMortalityFunctionsMod.F90
@@ -161,8 +161,6 @@ contains
                minval(bc_in%t_soisno_sl) - tfrz .ge. tsoil_thresh_hmort )then 
              hmort = EDPftvarcon_inst%mort_scalar_hydrfailure(cohort_in%pft)
           else
-             write(fates_log(),*) 'jfn soil frozen - no hmort'
-             write(fates_log(),*) 'jfn min soil temp - ', minval(bc_in%t_soisno_sl) - tfrz
              hmort = 0.0_r8
           endif
        endif

--- a/biogeophys/EDBtranMod.F90
+++ b/biogeophys/EDBtranMod.F90
@@ -49,7 +49,7 @@ contains
     check_layer_water = .false.
 
     if ( h2o_liq_vol .gt. 0._r8 ) then
-       if ( tempk .gt. soil_tfrz_thresh) then
+       if ( tempk .gt. soil_tfrz_thresh + tfrz) then
           check_layer_water = .true.
        end if
     end if

--- a/biogeophys/EDBtranMod.F90
+++ b/biogeophys/EDBtranMod.F90
@@ -12,6 +12,7 @@ module EDBtranMod
   use EDTypesMod        , only : ed_site_type
   use FatesPatchMod,      only : fates_patch_type
   use EDParamsMod,        only : maxpft
+  use EDParamsMod,        only : soil_tfrz_thresh
   use FatesCohortMod,     only : fates_cohort_type
   use shr_kind_mod      , only : r8 => shr_kind_r8
   use FatesInterfaceTypesMod , only : bc_in_type, &
@@ -48,7 +49,7 @@ contains
     check_layer_water = .false.
 
     if ( h2o_liq_vol .gt. 0._r8 ) then
-       if ( tempk .gt. tfrz-2._r8) then
+       if ( tempk .gt. soil_tfrz_thresh) then
           check_layer_water = .true.
        end if
     end if

--- a/main/EDParamsMod.F90
+++ b/main/EDParamsMod.F90
@@ -95,8 +95,10 @@ module EDParamsMod
    integer, public :: n_uptake_mode
    integer, public :: p_uptake_mode
 
+   real(r8), parameter, public :: tsoil_thresh_hmort = -2.0_r8 ! Soil temperature threshold below which hydraulic failure mortality is off (non-hydro only)
+   
    integer, parameter, public :: nclmax = 2                ! Maximum number of canopy layers
-  
+
    ! parameters that govern the VAI (LAI+SAI) bins used in radiative transfer code
    integer, parameter, public :: nlevleaf = 30   ! number of leaf+stem layers in each canopy layer
 

--- a/main/EDParamsMod.F90
+++ b/main/EDParamsMod.F90
@@ -100,7 +100,7 @@ module EDParamsMod
    integer, parameter, public :: nclmax = 2                ! Maximum number of canopy layers
 
    ! parameters that govern the VAI (LAI+SAI) bins used in radiative transfer code
-   integer, parameter, public :: nlevleaf = 40   ! number of leaf+stem layers in each canopy layer
+   integer, parameter, public :: nlevleaf = 30   ! number of leaf+stem layers in each canopy layer
 
    real(r8), public :: dinc_vai(nlevleaf)   = fates_unset_r8 ! VAI bin widths array
    real(r8), public :: dlower_vai(nlevleaf) = fates_unset_r8 ! lower edges of VAI bins

--- a/main/EDParamsMod.F90
+++ b/main/EDParamsMod.F90
@@ -95,12 +95,12 @@ module EDParamsMod
    integer, public :: n_uptake_mode
    integer, public :: p_uptake_mode
 
-   real(r8), parameter, public :: tsoil_thresh_hmort = -2.0_r8 ! Soil temperature threshold below which hydraulic failure mortality is off (non-hydro only)
+   real(r8), parameter, public :: soil_tfrz_thresh = -2.0_r8 ! Soil temperature threshold below which hydraulic failure mortality is off (non-hydro only) in degrees C
    
    integer, parameter, public :: nclmax = 2                ! Maximum number of canopy layers
 
    ! parameters that govern the VAI (LAI+SAI) bins used in radiative transfer code
-   integer, parameter, public :: nlevleaf = 30   ! number of leaf+stem layers in each canopy layer
+   integer, parameter, public :: nlevleaf = 40   ! number of leaf+stem layers in each canopy layer
 
    real(r8), public :: dinc_vai(nlevleaf)   = fates_unset_r8 ! VAI bin widths array
    real(r8), public :: dlower_vai(nlevleaf) = fates_unset_r8 ! lower edges of VAI bins


### PR DESCRIPTION
This PR address issue #1105 and turns off hydraulic failure mortality when soils are freezing, specifically, when any soil layer is below -2 degrees C. This should prevent high mortality of vegetation at high latitudes.  

### Collaborators:
@rosiealice @ckoven 

### Expectation of Answer Changes:
This is an answer changing fix - hydraulic failure will be reduced at high latitudes. 

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [x] The in-code documentation has been updated with descriptive comments
- [x] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [x] FATES PASS/FAIL regression tests were run
- [x] Evaluation of test results for answer changes was performed and results provided

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update: https://github.com/NGEET/fates-docs/pull/61
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

I haven’t tested with the latest commits from main. I branched from FATES a3048a646 (E3SM b8be65d). The figure  below is compared with FATES  a3048a646. It's a no comp run - mean over year 10. 
![Screenshot 2023-11-04 at 16 51 41](https://github.com/NGEET/fates/assets/10586303/1a7ddd88-18cd-4726-8568-8fec21509196)

