### PR TITLE
calculate sapwood cross-sectional area for grass PFT 

### DIFF
--- a/biogeochem/FatesAllometryMod.F90
+++ b/biogeochem/FatesAllometryMod.F90
@@ -93,6 +93,7 @@ module FatesAllometryMod
   use FatesConstantsMod, only : fates_unset_r8
   use FatesConstantsMod, only : itrue
   use FatesConstantsMod, only : nearzero
+  use FatesConstantsMod, only : pi_const
   use shr_log_mod      , only : errMsg => shr_log_errMsg
   use FatesGlobals     , only : fates_log
   use FatesGlobals     , only : endrun => fates_endrun
@@ -1045,8 +1046,10 @@ contains
             ! dead woody biomass. So bsap = bagw. Might remove the bsap and bdead for grass
             ! in the future as there is no need to distinguish the two for grass above- and belowground biomass
 
+       call sapwood_area_grass(d,sapw_area) 
        call bagw_allom(d,ipft,crowndamage,elongf_stem,bagw,dbagwdd)
        call bbgw_allom(d,ipft, elongf_stem,bbgw,dbbgwdd)
+       
        bsap = bagw + bbgw
 
        ! This is a grass-only functionnal type, no need to run crown-damage effects
@@ -1410,6 +1413,46 @@ contains
     end associate
     return
   end subroutine bsap_ltarg_slatop
+
+
+
+! ============================================================================
+  ! Area of sap wood cross-section specifically for grass PFT
+  ! ============================================================================
+
+  subroutine sapwood_area_grass(d,sapw_area)
+  !---------------------------------------------------------------------------
+  ! This function calculates sapwood cross-sectional area specifically for grass
+  ! PFT using basal diameter (cm) of the entire plant as size reference, 
+  ! assume basal area as the sum of cross-sectional area of each grass tiller 
+  ! so that water transport through sapwood can be seen as a collective behavior 
+  ! of all tillers
+  ! No reference. Might update this to more theoretical-based approach once there
+  ! is empirical evidence
+  !----------------
+  ! Input arguments
+  !----------------
+  ! d                -- basal diameter               [cm]
+
+  !----------------
+  ! Output variables
+  !----------------
+  ! sapw_area        -- sapwood cross-sectional area   [m2]
+
+  !---Arguments
+  real(r8), intent(in)              :: d             ! plant basal diameter               [    cm]
+  real(r8), intent(out)             :: sapw_area     ! sapwood cross-sectional area       [    m2]
+  
+  ! Calculate sapwood cross-sectional area assuming sapwood geometry as a 
+  ! cylinder and basal diameter is the diameter of the cylinder 
+  sapw_area = (pi_const * (d / (2.0_r8)**2.0_r8)) / cm2_per_m2
+
+  return
+
+  end subroutine sapwood_area_grass
+
+  
+
 
   ! ============================================================================
   ! Specific storage relationships


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
A subroutine, sapwood_area_grass, is added to calculate sapwood cross-sectional area specifically for grass PFT.
This is added to fix issue #1254 

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
Answers will change is FATES Hydro is turned on and using sapwood allometry mod 2

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [ x ] The in-code documentation has been updated with descriptive comments
- [ ] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

