### PR TITLE
fix typo in modify_fates_paramfile.py

### DIFF
--- a/tools/modify_fates_paramfile.py
+++ b/tools/modify_fates_paramfile.py
@@ -157,7 +157,7 @@ def main():
                                            'fates_history_damage_bins',
                                            'fates_NCWD','fates_litterclass','fates_leafage_class', \
                                            'fates_plant_organs','fates_hydr_organs','fates_hlm_pftno', \
-                                           'fates_leafage_class','fates_landuse_class']:
+                                           'fates_leafage_class','fates_landuseclass']:
                     otherdimpresent = True
                     otherdimname = var.dimensions[i]
                     otherdimlength = var.shape[i]


### PR DESCRIPTION
The dimension name for land use in the parameter file didn't match what it was listed as in modify_fates_paramfile.py, so this corrects that.

### Description:
n/a

### Collaborators:
n/a

### Expectation of Answer Changes:
None, python code only.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [ ] The in-code documentation has been updated with descriptive comments
- [ ] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
no testing because only python code.