### PR TITLE
Don't zero out `patch%fuel%frac_burnt()` before we use it

### DIFF
--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -1721,8 +1721,6 @@ contains
 
     call TransLitterNewPatch( currentSite, currentPatch, new_patch, temp_area, 0)
 
-    currentPatch%fuel%frac_burnt(:) = 0._r8
-
     ! Next, we loop through the cohorts in the donor patch, copy them with
     ! area modified number density into the new-patch, and apply survivorship.
     ! -------------------------------------------------------------------------

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -2077,7 +2077,7 @@ contains
 
        do c = 1,ncwd
          
-         if (dist_type == dtype_ifall .and. currentPatch%fire == 1) then
+         if (dist_type == dtype_ifire .and. currentPatch%fire == 1) then
             frac_burnt = currentPatch%fuel%frac_burnt(c)
          else 
             frac_burnt = 0.0_r8
@@ -2105,7 +2105,7 @@ contains
           
        enddo
        
-       if (dist_type == dtype_ifall .and. currentPatch%fire == 1) then
+       if (dist_type == dtype_ifire .and. currentPatch%fire == 1) then
          frac_burnt = currentPatch%fuel%frac_burnt(fuel_classes%dead_leaves())
       else 
          frac_burnt = 0.0_r8

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -769,7 +769,7 @@ contains
 
                             call CopyPatchMeansTimers(currentPatch, newPatch)
 
-                            call TransLitterNewPatch( currentSite, currentPatch, newPatch, patch_site_areadis)
+                            call TransLitterNewPatch( currentSite, currentPatch, newPatch, patch_site_areadis, i_disturbance_type)
 
                             ! Transfer in litter fluxes from plants in various contexts of death and destruction
                             select case(i_disturbance_type)
@@ -1719,7 +1719,7 @@ contains
 
     call CopyPatchMeansTimers(currentPatch, new_patch)
 
-    call TransLitterNewPatch( currentSite, currentPatch, new_patch, temp_area)
+    call TransLitterNewPatch( currentSite, currentPatch, new_patch, temp_area, 0)
 
     currentPatch%fuel%frac_burnt(:) = 0._r8
 

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -2074,13 +2074,11 @@ contains
           litter_stock0 = curr_litt%GetTotalLitterMass()*currentPatch%area + & 
                           new_litt%GetTotalLitterMass()*newPatch%area
        end if
-
+       
        do c = 1,ncwd
-         
+         frac_burnt = 0.0_r8
          if (dist_type == dtype_ifire .and. currentPatch%fire == 1) then
             frac_burnt = currentPatch%fuel%frac_burnt(c)
-         else 
-            frac_burnt = 0.0_r8
          end if 
              
           ! Transfer above ground CWD
@@ -2105,13 +2103,11 @@ contains
           
        enddo
        
+       frac_burnt = 0.0_r8
        if (dist_type == dtype_ifire .and. currentPatch%fire == 1) then
          frac_burnt = currentPatch%fuel%frac_burnt(fuel_classes%dead_leaves())
-      else 
-         frac_burnt = 0.0_r8
       end if 
-          
-          
+             
        do dcmpy=1,ndcmpy
 
            ! Transfer leaf fines

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -767,10 +767,6 @@ contains
                             ! and burned litter to atmosphere. Thus it is important to zero fuel%frac_burnt when
                             ! fire is not the current disturbance regime.
 
-                            if(i_disturbance_type .ne. dtype_ifire) then
-                               currentPatch%fuel%frac_burnt(:) = 0._r8
-                            end if
-
                             call CopyPatchMeansTimers(currentPatch, newPatch)
 
                             call TransLitterNewPatch( currentSite, currentPatch, newPatch, patch_site_areadis)
@@ -1045,7 +1041,6 @@ contains
                                   ! Some of of the leaf mass from living plants has been
                                   ! burned off.  Here, we remove that mass, and
                                   ! tally it in the flux we sent to the atmosphere
-
                                   if(prt_params%woody(currentCohort%pft) == itrue)then
                                      leaf_burn_frac = currentCohort%fraction_crown_burned
                                   else
@@ -1922,7 +1917,8 @@ contains
   subroutine TransLitterNewPatch(currentSite,        &
                                  currentPatch,       &
                                  newPatch,           &
-                                 patch_site_areadis)
+                                 patch_site_areadis, &
+                                 dist_type)
 
     ! -----------------------------------------------------------------------------------
     ! 
@@ -1971,6 +1967,7 @@ contains
     type(fates_patch_type) , intent(inout) :: newPatch           ! New patch
     real(r8)            , intent(in)    :: patch_site_areadis ! Area being donated
                                                               ! by current patch
+    integer,              intent(in)    :: dist_type          ! disturbance type
 
     
     ! locals
@@ -1993,6 +1990,7 @@ contains
     real(r8) :: litter_stock0,litter_stock1
     real(r8) :: burn_flux0,burn_flux1
     real(r8) :: error
+    real(r8) :: frac_burnt                 ! fraction burnt of current fuel type [0-1]
 
     do el = 1,num_elements
 
@@ -2078,13 +2076,19 @@ contains
        end if
 
        do c = 1,ncwd
+         
+         if (dist_type == dtype_ifall .and. currentPatch%fire == 1) then
+            frac_burnt = currentPatch%fuel%frac_burnt(c)
+         else 
+            frac_burnt = 0.0_r8
+         end if 
              
           ! Transfer above ground CWD
           donatable_mass     = curr_litt%ag_cwd(c) * patch_site_areadis * &
-                               (1._r8 - currentPatch%fuel%frac_burnt(c))
+                               (1._r8 - frac_burnt)
 
           burned_mass        = curr_litt%ag_cwd(c) * patch_site_areadis * &
-                               currentPatch%fuel%frac_burnt(c)
+                               frac_burnt
  
           new_litt%ag_cwd(c) = new_litt%ag_cwd(c) + donatable_mass*donate_m2
           curr_litt%ag_cwd(c) = curr_litt%ag_cwd(c) + donatable_mass*retain_m2
@@ -2100,15 +2104,22 @@ contains
           end do
           
        enddo
+       
+       if (dist_type == dtype_ifall .and. currentPatch%fire == 1) then
+         frac_burnt = currentPatch%fuel%frac_burnt(fuel_classes%dead_leaves())
+      else 
+         frac_burnt = 0.0_r8
+      end if 
+          
           
        do dcmpy=1,ndcmpy
 
            ! Transfer leaf fines
            donatable_mass           = curr_litt%leaf_fines(dcmpy) * patch_site_areadis * &
-                                      (1._r8 - currentPatch%fuel%frac_burnt(fuel_classes%dead_leaves()))
+                                      (1._r8 - frac_burnt)
 
            burned_mass              = curr_litt%leaf_fines(dcmpy) * patch_site_areadis * &
-                                      currentPatch%fuel%frac_burnt(fuel_classes%dead_leaves())
+                                       frac_burnt
 
            new_litt%leaf_fines(dcmpy) = new_litt%leaf_fines(dcmpy) + donatable_mass*donate_m2
            curr_litt%leaf_fines(dcmpy) = curr_litt%leaf_fines(dcmpy) + donatable_mass*retain_m2

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -71,6 +71,7 @@ contains
     do while(associated(currentPatch))
       currentPatch%frac_burnt = 0.0_r8
       currentPatch%fire = 0
+      currentPatch%fuel%frac_burnt(:) = 0.0_r8
       currentPatch => currentPatch%older
     end do
     


### PR DESCRIPTION
Fixes #1301 by checking inside the `TransLitterNewPatch` for the type of disturbance instead of zero-ing outside of the subroutine. 

### Description:

Removed the lines in `spawn_patches` that zero-d the `frac_burnt` array too soon.
Added checks in `TransLitterNewPatch` to check for fire disturbance and a fire on the patch:
   If no fire, new local variable `frac_burnt` set to 0.0, otherwise use `patch%fuel%frac_burnt`

### Collaborators:
@glemieux 

### Expectation of Answer Changes:
Yes - should change answers because before we weren't burning any fuel

### Checklist

*Contributor*
- [x] The in-code documentation has been updated with descriptive comments
- [x] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [x] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided

### Test Results:

*CTSM (or) E3SM (specify which) test hash-tag:* `ctsm5.3.012`

*CTSM (or) E3SM (specify which) baseline hash-tag:* `ctsm5.3.012`

*FATES baseline hash-tag:* `sci.1.80.4_api.37.0.0`

*Test Output:*

Running tests now
