### PR TITLE
Bug Fix - remove trunk loading from patch-level `sum_fuel` variable

### DIFF
--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -306,6 +306,10 @@ contains
           currentPatch%litter_moisture(tr_sf)       = fuel_moisture(tr_sf)/MEF(tr_sf)
           currentPatch%litter_moisture(dl_sf)       = fuel_moisture(dl_sf)/MEF(dl_sf)
           currentPatch%litter_moisture(lg_sf)       = fuel_moisture(lg_sf)/MEF(lg_sf)
+
+          ! remove trunks from patch%sum_fuel because they should not be included in fire equations
+          ! NOTE: ACF will update this soon to be more clean/bug-proof
+          currentPatch%sum_fuel = currentPatch%sum_fuel - litt_c%ag_cwd(4)
           
        else
 


### PR DESCRIPTION
As laid out in #1178, trunks should (but currently aren't) removed from the patch-level variable `sum_fuel` before being used to calculate rate of spread and fuel consumption.

See [Thonicke 2010](https://bg.copernicus.org/articles/7/1991/2010/bg-7-1991-2010.html) to confirm that this is how it is supposed to behave.

I added a quick fix at the end of the `charecteriscis_of_fuel` subroutine to do this.

### Description:

Just added one line to the end of the subroutine that removes the trunk litter. Currently this is not very nice looking, but since I am bringing in a big fire refactor I felt it was okay for now (??).

### Collaborators:
@rgknox @samsrabin 

### Expectation of Answer Changes:
Yes, if fire is turned on at all, this should change rate of spread calculations, and thus fire intensity, fuel consumption, tree mortality, etc....

### Checklist
*Contributor*
- [ x ] The in-code documentation has been updated with descriptive comments
- [ x ] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided

### Documentation

I don't believe documentation updates are needed since we are updating the code to reflect what we actually intend.

### Test Results:

Working on this now...

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*


