### PR TITLE
Fix write of inventory init files

### DIFF
--- a/main/FatesInventoryInitMod.F90
+++ b/main/FatesInventoryInitMod.F90
@@ -1179,10 +1179,10 @@ contains
        else
            ilon_sign = 'W'
        end if
-
-       write(pss_name_out,'(A8, I2.2, A1, I5.5, A1)') &
+ 
+       write(pss_name_out,'(A8,I2.2,A1,I5.5,A1,A1,I3.3,A1,I5.5,A1,A4)') &
              'pss_out_',ilat_int,'.',ilat_dec,ilat_sign,'_',ilon_int,'.',ilon_dec,ilon_sign,'.txt'
-       write(css_name_out,'(A8, I2.2,  A1, A1, I3.3, A1)') &
+       write(css_name_out,'(A8,I2.2,A1,I5.5,A1,A1,I3.3,A1,I5.5,A1,A4)') &
              'css_out_',ilat_int,'.',ilat_dec,ilat_sign,'_',ilon_int,'.',ilon_dec,ilon_sign,'.txt'
 
        pss_file_out       = shr_file_getUnit()
@@ -1208,7 +1208,7 @@ contains
            do while(associated(currentcohort))
                icohort=icohort+1
                write(css_file_out,*) '0000 ',trim(patch_str), &
-                     currentCohort%dbh,currentCohort%height,currentCohort%pft,currentCohort%n/currentPatch%area
+                     currentCohort%dbh,-3.0_r8,currentCohort%pft,currentCohort%n/currentPatch%area
 
                currentcohort => currentcohort%shorter
            end do


### PR DESCRIPTION
This PR fixes inventory initialization so that cohort and patch files can be written when do_inventory_out is true. After the refactor, either dbh or height needs to be negative in the cohort file, so this PR sets cohort height to -3.0 when writing the cohort file. It also changes formatting of file names (which seemed to work before but were broken by me in the last refactor I think).  Not tested yet. 

### Collaborators:


### Expectation of Answer Changes:
Should be bfb in all respects except that if do_inventory_out is true then files will be written out correctly rather than crashing the model. 


### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [x] The in-code documentation has been updated with descriptive comments
- [x] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [x] FATES PASS/FAIL regression tests were run
- [x] Evaluation of test results for answer changes was performed and results provided

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
Not tested 

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

