### PR TITLE
Optional change to the scaling of leaf MR with LAI

### DIFF
--- a/biogeophys/FatesPlantRespPhotosynthMod.F90
+++ b/biogeophys/FatesPlantRespPhotosynthMod.F90
@@ -543,7 +543,8 @@ contains
                                case (lmrmodel_atkin_etal_2017)
 
                                   call LeafLayerMaintenanceRespiration_Atkin_etal_2017(lnc_top, &  ! in
-                                       nscaler,                            &  ! in
+                                       cumulative_lai,                     &  ! in
+                                       currentCohort%vcmax25top,           &  ! in
                                        ft,                                 &  ! in
                                        bc_in(s)%t_veg_pa(ifp),             &  ! in
                                        currentPatch%tveg_lpa%GetMean(),    &  ! in
@@ -2131,11 +2132,12 @@ end subroutine LeafLayerMaintenanceRespiration_Ryan_1991
 ! ====================================================================================   
 
 subroutine LeafLayerMaintenanceRespiration_Atkin_etal_2017(lnc_top, &
-   nscaler,   &
-   ft,        &
-   veg_tempk, &
-   tgrowth,   &
-   lmr)
+     cumulative_lai, &
+     vcmax25top,     &
+     ft,             &
+     veg_tempk,      &
+     tgrowth,        &
+     lmr)
 
    use FatesConstantsMod, only : tfrz => t_water_freeze_k_1atm
    use FatesConstantsMod, only : umolC_to_kgC
@@ -2148,19 +2150,24 @@ subroutine LeafLayerMaintenanceRespiration_Atkin_etal_2017(lnc_top, &
    use EDPftvarcon      , only : EDPftvarcon_inst
 
    ! Arguments
-   real(r8), intent(in)  :: lnc_top      ! Leaf nitrogen content per unit area at canopy top [gN/m2]
-   integer,  intent(in)  :: ft           ! (plant) Functional Type Index
-   real(r8), intent(in)  :: nscaler      ! Scale for leaf nitrogen profile
-   real(r8), intent(in)  :: veg_tempk    ! vegetation temperature  (degrees K)
-   real(r8), intent(in)  :: tgrowth      ! lagged vegetation temperature averaged over acclimation timescale (degrees K)
-   real(r8), intent(out) :: lmr          ! Leaf Maintenance Respiration  (umol CO2/m**2/s)
+   real(r8), intent(in)  :: lnc_top          ! Leaf nitrogen content per unit area at canopy top [gN/m2]
+   integer,  intent(in)  :: ft               ! (plant) Functional Type Index
+   real(r8), intent(in)  :: vcmax25top       ! top of canopy vcmax
+   real(r8), intent(in)  :: cumulative_lai   ! cumulative lai above the current leaf layer
+   real(r8), intent(in)  :: veg_tempk        ! vegetation temperature  (degrees K)
+   real(r8), intent(in)  :: tgrowth          ! lagged vegetation temperature averaged over acclimation timescale (degrees K)
+   real(r8), intent(out) :: lmr              ! Leaf Maintenance Respiration  (umol CO2/m**2/s)
 
    ! Locals
    real(r8) :: lmr25   ! leaf layer: leaf maintenance respiration rate at 25C (umol CO2/m**2/s)
    real(r8) :: r_0     ! base respiration rate, PFT-dependent (umol CO2/m**2/s)
    real(r8) :: r_t_ref ! acclimated ref respiration rate (umol CO2/m**2/s)
    real(r8) :: lmr25top  ! canopy top leaf maint resp rate at 25C for this pft (umol CO2/m**2/s)
+   real(r8) :: rdark_scaler ! negative exponential scaling of rdark
+   real(r8) :: kn           ! decay coefficient
+   real(r8) :: rdark_decay  ! determines rate of rdark decay through canopy
 
+   
    ! parameter values of r_0 as listed in Atkin et al 2017: (umol CO2/m**2/s) 
    ! Broad-leaved trees  1.7560
    ! Needle-leaf trees   1.4995
@@ -2168,14 +2175,25 @@ subroutine LeafLayerMaintenanceRespiration_Atkin_etal_2017(lnc_top, &
    ! C3 herbs/grasses    2.1956
    ! In the absence of better information, we use the same value for C4 grasses as C3 grasses.
 
-   ! note that this code uses the relationship between leaf N and respiration from Atkin et al 
-   ! for the top of the canopy, but then assumes proportionality with N through the canopy.
-
+  
    ! r_0 currently put into the EDPftvarcon_inst%dev_arbitrary_pft
    ! all figs in Atkin et al 2017 stop at zero Celsius so we will assume acclimation is fixed below that
    r_0 = EDPftvarcon_inst%maintresp_leaf_atkin2017_baserate(ft)
-   r_t_ref = max( 0._r8, nscaler * (r_0 + lmr_r_1 * lnc_top + lmr_r_2 * max(0._r8, (tgrowth - tfrz) )) )
-   
+   rdark_decay = EDPftvarcon_inst%maintresp_leaf_decay(ft)
+
+   ! This code uses the relationship between leaf N and respiration from Atkin et al 
+   ! for the top of the canopy, but then scales through the canopy based on a rdark_scaler.
+   ! To assume proportionality with N through the canopy following Lloyd et al. 2010, use the
+   ! default parameter value of 2.43, which results in the scaling of photosynthesis and respiraiton
+   ! being proportional through the canopy. To have a steeper decrease in respiration than photosynthesis
+   ! this number can be smaller. There is some observational evidence for this being the case
+   ! in Lamour et al. 2023. 
+
+   kn = exp(0.00963_r8 * vcmax25top - rdark_decay)
+   rdark_scaler = exp(-kn * cumulative_lai)
+      
+   r_t_ref = max(0._r8, rdark_scaler * (r_0 + lmr_r_1 * lnc_top + lmr_r_2 * max(0._r8, (tgrowth - tfrz) )) )
+
    if (r_t_ref .eq. 0._r8) then
       warn_msg = 'Rdark is negative at this temperature and is capped at 0. tgrowth (C): '//trim(N2S(tgrowth-tfrz))//' pft: '//trim(I2S(ft))
       call FatesWarn(warn_msg,index=4)            

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -89,7 +89,9 @@ module EDPftvarcon
                                                                    ! per Atkin et al 2017
 
      real(r8), allocatable :: maintresp_leaf_ryan1991_baserate(:)  ! leaf maintenance respiration per Ryan et al 1991
-
+     real(r8), allocatable :: maintresp_leaf_decay(:)              ! leaf maintenance respiration decrease through the canopy
+                                                                   ! only with Atkin et al. 2017
+     
      real(r8), allocatable :: bmort(:)
      real(r8), allocatable :: mort_ip_size_senescence(:) ! inflection point of dbh dependent senescence
      real(r8), allocatable :: mort_r_size_senescence(:)  ! rate of change in mortality with dbh
@@ -469,6 +471,10 @@ contains
     call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
         dimension_names=dim_names, lower_bounds=dim_lower_bound)
 
+    name = 'fates_maintresp_leaf_decay'
+    call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
+        dimension_names=dim_names, lower_bounds=dim_lower_bound)
+    
     name = 'fates_prescribed_npp_canopy'
     call fates_params%RegisterParameter(name=name, dimension_shape=dimension_shape_1d, &
          dimension_names=dim_names, lower_bounds=dim_lower_bound)
@@ -910,6 +916,10 @@ contains
     call fates_params%RetrieveParameterAllocate(name=name, &
          data=this%maintresp_leaf_ryan1991_baserate)
 
+    name = 'fates_maintresp_leaf_decay'
+    call fates_params%RetrieveParameterAllocate(name=name, &
+         data=this%maintresp_leaf_decay)
+    
     name = 'fates_prescribed_npp_canopy'
     call fates_params%RetrieveParameterAllocate(name=name, &
          data=this%prescribed_npp_canopy)


### PR DESCRIPTION
This PR allows for variable vertical scaling of leaf maintenance respiration when using the Atkin et al. 2017 leaf MR model. The current model calculates top of canopy leaf MR following Atkin et al. 2017 and then scales through the canopy using the leaf nitrogen scaler from Lloyd et al. 2010. Recent observational evidence from [Lamour et al. 2023](https://nph.onlinelibrary.wiley.com/doi/full/10.1111/nph.18901) suggest that respiration might decrease more rapidly than photosynthesis through the canopy. In Lamour et al. 2023 they fit a linear model to observations of leaf MR by LAI, but here to avoid negative leaf MR we use the same negative exponential function as in Lloyd et al. 2010 but allow the curve to vary according to a new parameter fates_maintresp_leaf_decay. This should in principle improve the carbon budget of understory plants, and as a result increase LAI which has been biased low when using the Atkin respiration model. 

### Collaborators:
@ckoven @mpaiao @jenniferholm @jennykowalcz

### Expectation of Answer Changes:
With the new parameter set to its default value of 2.43 results should be bfb with main. Decreasing this parameter decreases understory respiration and should decrease carbon starvation mortality in understory cohorts. I’m running a control and test with a version up to date with API 29 now and will post results. 

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [x ] The in-code documentation has been updated with descriptive comments
- [ x] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->
