### PR TITLE
giving the fraction of energy used in photosystem 2 a named constant

### DIFF
--- a/biogeophys/FatesPlantRespPhotosynthMod.F90
+++ b/biogeophys/FatesPlantRespPhotosynthMod.F90
@@ -1302,9 +1302,11 @@ subroutine LeafLayerPhotosynthesis(f_sun_lsl,         &  ! in
   real(r8),parameter :: fnps = 0.15_r8
 
   ! term accounting that two photons are needed to fully transport a single 
-  ! electron to the thylakoid-membrane-bound NADP reductase (see Farquhar 1980)
-  ! ie only half the energy from a photon enters photosystem 2
-  real(r8), parameter :: photon_to_e_nadp = 0.5_r8
+  ! electron in photosystem 2
+  real(r8), parameter :: photon_to_e = 0.5_r8
+
+  ! Unit conversion of w/m2 to umol photons m-2 s-1
+  real(r8), parameter :: wm2_to_umolm2s = 4.6_r8
   
   ! For plants with no leaves, a miniscule amount of conductance
   ! can happen through the stems, at a partial rate of cuticular conductance
@@ -1369,7 +1371,7 @@ subroutine LeafLayerPhotosynthesis(f_sun_lsl,         &  ! in
 
         do  sunsha = 1,2
            ! Electron transport rate for C3 plants.
-           ! Convert par from W/m2 to umol photons/m**2/s using the factor 4.6
+           ! Convert par from W/m2 to umol photons/m**2/s
            ! Convert from units of par absorbed per unit ground area to par
            ! absorbed per unit leaf area.
 
@@ -1377,7 +1379,7 @@ subroutine LeafLayerPhotosynthesis(f_sun_lsl,         &  ! in
               if(( laisun_lsl * canopy_area_lsl) > min_la_to_solve)then
 
                  qabs = parsun_lsl / (laisun_lsl * canopy_area_lsl )
-                 qabs = qabs * photon_to_e_nadp * (1._r8 - fnps) *  4.6_r8
+                 qabs = qabs * photon_to_e * (1._r8 - fnps) * wm2_to_umolm2s
 
               else
                  qabs = 0.0_r8
@@ -1387,7 +1389,7 @@ subroutine LeafLayerPhotosynthesis(f_sun_lsl,         &  ! in
               if( (parsha_lsl>nearzero) .and. (laisha_lsl * canopy_area_lsl) > min_la_to_solve  ) then
 
                  qabs = parsha_lsl / (laisha_lsl * canopy_area_lsl)
-                 qabs = qabs * photon_to_e_nadp * (1._r8 - fnps) *  4.6_r8
+                 qabs = qabs * photon_to_e * (1._r8 - fnps) *  wm2_to_umolm2s
               else                 
                  ! The radiative transfer schemes are imperfect
                  ! they can sometimes generate negative values here
@@ -1443,14 +1445,14 @@ subroutine LeafLayerPhotosynthesis(f_sun_lsl,         &  ! in
                  if(sunsha == 1)then !sunlit
                     !guard against /0's in the night.
                     if((laisun_lsl * canopy_area_lsl) > 0.0000000001_r8) then
-                       aj = quant_eff(c3c4_path_index) * parsun_lsl * 4.6_r8
+                       aj = quant_eff(c3c4_path_index) * parsun_lsl * wm2_to_umolm2s
                        !convert from per cohort to per m2 of leaf)
                        aj = aj / (laisun_lsl * canopy_area_lsl)
                     else
                        aj = 0._r8
                     end if
                  else
-                    aj = quant_eff(c3c4_path_index) * parsha_lsl * 4.6_r8
+                    aj = quant_eff(c3c4_path_index) * parsha_lsl * wm2_to_umolm2s
                     aj = aj / (laisha_lsl * canopy_area_lsl)
                  end if
 

--- a/biogeophys/FatesPlantRespPhotosynthMod.F90
+++ b/biogeophys/FatesPlantRespPhotosynthMod.F90
@@ -1301,6 +1301,11 @@ subroutine LeafLayerPhotosynthesis(f_sun_lsl,         &  ! in
   ! Fraction of light absorbed by non-photosynthetic pigments
   real(r8),parameter :: fnps = 0.15_r8
 
+  ! term accounting that two photons are needed to fully transport a single 
+  ! electron to the thylakoid-membrane-bound NADP reductase (see Farquhar 1980)
+  ! ie only have the energy enters photosystem 2
+  real(r8), parameter :: photon_to_e_nadp = 0.5_r8
+  
   ! For plants with no leaves, a miniscule amount of conductance
   ! can happen through the stems, at a partial rate of cuticular conductance
   real(r8),parameter :: stem_cuticle_loss_frac = 0.1_r8
@@ -1372,7 +1377,7 @@ subroutine LeafLayerPhotosynthesis(f_sun_lsl,         &  ! in
               if(( laisun_lsl * canopy_area_lsl) > min_la_to_solve)then
 
                  qabs = parsun_lsl / (laisun_lsl * canopy_area_lsl )
-                 qabs = qabs * 0.5_r8 * (1._r8 - fnps) *  4.6_r8
+                 qabs = qabs * photon_to_e_nadp * (1._r8 - fnps) *  4.6_r8
 
               else
                  qabs = 0.0_r8
@@ -1382,7 +1387,7 @@ subroutine LeafLayerPhotosynthesis(f_sun_lsl,         &  ! in
               if( (parsha_lsl>nearzero) .and. (laisha_lsl * canopy_area_lsl) > min_la_to_solve  ) then
 
                  qabs = parsha_lsl / (laisha_lsl * canopy_area_lsl)
-                 qabs = qabs * 0.5_r8 * (1._r8 - fnps) *  4.6_r8
+                 qabs = qabs * photon_to_e_nadp * (1._r8 - fnps) *  4.6_r8
               else                 
                  ! The radiative transfer schemes are imperfect
                  ! they can sometimes generate negative values here

--- a/biogeophys/FatesPlantRespPhotosynthMod.F90
+++ b/biogeophys/FatesPlantRespPhotosynthMod.F90
@@ -1510,10 +1510,10 @@ subroutine LeafLayerPhotosynthesis(f_sun_lsl,         &  ! in
               ! e_s = (e_i g_s + e_c g_b)/(g_b + g_s)
               !
               ! The leaf surface humidity (e_s) becomes an expression of canopy humidity (e_c),
-              ! intercellular humidity (e_i), boundary layer conductance (g_b) (these are known)
-              ! and stomatal conductance (g_s) (this is still unknown).  This expression is
-              ! substituted into the stomatal conductance equation. The resulting form of these
-              ! equations becomes a quadratic.
+              ! intercellular humidity (e_i, which is the saturation humidity at leaf temperature),
+              ! boundary layer conductance (g_b) (these are all known) and stomatal conductance
+              ! (g_s) (this is still unknown).  This expression is substituted into the stomatal
+              ! conductance equation. The resulting form of these equations becomes a quadratic.
               !
               ! For a detailed explanation, see the FATES technical note, section
               ! "1.11 Stomatal Conductance"

--- a/biogeophys/FatesPlantRespPhotosynthMod.F90
+++ b/biogeophys/FatesPlantRespPhotosynthMod.F90
@@ -1495,6 +1495,29 @@ subroutine LeafLayerPhotosynthesis(f_sun_lsl,         &  ! in
               ! With an <= 0, then gs_mol = stomatal_intercept_btran
               leaf_co2_ppress = can_co2_ppress- h2o_co2_bl_diffuse_ratio/gb_mol * a_gs * can_press 		   
               leaf_co2_ppress = max(leaf_co2_ppress,1.e-06_r8)
+
+              ! A note about the use of the quadratic equations for calculating stomatal conductance
+              ! ------------------------------------------------------------------------------------
+              ! These two following models calculate the conductance between the intercellular leaf
+              ! space and the leaf surface, not the canopy air space.  Transport between the leaf
+              ! surface and the canopy air space is governed by the leaf boundary layer conductance.
+              ! However, we need to estimate the properties at the surface of the leaf to solve for
+              ! the stomatal conductance. We do this by using Fick's law (gradient resistance
+              ! approximation of diffusion).
+              !
+              ! e_s = (e_i g_s + e_c g_b)/(g_b + g_s)
+              !
+              ! The leaf surface humidity (e_s) then becomes an expression of canopy humidity (e_c),
+              ! intercellular humidity (e_i), boundary layer conductance (g_b) (these are known)
+              ! and stomatal conductance (g_s) (this is still unknown).  This expression is
+              ! substituted into the stomatal conductance equation. The resulting form of these
+              ! equations becomes a quadratic.
+              !
+              ! For a detailed explanation, see the FATES technical note, section
+              ! "1.11 Stomatal Conductance"
+              !
+              ! ------------------------------------------------------------------------------------
+              
               
               if ( stomatal_model == medlyn_model ) then
                  !stomatal conductance calculated from Medlyn et al. (2011), the numerical &

--- a/biogeophys/FatesPlantRespPhotosynthMod.F90
+++ b/biogeophys/FatesPlantRespPhotosynthMod.F90
@@ -1303,7 +1303,7 @@ subroutine LeafLayerPhotosynthesis(f_sun_lsl,         &  ! in
 
   ! term accounting that two photons are needed to fully transport a single 
   ! electron to the thylakoid-membrane-bound NADP reductase (see Farquhar 1980)
-  ! ie only have the energy enters photosystem 2
+  ! ie only half the energy from a photon enters photosystem 2
   real(r8), parameter :: photon_to_e_nadp = 0.5_r8
   
   ! For plants with no leaves, a miniscule amount of conductance

--- a/biogeophys/FatesPlantRespPhotosynthMod.F90
+++ b/biogeophys/FatesPlantRespPhotosynthMod.F90
@@ -1503,11 +1503,13 @@ subroutine LeafLayerPhotosynthesis(f_sun_lsl,         &  ! in
               ! surface and the canopy air space is governed by the leaf boundary layer conductance.
               ! However, we need to estimate the properties at the surface of the leaf to solve for
               ! the stomatal conductance. We do this by using Fick's law (gradient resistance
-              ! approximation of diffusion).
+              ! approximation of diffusion) to estimate the flux of water vapor across the
+              ! leaf boundary layer, and balancing that with the flux across the stomata. It
+              ! results in the following equation for leaf surface humidity:
               !
               ! e_s = (e_i g_s + e_c g_b)/(g_b + g_s)
               !
-              ! The leaf surface humidity (e_s) then becomes an expression of canopy humidity (e_c),
+              ! The leaf surface humidity (e_s) becomes an expression of canopy humidity (e_c),
               ! intercellular humidity (e_i), boundary layer conductance (g_b) (these are known)
               ! and stomatal conductance (g_s) (this is still unknown).  This expression is
               ! substituted into the stomatal conductance equation. The resulting form of these


### PR DESCRIPTION

### Description:

Very simple, naming this constant. It really needs to not be just a 0.5 in the code, and really needs to have a name and description so people aren't confused.


<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

### Collaborators:

@rosiealice @walkeranthonyp @alistairrogers @ckoven 

<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

None, should be B4b

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [ ] The in-code documentation has been updated with descriptive comments
- [ ] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

