### PR TITLE
Fix vegetation temperature weighting during phenology

### DIFF
--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -1028,7 +1028,7 @@ contains
        temp_wgt = temp_wgt + cpatch%total_canopy_area
        cpatch => cpatch%younger
     end do
-    if(cpatch%total_canopy_area>nearzero)then
+    if(temp_wgt>nearzero)then
        temp_in_C = temp_in_C/temp_wgt - tfrz
     else
        ! If there is no canopy area, we use the veg temperature


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

This change improves how we calculate vegetation temperature during phenology.  The previous method included bare ground patches in the mean.  Bare ground temperatures are initialized with the column/site level air temperature, but those values are not as representative of using only patch level vegetation temperatures.  This new method filters in only temperatures from patches with vegetation, and uses the canopy area as the weighting factor, instead of total patch area.

This should precede #1226 


<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

### Collaborators:
@rosiealice 

<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->
Yes, this should change answers, at least for tests that are long enough to trigger phenology events.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [x] The in-code documentation has been updated with descriptive comments
- [x] The documentation has been assessed to determine if updates are necessary (NOT NECESSARY)

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided

### Test Results:

TBD

<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

