### PR TITLE
Indexing fix in multiple python scripts

### DIFF
--- a/tools/BatchPatchParams.py
+++ b/tools/BatchPatchParams.py
@@ -107,13 +107,17 @@ def main():
     base_cdl = xmlroot.find('base_file').text
     new_cdl = xmlroot.find('new_file').text
 
+    # Append extension nc to temporary files 
+    # (in some netcdf versions, the lack of extension causes failures)
+    ext_nc  = ".nc"
+
     # Convert the base cdl file into a temp nc binary
-    base_nc = os.popen('mktemp').read().rstrip('\n')
+    base_nc = os.popen('mktemp').read().rstrip('\n')+ext_nc
     gencmd = "ncgen -o "+base_nc+" "+base_cdl
     os.system(gencmd)
 	 
     # Generate a temp output file name
-    new_nc = os.popen('mktemp').read().rstrip('\n')
+    new_nc = os.popen('mktemp').read().rstrip('\n')+ext_nc
 
     os.system("ls "+base_nc)
     os.system("ls "+new_nc)
@@ -190,7 +194,7 @@ def main():
     fp_nc.close()
 
     # Sort the new file
-    newer_nc = os.popen('mktemp').read().rstrip('\n')
+    newer_nc = os.popen('mktemp').read().rstrip('\n')+ext_nc
     os.system("../tools/ncvarsort.py --fin "+new_nc+" --fout "+newer_nc+" --overwrite")
 
 

--- a/tools/FatesPFTIndexSwapper.py
+++ b/tools/FatesPFTIndexSwapper.py
@@ -203,8 +203,9 @@ def main(argv):
         # Copy over the input data
         # Tedious, but I have to permute through all combinations of dimension position
         if( pft_dim_len == 0 ):
-            out_var = fp_out.createVariable(key,'d',(fp_in.variables.get(key).dimensions))
-            out_var.assignValue(float(fp_in.variables.get(key).data))
+            # Scalar: do not assume any dimensions.
+            out_var = fp_out.createVariable(key,'d',())
+            out_var[()] = in_var[()]
         elif( (pft_dim_found==-1) & (prt_dim_found==-1) & (litt_dim_found==-1) & (hydro_dim_found==-1) & (landuse_dim_found==-1)  ):
             out_var = fp_out.createVariable(key,'d',(fp_in.variables.get(key).dimensions))
             out_var[:] = in_var[:]
@@ -283,7 +284,7 @@ def main(argv):
     fp_in.close()
     fp_out.close()
 
-    print('Cloneing complete!')
+    print('Cloning complete!')
     exit(0)
 
 

--- a/tools/modify_fates_paramfile.py
+++ b/tools/modify_fates_paramfile.py
@@ -133,7 +133,7 @@ def main():
                 for i in range(var.shape[0]):
                     var[i] = outputval[i]
             elif(ndim_file==0):
-                var.assignValue(outputval[0])
+                var[()] = outputval[()]
 
             else:
                 print("Unhandled dimension size in modify_fates_paramfile.py")

--- a/tools/ncvarsort.py
+++ b/tools/ncvarsort.py
@@ -126,15 +126,18 @@ def main():
     # as well as all metadata to the new file.
     for i in range(len(varnames_list_sorted)):
         v_name = varnames_list_sorted[i]
-        varin = dsin.variables.get(v_name)
-        outVar = dsout.createVariable(v_name, varin.typecode, varin.dimensions)
+        v_type = dsin.variables[v_name].type
+        v_dims = dsin.variables[v_name].dimensions
+        varin  = dsin.variables.get(v_name)
         
-        n_dimensions = len(varin.dimensions)
+        outVar = dsout.createVariable(v_name, v_type, v_dims)
+        
+        n_dims = len(v_dims)
         if args.debug:
             if (verbose): print(v_name)
         #
         outVar.setncatts({k: varin.getncattr(k) for k in varin.ncattrs()})
-        if ( n_dimensions == 0):
+        if ( n_dims == 0):
            outVar[()] = varin[()]
         else:
            outVar[:] = varin[:]

--- a/tools/ncvarsort.py
+++ b/tools/ncvarsort.py
@@ -127,7 +127,7 @@ def main():
     for i in range(len(varnames_list_sorted)):
         v_name = varnames_list_sorted[i]
         varin = dsin.variables.get(v_name)
-        outVar = dsout.createVariable(v_name, varin.datatype, varin.dimensions)
+        outVar = dsout.createVariable(v_name, varin.typecode, varin.dimensions)
         
         n_dimensions = len(varin.dimensions)
         if args.debug:

--- a/tools/ncvarsort.py
+++ b/tools/ncvarsort.py
@@ -4,10 +4,18 @@
 # --input or --fin: input filename.
 # --output or --fout: output filename.  If missing, will assume its directly modifying the input file, and will prompt unless -O is specified
 
-import netCDF4 as nc
+#import netCDF4 as nc
 import sys
 import os
 import argparse
+
+# Newer versions of scipy have dropped the netcdf module and
+# netcdf functions are part of the io parent module
+try:
+    from scipy import io as nc
+
+except ImportError:
+    from scipy.io import netcdf as nc
 
 # program sorts the variables based on the provided list, and pulls them one at a time
 # from an existing file and adds them to a new file in the sorted order.

--- a/tools/ncvarsort.py
+++ b/tools/ncvarsort.py
@@ -126,7 +126,7 @@ def main():
     # as well as all metadata to the new file.
     for i in range(len(varnames_list_sorted)):
         v_name = varnames_list_sorted[i]
-        varin = dsin.variables.get[v_name]
+        varin = dsin.variables.get(v_name)
         outVar = dsout.createVariable(v_name, varin.datatype, varin.dimensions)
         
         n_dimensions = len(varin.dimensions)

--- a/tools/ncvarsort.py
+++ b/tools/ncvarsort.py
@@ -129,7 +129,6 @@ def main():
         varin  = dsin.variables.get(v_name)
         v_type = dsin.variables[v_name].typecode()
         v_dims = varin.dimensions
-        print(" V_NAME = ",v_name,"; V_TYPE = ",v_type,"; V_DIMS = ",v_dims)
         outVar = dsout.createVariable(v_name, v_type, v_dims)
         
         n_dims = len(v_dims)

--- a/tools/ncvarsort.py
+++ b/tools/ncvarsort.py
@@ -112,7 +112,7 @@ def main():
     for dname, the_dim in dsin.dimensions.items():
         if args.debug:
             if (verbose): print(dname, the_dim.size)
-        dsout.createDimension(dname, the_dim.size )
+        dsout.createDimension(dname, int(the_dim.size) )
     #
     if (verbose): print()
     #

--- a/tools/ncvarsort.py
+++ b/tools/ncvarsort.py
@@ -33,7 +33,7 @@ def main():
     args = parser.parse_args()
     #
     # open the input dataset
-    dsin = nc.Dataset(args.fnamein, 'r')
+    dsin = nc.netcdf_file(args.fnamein, 'r')
     #
     # make empty lists to hold the variable names in. the first of these is a list of sub-lists,
     # one for each type of variable (based on dimensionality).
@@ -106,7 +106,7 @@ def main():
         else:
             raise ValueError('Output file already exists and overwrite flag not specified for filename: '+args.fnameout)
     #
-    dsout = nc.Dataset(args.fnameout,  "w")
+    dsout = nc.netcdf_file(args.fnameout,  "w")
     #
     #Copy dimensions
     for dname, the_dim in dsin.dimensions.items():
@@ -126,14 +126,20 @@ def main():
     # as well as all metadata to the new file.
     for i in range(len(varnames_list_sorted)):
         v_name = varnames_list_sorted[i]
-        varin = dsin.variables[v_name]
+        varin = dsin.variables.get[v_name]
         outVar = dsout.createVariable(v_name, varin.datatype, varin.dimensions)
+        
+        n_dimensions = len(varin.dimensions)
         if args.debug:
             if (verbose): print(v_name)
         #
         outVar.setncatts({k: varin.getncattr(k) for k in varin.ncattrs()})
-        outVar[:] = varin[:]
+        if ( n_dimensions == 0):
+           outVar[()] = varin[()]
+        else:
+           outVar[:] = varin[:]
         #
+
         # copy global attributes
         dsout.setncatts({k: dsin.getncattr(k) for k in dsin.ncattrs()})#
     #

--- a/tools/ncvarsort.py
+++ b/tools/ncvarsort.py
@@ -126,7 +126,7 @@ def main():
     # as well as all metadata to the new file.
     for i in range(len(varnames_list_sorted)):
         v_name = varnames_list_sorted[i]
-        v_type = dsin.variables[v_name].type
+        v_type = dsin.variables[v_name].typecode
         v_dims = dsin.variables[v_name].dimensions
         varin  = dsin.variables.get(v_name)
         

--- a/tools/ncvarsort.py
+++ b/tools/ncvarsort.py
@@ -111,8 +111,8 @@ def main():
     #Copy dimensions
     for dname, the_dim in dsin.dimensions.items():
         if args.debug:
-            if (verbose): print(dname, the_dim.size)
-        dsout.createDimension(dname, int(the_dim.size) )
+            if (verbose): print(dname, the_dim)
+        dsout.createDimension(dname, int(the_dim) )
     #
     if (verbose): print()
     #

--- a/tools/ncvarsort.py
+++ b/tools/ncvarsort.py
@@ -126,25 +126,31 @@ def main():
     # as well as all metadata to the new file.
     for i in range(len(varnames_list_sorted)):
         v_name = varnames_list_sorted[i]
-        v_type = dsin.variables[v_name].typecode
-        v_dims = dsin.variables[v_name].dimensions
         varin  = dsin.variables.get(v_name)
-        
+        v_type = dsin.variables[v_name].typecode()
+        v_dims = varin.dimensions
+        print(" V_NAME = ",v_name,"; V_TYPE = ",v_type,"; V_DIMS = ",v_dims)
         outVar = dsout.createVariable(v_name, v_type, v_dims)
         
         n_dims = len(v_dims)
         if args.debug:
             if (verbose): print(v_name)
         #
-        outVar.setncatts({k: varin.getncattr(k) for k in varin.ncattrs()})
+        
+        # Copy attributes
+        for v_attr in varin._attributes:
+           setattr(outVar,v_attr,getattr(varin,v_attr))
+        
         if ( n_dims == 0):
            outVar[()] = varin[()]
         else:
            outVar[:] = varin[:]
         #
 
-        # copy global attributes
-        dsout.setncatts({k: dsin.getncattr(k) for k in dsin.ncattrs()})#
+    # copy global attributes
+    for g_attr in dsin._attributes:
+       setattr(dsout,g_attr,getattr(dsin,g_attr))
+
     #
     # close the output file
     dsin.close()


### PR DESCRIPTION
Minor updates on multiple python scripts, for indexing and for using netcdf from scipy.io libraries


<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

I don't know if this is only happening on my computer, but `FatesPFTIndexSwapper.py ` started to issue the following indexing error when it attempted to copy scalars:
```
Creating Variable:  fates_canopy_closure_thresh
Traceback (most recent call last):
  File "/path_to/E3SM/components/elm/src/external_models/fates/tools/FatesPFTIndexSwapper.py", line 296, in <module>
    main(sys.argv)
    ~~~~^^^^^^^^^^
  File "/path_to/Models/E3SM/components/elm/src/external_models/fates/tools/FatesPFTIndexSwapper.py", line 207, in main
    out_var.assignValue(float(fp_in.variables.get(key).data))
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/scipy/io/_netcdf.py", line 943, in assignValue
    self.data[:] = value
    ~~~~~~~~~^^^
IndexError: too many indices for array: array is 0-dimensional, but 1 were indexed
<sys>:0: RuntimeWarning: Cannot close a netcdf_file opened with mmap=True, when netcdf_variables or arrays referring to its data still exist. All data arrays obtained from such files refer directly to data on disk, and must be copied before the file can be cleanly closed. (See netcdf_file docstring for more information on mmap.)

```
The suggested change in the code seems to work fine (though I still get the RuntimeWarning message). I made similar updates in a few other scripts. I also updated `ncvarsort.py` to use scipy.



### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

No change in the FATES code, just the tool.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [ ] The in-code documentation has been updated with descriptive comments
- [ ] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

