### PR TITLE
Fix CNP allocation weights when reproductive fraction is 1

### DIFF
--- a/parteh/PRTAllometricCNPMod.F90
+++ b/parteh/PRTAllometricCNPMod.F90
@@ -2541,7 +2541,7 @@ contains
         ! repro_w * (1 - repro_c_frac) = total_w*repro_c_frac
         ! repro_w = total_w * repro_c_frac/(1-repro_c_frac)
 
-        if(repro_c_frac - 1._r8 < nearzero) then
+        if(1._r8 - repro_c_frac < nearzero) then
            repro_w = repro_c_frac 
         else
            repro_w = total_w * repro_c_frac/(1._r8 - repro_c_frac)

--- a/parteh/PRTAllometricCNPMod.F90
+++ b/parteh/PRTAllometricCNPMod.F90
@@ -2540,8 +2540,13 @@ contains
         ! repro_w = (total_w + repro_w)*repro_c_frac = total_w*repro_c_frac + repro_w*repro_c_frac
         ! repro_w * (1 - repro_c_frac) = total_w*repro_c_frac
         ! repro_w = total_w * repro_c_frac/(1-repro_c_frac)
+
+        if(repro_c_frac - 1._r8 < nearzero) then
+           repro_w = repro_c_frac 
+        else
+           repro_w = total_w * repro_c_frac/(1._r8 - repro_c_frac)
+        end if
         
-        repro_w = total_w * repro_c_frac/(1._r8 - repro_c_frac)
         total_w = total_w  + repro_w
         avg_nc = avg_nc + repro_w * nc_repro
         avg_pc = avg_pc + repro_w * pc_repro


### PR DESCRIPTION
This PR address issue #1283. When 100% of allocation goes to seeds (as is the default case for mature shrubs), then we need an if statement in the EstimateGrowthNC subroutine to avoid a divide by zero error. 

### Collaborators:
@rgknox @mpaiao 

### Expectation of Answer Changes:
This might be answer changing in CNP runs, although I'm not sure what FATES was doing when DEBUG was false. 


### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [x] The in-code documentation has been updated with descriptive comments
- [x] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [x] FATES PASS/FAIL regression tests were run
- [x] Evaluation of test results for answer changes was performed and results provided

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
Quick test on main at API 36.0 with debug=TRUE is running. No regression testing done yet. 
