### PR TITLE
Make sure to define `state_vector` if not in land use mode

### DIFF
--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -325,6 +325,8 @@ contains
        call GetLUHStatedata(bc_in, state_vector)
        site_secondaryland_first_exceeding_min =  (state_vector(secondaryland) .gt. site_in%min_allowed_landuse_fraction) &
             .and. (.not. site_in%landuse_vector_gt_min(secondaryland))
+    else
+       state_vector = current_fates_landuse_state_vector
     end if
 
     currentPatch => site_in%oldest_patch


### PR DESCRIPTION
### Description:
This is a bug fix for #1221 which came in with the latest tag `sci.1.77.0_api.36.0.0`.  The local variable `state_vector` is undefined in `disturbance_rates` if land use mode is off.  To avoid indexing into an array of `NaN` we need to define values for `state_vector`.  The fix proposed here is to set it by getting the current state vector, which is called at the top of the subroutine.

### Collaborators:

### Expectation of Answer Changes:
Answer changes are not expected

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [x] The in-code documentation has been updated with descriptive comments
- [x] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [x] FATES PASS/FAIL regression tests were run
- [x] Evaluation of test results for answer changes was performed and results provided

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:* `12c60f3de477bbdaa2cf7a8afe0d089886d2c960`

*CTSM (or) E3SM (specify which) baseline hash-tag:* `12c60f3de477bbdaa2cf7a8afe0d089886d2c960`

*FATES baseline hash-tag:* `sci.1.77.0_api.36.0.0`

*Test Output:* TBD

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

