### PR TITLE
Update FatesPFTIndexSwapper.py to work with landuse dimension

### DIFF
--- a/tools/FatesPFTIndexSwapper.py
+++ b/tools/FatesPFTIndexSwapper.py
@@ -28,6 +28,7 @@ prt_dim_name = 'fates_plant_organs'
 hydro_dim_name = 'fates_hydr_organs'
 litt_dim_name = 'fates_litterclass'
 string_dim_name = 'fates_string_length'
+landuse_dim_name = 'fates_landuseclass'
 
 class timetype:
 
@@ -165,14 +166,14 @@ def main(argv):
 
 
         in_var  = fp_in.variables.get(key)
-
-
+      
         # Idenfity if this variable has pft dimension
-        pft_dim_found = -1
-        prt_dim_found = -1
-        hydro_dim_found = -1
-        litt_dim_found  = -1
-        string_dim_found = -1
+        pft_dim_found       = -1
+        prt_dim_found       = -1
+        hydro_dim_found     = -1
+        litt_dim_found      = -1
+        string_dim_found    = -1
+        landuse_dim_found   = -1
         pft_dim_len   = len(fp_in.variables.get(key).dimensions)
 
         for idim, name in enumerate(fp_in.variables.get(key).dimensions):
@@ -188,13 +189,18 @@ def main(argv):
                 hydro_dim_found = idim
             if(name==string_dim_name):
                 string_dim_found = idim
-
+            if(name==landuse_dim_name):
+                landuse_dim_found = idim
+               
+        
+        
+        
         # Copy over the input data
         # Tedious, but I have to permute through all combinations of dimension position
         if( pft_dim_len == 0 ):
             out_var = fp_out.createVariable(key,'d',(fp_in.variables.get(key).dimensions))
             out_var.assignValue(float(fp_in.variables.get(key).data))
-        elif( (pft_dim_found==-1) & (prt_dim_found==-1) & (litt_dim_found==-1) & (hydro_dim_found==-1)  ):
+        elif( (pft_dim_found==-1) & (prt_dim_found==-1) & (litt_dim_found==-1) & (hydro_dim_found==-1) & (landuse_dim_found==-1)  ):
             out_var = fp_out.createVariable(key,'d',(fp_in.variables.get(key).dimensions))
             out_var[:] = in_var[:]
         elif( (pft_dim_found==0) & (pft_dim_len==1) ):           # 1D fates_pft
@@ -232,6 +238,10 @@ def main(argv):
         
         elif( (litt_dim_found==0) & (string_dim_found>=0) ):       
             out_var = fp_out.createVariable(key,'c',(fp_in.variables.get(key).dimensions))
+            out_var[:] = in_var[:]
+
+        elif( (landuse_dim_found==0) & (string_dim_found>=0) ):       
+            out_var = fp_out.createVariable(key,'c',(fp_in.variables.get(key).dimensions))
             out_var[:] = in_var[:]   
 
         elif( prt_dim_found==0 ): # fates_prt_organs - indices
@@ -241,6 +251,9 @@ def main(argv):
         elif( litt_dim_found==0 ):
             out_var = fp_out.createVariable(key,'d',(fp_in.variables.get(key).dimensions))
             out_var[:] = in_var[:]
+        elif( landuse_dim_found==0 ):
+            out_var = fp_out.createVariable(key,'d',(fp_in.variables.get(key).dimensions))
+            out_var[:] = in_var[:]    
         elif( hydro_dim_found==0):
             out_var = fp_out.createVariable(key,'d',(fp_in.variables.get(key).dimensions))
             out_var[:] = in_var[:]


### PR DESCRIPTION
The new land use class dimension in the fates parameter file means that FatesPFTIndexSwapper.py needs to be updated. 
### Collaborators:


### Expectation of Answer Changes:
These are minor changes only to FatesPFTIndexSwapper.py and will not affect FATES runs. 


### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [ ] The in-code documentation has been updated with descriptive comments
- [x] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*
