### PR TITLE
alternative way to adjust area issues in FATES twostream

### DIFF
--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -2274,6 +2274,13 @@ contains
 
    ! Number of actual vegetation layers in this cohort's crown
    currentCohort%nv =  count((currentCohort%treelai+currentCohort%treesai) .gt. dlower_vai(:)) + 1
+
+   if( currentCohort%nv .ne. minloc(dlower_vai, DIM=1, MASK=(dlower_vai>(currentCohort%treelai+currentCohort%treesai))) ) then
+      write(fates_log(),*) 'We use two methods of finding maximum leaf layers, and they are not equivalent'
+      write(fates_log(),*) 'count method:',currentCohort%nv
+      write(fates_log(),*) 'minloc method:',minloc(dlower_vai, DIM=1, MASK=(dlower_vai>(currentCohort%treelai+currentCohort%treesai)))
+      call endrun(msg=errMsg(sourcefile, __LINE__))
+   end if
    
   end subroutine UpdateCohortLAI
   

--- a/radiation/FatesTwoStreamUtilsMod.F90
+++ b/radiation/FatesTwoStreamUtilsMod.F90
@@ -31,7 +31,7 @@ Module FatesTwoStreamUtilsMod
   
   implicit none
 
-  logical, parameter :: debug  = .true. ! local debug flag
+  logical, parameter :: debug  = .false. ! local debug flag
   character(len=*), parameter, private :: sourcefile = &
        __FILE__
 

--- a/radiation/FatesTwoStreamUtilsMod.F90
+++ b/radiation/FatesTwoStreamUtilsMod.F90
@@ -31,7 +31,7 @@ Module FatesTwoStreamUtilsMod
   
   implicit none
 
-  logical, parameter :: debug  = .false. ! local debug flag
+  logical, parameter :: debug  = .true. ! local debug flag
   character(len=*), parameter, private :: sourcefile = &
        __FILE__
 
@@ -261,7 +261,7 @@ contains
                   write(fates_log(),*) 'more than 100% of the area footprint, exceeding a'
                   write(fates_log(),*) 'precision threshold of 0.01'
                   write(fates_log(),*) 'Aborting'
-                  write(fates_log(),*) 'canopy layer: ',ican',canopy_frac:',canopy_frac(ican)
+                  write(fates_log(),*) 'canopy layer: ',ican,' canopy_frac:',canopy_frac(ican)
                   call endrun(msg=errMsg(sourcefile, __LINE__))
                end if if_very_overfull
             end if
@@ -289,7 +289,7 @@ contains
                         write(fates_log(),*) 'This will have to large of an impact on the donor and is not representative'
                         write(fates_log(),*) 'of the actual composition of the canopy'
                         write(fates_log(),*) 'Aborting'
-                        write(fates_log(),*) 'canopy layer: ',ican',canopy_frac:',canopy_frac(ican)
+                        write(fates_log(),*) 'canopy layer: ',ican,' canopy_frac:',canopy_frac(ican)
                         write(fates_log(),*) 'existing donor area',twostr%scelg(ican,icolmax)%area
                         call endrun(msg=errMsg(sourcefile, __LINE__))
                      end if

--- a/radiation/FatesTwoStreamUtilsMod.F90
+++ b/radiation/FatesTwoStreamUtilsMod.F90
@@ -255,15 +255,16 @@ contains
             ! model if so. This should not happen and would most likely be an issue
             ! with the canopy ppa promotion/demotion logic
             ! This is more of a sanity check, so we use a 1% threshold
-            if_very_overfull: if( (canopy_frac(ican)-1._r8)>0.01_r8 ) then
-               write(fates_log(),*) 'One of the fates canopy layers takes up'
-               write(fates_log(),*) 'more than 100% of the area footprint, exceeding a'
-               write(fates_log(),*) 'precision threshold of 0.01'
-               write(fates_log(),*) 'Aborting'
-               write(fates_log(),*) 'canopy layer: ',ican',canopy_frac:',canopy_frac(ican)
-               call endrun(msg=errMsg(sourcefile, __LINE__))
-            end if if_very_overfull
-               
+            if(debug)then
+               if_very_overfull: if( (canopy_frac(ican)-1._r8)>0.01_r8 ) then
+                  write(fates_log(),*) 'One of the fates canopy layers takes up'
+                  write(fates_log(),*) 'more than 100% of the area footprint, exceeding a'
+                  write(fates_log(),*) 'precision threshold of 0.01'
+                  write(fates_log(),*) 'Aborting'
+                  write(fates_log(),*) 'canopy layer: ',ican',canopy_frac:',canopy_frac(ican)
+                  call endrun(msg=errMsg(sourcefile, __LINE__))
+               end if if_very_overfull
+            end if
             ! If the layer is overfull, remove some from area from
             ! the element with the largest footprint
 
@@ -281,6 +282,18 @@ contains
                
                ! Test out a simpler way to correct area errors
                if(do_simple_area_correct) then
+                  if(debug) then
+                     if((canopy_frac(ican)-1._r8)>0.5_r8*twostr%scelg(ican,icolmax)%area)then
+                        write(fates_log(),*) 'An area correction is being applied where '
+                        write(fates_log(),*) 'the correction is greater than 50% of the area of the largest donor.'
+                        write(fates_log(),*) 'This will have to large of an impact on the donor and is not representative'
+                        write(fates_log(),*) 'of the actual composition of the canopy'
+                        write(fates_log(),*) 'Aborting'
+                        write(fates_log(),*) 'canopy layer: ',ican',canopy_frac:',canopy_frac(ican)
+                        write(fates_log(),*) 'existing donor area',twostr%scelg(ican,icolmax)%area
+                        call endrun(msg=errMsg(sourcefile, __LINE__))
+                     end if
+                  end if
                   twostr%scelg(ican,icolmax)%area = twostr%scelg(ican,icolmax)%area - (canopy_frac(ican)-1._r8)
                else
                   area_ratio = (twostr%scelg(ican,icolmax)%area + (1._r8-canopy_frac(ican)))/twostr%scelg(ican,icolmax)%area

--- a/radiation/FatesTwoStreamUtilsMod.F90
+++ b/radiation/FatesTwoStreamUtilsMod.F90
@@ -152,7 +152,8 @@ contains
          else
             canopy_frac(:) = 0._r8
          end if
-         
+
+         ! Add the air element if the canopy area is not filled
          do ican = 1,patch%ncl_p
             if( (1._r8-canopy_frac(ican))>area_err_thresh ) then
                n_col(ican) = n_col(ican) + 1
@@ -250,6 +251,19 @@ contains
                twostr%scelg(ican,n_col(ican))%sai  = 0._r8
             end if
 
+            ! Check to see if any of these layers are extremely over-full and stop the
+            ! model if so. This should not happen and would most likely be an issue
+            ! with the canopy ppa promotion/demotion logic
+            ! This is more of a sanity check, so we use a 1% threshold
+            if_very_overfull: if( (canopy_frac(ican)-1._r8)>0.01_r8 ) then
+               write(fates_log(),*) 'One of the fates canopy layers takes up'
+               write(fates_log(),*) 'more than 100% of the area footprint, exceeding a'
+               write(fates_log(),*) 'precision threshold of 0.01'
+               write(fates_log(),*) 'Aborting'
+               write(fates_log(),*) 'canopy layer: ',ican',canopy_frac:',canopy_frac(ican)
+               call endrun(msg=errMsg(sourcefile, __LINE__))
+            end if if_very_overfull
+               
             ! If the layer is overfull, remove some from area from
             ! the element with the largest footprint
 

--- a/radiation/FatesTwoStreamUtilsMod.F90
+++ b/radiation/FatesTwoStreamUtilsMod.F90
@@ -78,7 +78,7 @@ contains
     integer :: max_elements     ! Maximum number of scattering elements on the site
     integer :: n_scr            ! The size of the scratch arrays
     logical :: allocate_scratch ! Whether to re-allocate the scratch arrays
-    integer  :: icolmax         ! Column index for each layer with largest are footprint
+    integer  :: icolmax         ! Column index for each layer with largest area footprint
     real(r8) :: areamax         ! The area footprint of the largest column
     
     ! its possible that there is more horizontal area taken up by the cohorts


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

Its possible that there is more horizontal area taken up by the cohorts than there is ground, which is simply a result of numerical imprecision in the rest of FATES. If this is true, then we need to somehow force the total area of the two-stream scattering elements to be exactly 1 and not slightly more. One way is to just chop off some area of the largest scattering element (simple way). This is simple, yet does not conserve total scattering depth.  The other (which we already allow) is to chop off that area but also increase the LAI+SAI. The latter is conservative, but is creating indexing problems when when the LAI and SAI is increased enough such that it uses more depth bins than FATES anticipated.

### Collaborators:

@jennykowalcz 

<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
Good chance there will be very slight differences in two-stream tests.  There should be no scientifically meaningful impacts to results.

<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [x] The in-code documentation has been updated with descriptive comments

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->
TBD

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

