### PR TITLE
preserve cohort order when cohorts have identical heights

### DIFF
--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -1309,10 +1309,10 @@ end subroutine create_cohort
     shortestc => NULL()
     storebigcohort   => null()
     storesmallcohort => null()
-    current_c => current_patch%tallest
+    current_c => current_patch%shortest
 
     do while (associated(current_c))
-       next_c => current_c%shorter
+       next_c => current_c%taller
        tallestc  => storebigcohort
        shortestc => storesmallcohort
        if (associated(tallestc)) then
@@ -1388,7 +1388,7 @@ end subroutine create_cohort
     !taller than tree being considered and return its pointer
     if (associated(current)) then
        do while (associated(current).and.exitloop == 0)
-          if (current%height < tsp) then
+          if (current%height <= tsp) then
              current => current%taller
           else
              exitloop = 1


### PR DESCRIPTION
Fixes #1313 

### Description:

Just makes the cohort order preserved when the cohorts have identical heights

### Collaborators:

@billsacks @glemieux 

### Expectation of Answer Changes:
Yes - round off diffs


### Checklist

*Contributor*
- [X] The in-code documentation has been updated with descriptive comments
- [X] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided

### Test Results:

*CTSM (or) E3SM (specify which) test hash-tag:* `ctsm5.3.021`

*CTSM (or) E3SM (specify which) baseline hash-tag:* `ctsm5.3.021`

*FATES baseline hash-tag:* `sci.1.80.11_api.37.0.0`

*Test Output:*

