### PR TITLE
prevent FATES-Hydro from failing upon restart with a drought deciduous PFT

### DIFF
--- a/biogeophys/FatesPlantHydraulicsMod.F90
+++ b/biogeophys/FatesPlantHydraulicsMod.F90
@@ -936,7 +936,7 @@ contains
     ! we set as our lower cap on leaf volume
     real(r8), parameter :: min_trim      = 0.1_r8   ! The lower cap on trimming function used
     ! to estimate maximum leaf carbon
-    real(r8), parameter :: min_efleaf = 0.1_r8 ! Lower cap on leaf elongation factor
+
 
     ccohort_hydr => ccohort%co_hydr
     ft           = ccohort%pft
@@ -982,7 +982,7 @@ contains
     ! Lets also avoid super-low targets that have very low trimming functions
 
     call bleaf(ccohort%dbh,ccohort%pft,ccohort%crowndamage, &
-         max(ccohort%canopy_trim,min_trim),max(ccohort%efleaf_coh,min_efleaf), leaf_c_target)
+         max(ccohort%canopy_trim,min_trim),1.0, leaf_c_target)
 
     ccohort_hydr%v_ag(1:n_hypool_leaf) = max(leaf_c,min_leaf_frac*leaf_c_target) * &
          prt_params%c2b(ft) / denleaf/ real(n_hypool_leaf,r8)

--- a/biogeophys/FatesPlantHydraulicsMod.F90
+++ b/biogeophys/FatesPlantHydraulicsMod.F90
@@ -936,6 +936,7 @@ contains
     ! we set as our lower cap on leaf volume
     real(r8), parameter :: min_trim      = 0.1_r8   ! The lower cap on trimming function used
     ! to estimate maximum leaf carbon
+    real(r8), parameter :: min_efleaf = 0.1_r8 ! Lower cap on leaf elongation factor
 
     ccohort_hydr => ccohort%co_hydr
     ft           = ccohort%pft
@@ -981,12 +982,11 @@ contains
     ! Lets also avoid super-low targets that have very low trimming functions
 
     call bleaf(ccohort%dbh,ccohort%pft,ccohort%crowndamage, &
-         max(ccohort%canopy_trim,min_trim),ccohort%efleaf_coh, leaf_c_target)
+         max(ccohort%canopy_trim,min_trim),max(ccohort%efleaf_coh,min_efleaf), leaf_c_target)
 
-    if( (ccohort%status_coh == leaves_on) .or. ccohort_hydr%is_newly_recruited ) then
-       ccohort_hydr%v_ag(1:n_hypool_leaf) = max(leaf_c,min_leaf_frac*leaf_c_target) * &
-            prt_params%c2b(ft) / denleaf/ real(n_hypool_leaf,r8)
-    end if
+    ccohort_hydr%v_ag(1:n_hypool_leaf) = max(leaf_c,min_leaf_frac*leaf_c_target) * &
+         prt_params%c2b(ft) / denleaf/ real(n_hypool_leaf,r8)
+
 
     ! Step sapwood volume
     ! -----------------------------------------------------------------------------------

--- a/biogeophys/FatesPlantHydraulicsMod.F90
+++ b/biogeophys/FatesPlantHydraulicsMod.F90
@@ -981,6 +981,7 @@ contains
     ! Get the target, or rather, maximum leaf carrying capacity of plant
     ! Lets also avoid super-low targets that have very low trimming functions
 
+    ! efleaf_coh hard-coded to 1 in the call below to avoid zero leaf volume
     call bleaf(ccohort%dbh,ccohort%pft,ccohort%crowndamage, &
          max(ccohort%canopy_trim,min_trim),1.0_r8, leaf_c_target)
 

--- a/biogeophys/FatesPlantHydraulicsMod.F90
+++ b/biogeophys/FatesPlantHydraulicsMod.F90
@@ -982,7 +982,7 @@ contains
     ! Lets also avoid super-low targets that have very low trimming functions
 
     call bleaf(ccohort%dbh,ccohort%pft,ccohort%crowndamage, &
-         max(ccohort%canopy_trim,min_trim),1.0, leaf_c_target)
+         max(ccohort%canopy_trim,min_trim),1.0_r8, leaf_c_target)
 
     ccohort_hydr%v_ag(1:n_hypool_leaf) = max(leaf_c,min_leaf_frac*leaf_c_target) * &
          prt_params%c2b(ft) / denleaf/ real(n_hypool_leaf,r8)


### PR DESCRIPTION
### Description:
As discussed in [issue 1151 ](https://github.com/NGEET/fates/issues/1151), FATES-Hydro was failing upon restart for simulations including a drought-deciduous PFT, with error messages saying is recruitment = F, LAI = 0, stem_water = 0, w_tot_* = NaN, and LWP = NaN. This PR implements a fix suggested by @mpaiao to prevent the failure by preventing the leaf elongation factor from being zero when the Fates-Hydro code is calculating water storage volume.


### Collaborators:
@mpaiao @ckoven 

### Expectation of Answer Changes:
I tested this PR using a small region in the central Amazon with a control case from the main branch and a test case from this branch, for sets of simulations with a single evergreen PFT and a single drought-deciduous PFT. The control cases comprised of 20 year runs (no restart) while the test cases reached 20 years with restarts every 2 years. Changes are near-zero for the evergreen PFT for the quantities I looked at. For the drought-deciduous PFT quantities change by up to a couple percent.
[Hydro restart test.pdf](https://github.com/NGEET/fates/files/14143156/Hydro.restart.test.pdf)


### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [x] The in-code documentation has been updated with descriptive comments
- [x] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [x] FATES PASS/FAIL regression tests were run
- [x] Evaluation of test results for answer changes was performed and results provided

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

