### PR TITLE
Deciduous vegetation declines due to reset in L2FR during leaf-off.

### DIFF
--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -18,7 +18,7 @@ module EDPhysiologyMod
   use FatesInterfaceTypesMod, only    : hlm_parteh_mode
   use FatesInterfaceTypesMod, only    : hlm_use_fixed_biogeog
   use FatesInterfaceTypesMod, only    : hlm_use_nocomp
-  use EDParamsMod           , only    : crop_lu_pft_vector     
+  use EDParamsMod           , only    : crop_lu_pft_vector
   use FatesInterfaceTypesMod, only    : hlm_nitrogen_spec
   use FatesInterfaceTypesMod, only    : hlm_phosphorus_spec
   use FatesInterfaceTypesMod, only    : hlm_use_tree_damage
@@ -164,14 +164,14 @@ module EDPhysiologyMod
   public :: UpdateRecruitL2FR
   public :: UpdateRecruitStoicH
   public :: SetRecruitL2FR
-  
+
   logical, parameter :: debug  = .false. ! local debug flag
   character(len=*), parameter, private :: sourcefile = &
        __FILE__
 
   integer :: istat           ! return status code
   character(len=255) :: smsg ! Message string for deallocation errors
-  
+
   integer, parameter :: dleafon_drycheck = 100 ! Drought deciduous leaves max days on check parameter
 
   real(r8), parameter :: decid_leaf_long_max = 1.0_r8 ! Maximum leaf lifespan for
@@ -196,7 +196,7 @@ module EDPhysiologyMod
                                                       !    computational problems. The current threshold
                                                       !    is the same used in ED-2.2.
 
-  real(r8), parameter :: smp_lwr_bound = -1000000._r8 ! Imposed soil matric potential lower bound for 
+  real(r8), parameter :: smp_lwr_bound = -1000000._r8 ! Imposed soil matric potential lower bound for
                                                       !    frozen or excessively dry soils, used when
                                                       !    computing water stress.
   ! ============================================================================
@@ -256,14 +256,14 @@ contains
   end subroutine ZeroAllocationRates
 
   ! ============================================================================
-  
+
   subroutine GenerateDamageAndLitterFluxes( csite, cpatch, bc_in )
 
     ! Arguments
     type(ed_site_type)  :: csite
     type(fates_patch_type) :: cpatch
     type(bc_in_type), intent(in) :: bc_in
-    
+
 
     ! Locals
     type(fates_cohort_type), pointer :: ccohort    ! Current cohort
@@ -283,10 +283,10 @@ contains
     real(r8) :: repro_loss       ! "" [kg]
     real(r8) :: sapw_loss        ! "" [kg]
     real(r8) :: store_loss       ! "" [kg]
-    real(r8) :: struct_loss      ! "" [kg]       
+    real(r8) :: struct_loss      ! "" [kg]
     real(r8) :: dcmpy_frac       ! fraction of mass going to each decomposition pool
-    real(r8) :: SF_val_CWD_frac_adj(4) !SF_val_CWD_frac adjusted based on cohort dbh 
-    
+    real(r8) :: SF_val_CWD_frac_adj(4) !SF_val_CWD_frac adjusted based on cohort dbh
+
     if(hlm_use_tree_damage .ne. itrue) return
 
     if(.not.damage_time) return
@@ -298,12 +298,12 @@ contains
        if(prt_params%woody(ccohort%pft)==ifalse  ) cycle
        if(ccohort%isnew ) cycle
 
-       associate( ipft     => ccohort%pft, & 
+       associate( ipft     => ccohort%pft, &
                   agb_frac => prt_params%allom_agb_frac(ccohort%pft), &
                   branch_frac => param_derived%branch_frac(ccohort%pft))
-         
+
        do_dclass: do cd = ccohort%crowndamage+1, nlevdamage
-          
+
           call GetDamageFrac(ccohort%crowndamage, cd, ipft, cd_frac)
 
           ! now to get the number of damaged trees we multiply by damage frac
@@ -315,7 +315,7 @@ contains
              ! Create a new damaged cohort
              allocate(ndcohort)  ! new cohort surviving but damaged
              if(hlm_use_planthydro.eq.itrue) call InitHydrCohort(csite,ndcohort)
-             
+
              ! Initialize the PARTEH object and point to the
              ! correct boundary condition fields
              ndcohort%prt => null()
@@ -323,37 +323,37 @@ contains
              call InitPRTObject(ndcohort%prt)
              call ndcohort%InitPRTBoundaryConditions()
              call ndcohort%ZeroValues()
-             
-             ! nc_canopy_d is the new cohort that gets damaged 
+
+             ! nc_canopy_d is the new cohort that gets damaged
              call ccohort%Copy(ndcohort)
-             
+
              ! new number densities - we just do damaged cohort here -
              ! undamaged at the end of the cohort loop once we know how many damaged to
              ! subtract
-             
+
              ndcohort%n = num_trees_cd
              ndcohort%crowndamage = cd
 
              ! Remove these trees from the donor cohort
              ccohort%n = ccohort%n - num_trees_cd
-             
-             ! update crown area here - for cohort fusion and canopy organisation below 
+
+             ! update crown area here - for cohort fusion and canopy organisation below
              call carea_allom(ndcohort%dbh, ndcohort%n, csite%spread, &
                   ipft, ndcohort%crowndamage, ndcohort%c_area)
-             
+
              call GetCrownReduction(cd-ccohort%crowndamage, crown_loss_frac)
 
              do_element: do el = 1, num_elements
-                
+
                 litt => cpatch%litter(el)
                 elflux_diags => csite%flux_diags%elem(el)
-                
+
                 ! Reduce the mass of the newly damaged cohort
                 ! Fine-roots are not damaged as of yet
                 ! only above-ground sapwood,structure and storage in
                 ! branches is damaged/removed
                 branch_loss_frac = crown_loss_frac * branch_frac * agb_frac
-                
+
                 leaf_loss = ndcohort%prt%GetState(leaf_organ,element_list(el))*crown_loss_frac
                 repro_loss = ndcohort%prt%GetState(repro_organ,element_list(el))*crown_loss_frac
                 sapw_loss = ndcohort%prt%GetState(sapw_organ,element_list(el))*branch_loss_frac
@@ -364,7 +364,7 @@ contains
                 ! Transfer the biomass from the cohort's
                 ! damage to the litter input fluxes
                 ! ------------------------------------------------------
-    
+
                 do dcmpy=1,ndcmpy
                    dcmpy_frac = GetDecompyFrac(ipft,leaf_organ,dcmpy)
                    litt%leaf_fines_in(dcmpy) = litt%leaf_fines_in(dcmpy) + &
@@ -375,7 +375,7 @@ contains
                 elflux_diags%surf_fine_litter_input(ipft) = &
                      elflux_diags%surf_fine_litter_input(ipft) +  &
                      (store_loss+leaf_loss+repro_loss) * ndcohort%n
-                
+
                 call adjust_SF_CWD_frac(ndcohort%dbh,ncwd,SF_val_CWD_frac,SF_val_CWD_frac_adj)
 
                 do c = 1,ncwd
@@ -383,12 +383,12 @@ contains
                         (sapw_loss + struct_loss) * &
                         SF_val_CWD_frac_adj(c) * ndcohort%n / &
                         cpatch%area
-                   
+
                    elflux_diags%cwd_ag_input(c)  = elflux_diags%cwd_ag_input(c) + &
                         (struct_loss + sapw_loss) * &
                         SF_val_CWD_frac_adj(c) * ndcohort%n
                 end do
-                
+
              end do do_element
 
              ! Applying the damage to the cohort, does not need to happen
@@ -398,14 +398,14 @@ contains
              call PRTDamageLosses(ndcohort%prt, sapw_organ, branch_loss_frac)
              call PRTDamageLosses(ndcohort%prt, store_organ, branch_loss_frac)
              call PRTDamageLosses(ndcohort%prt, struct_organ, branch_loss_frac)
-                                
-             
+
+
              !----------- Insert new cohort into the linked list
              ! This list is going tall to short, lets add this new
              ! cohort into a taller position so we don't hit it again
              ! as the loop traverses
              ! --------------------------------------------------------------!
-             
+
              ndcohort%shorter => ccohort
              if(associated(ccohort%taller))then
                 ndcohort%taller => ccohort%taller
@@ -415,7 +415,7 @@ contains
                 ndcohort%taller => null()
              endif
              ccohort%taller => ndcohort
-             
+
           end if if_numtrees
 
        end do do_dclass
@@ -423,7 +423,7 @@ contains
        end associate
        ccohort => ccohort%shorter
     enddo
-    
+
     return
   end subroutine GenerateDamageAndLitterFluxes
 
@@ -472,29 +472,29 @@ contains
 
          ! Calculate loss rate of viable seeds to litter
          call SeedDecay(litt, currentPatch, bc_in)
-         
+
          ! Calculate seed germination rate, the status flags prevent
          ! germination from occuring when the site is in a drought
          ! (for drought deciduous) or too cold (for cold deciduous)
          call SeedGermination(litt, currentSite%cstatus, currentSite%dstatus(1:numpft), bc_in, currentPatch)
-         
+
          ! Send fluxes from newly created litter into the litter pools
          ! This litter flux is from non-disturbance inducing mortality, as well
          ! as litter fluxes from live trees
          call CWDInput(currentSite, currentPatch, litt,bc_in)
-         
+
          ! Only calculate fragmentation flux over layers that are active
          ! (RGK-Mar2019) SHOULD WE MAX THIS AT 1? DONT HAVE TO
-         
+
          nlev_eff_decomp = max(bc_in%max_rooting_depth_index_col, 1)
          call CWDOut(litt,currentPatch%fragmentation_scaler,nlev_eff_decomp)
-         
+
          ! Fragmentation flux to soil decomposition model [kg/site/day]
          site_mass%frag_out = site_mass%frag_out + currentPatch%area * &
               ( sum(litt%ag_cwd_frag) + sum(litt%bg_cwd_frag) + &
               sum(litt%leaf_fines_frag) + sum(litt%root_fines_frag) + &
               sum(litt%seed_decay) + sum(litt%seed_germ_decay))
-         
+
          ! Track total seed decay diagnostic in [kg/m2/day]
          diag%tot_seed_turnover = diag%tot_seed_turnover + &
               (sum(litt%seed_decay) + sum(litt%seed_germ_decay))*currentPatch%area*area_inv
@@ -668,7 +668,7 @@ contains
     real(r8) :: target_c_area
 
     real(r8) :: pft_leaf_lifespan         ! Leaf lifespan of each PFT [years]
-    real(r8) :: leaf_long                 ! temporary leaf lifespan before accounting for deciduousness 
+    real(r8) :: leaf_long                 ! temporary leaf lifespan before accounting for deciduousness
     !----------------------------------------------------------------------
 
     currentPatch => currentSite%youngest_patch
@@ -713,7 +713,7 @@ contains
              call endrun(msg=errMsg(sourcefile, __LINE__))
           endif
 
-          ! Find target leaf biomass. Here we assume that leaves would be fully flushed 
+          ! Find target leaf biomass. Here we assume that leaves would be fully flushed
           ! (elongation factor = 1)
           call bleaf(currentcohort%dbh,ipft,&
                currentCohort%crowndamage, currentcohort%canopy_trim,1.0_r8, tar_bl)
@@ -734,7 +734,7 @@ contains
           else
              leaf_long = sum(prt_params%leaf_long_ustory(ipft,:))
           end if
-          
+
 
           ! PFT-level maximum SLA value, even if under a thick canopy (same units as slatop)
           sla_max = prt_params%slamax(ipft)
@@ -749,7 +749,7 @@ contains
              ! Calculate the cumulative total vegetation area index (no snow occlusion, stems and leaves)
              leaf_inc    = dinc_vai(z) * &
                   currentCohort%treelai/(currentCohort%treelai+currentCohort%treesai)
-             
+
              ! Now calculate the cumulative top-down lai of the current layer's midpoint within the current cohort
              lai_layers_above      = (dlower_vai(z) - dinc_vai(z)) * &
                   currentCohort%treelai/(currentCohort%treelai+currentCohort%treesai)
@@ -768,7 +768,7 @@ contains
                 kn = decay_coeff_vcmax(currentCohort%vcmax25top, &
                      prt_params%leafn_vert_scaler_coeff1(ipft), &
                      prt_params%leafn_vert_scaler_coeff2(ipft))
-                
+
                 ! Nscaler value at leaf level z
                 nscaler_levleaf = exp(-kn * cumulative_lai)
                 ! Sla value at leaf level z after nitrogen profile scaling (m2/gC)
@@ -954,8 +954,8 @@ contains
     real(r8) :: elongf_prev       ! Elongation factor from previous time
     real(r8) :: elongf_1st        ! First guess for elongation factor
     integer  :: ndays_pft_leaf_lifespan ! PFT life span of drought deciduous [days].
-                                        !    This is the shortest between the PFT leaf 
-                                        !    lifespan and the maximum lifespan of drought 
+                                        !    This is the shortest between the PFT leaf
+                                        !    lifespan and the maximum lifespan of drought
                                         !    deciduous (see parameter decid_leaf_long_max
                                         !    at the beginning of this file).
      real(r8) :: phen_drought_threshold ! For drought hard-deciduous, this is the threshold
@@ -966,14 +966,14 @@ contains
                                         !   on the sign. If positive, these are soil
                                         !   volumetric water content [m3/m3]. If negative,
                                         !   the values are soil matric potential [mm]. Not
-                                        !   used for non-deciduous plants. Ignored for 
+                                        !   used for non-deciduous plants. Ignored for
                                         !   non-deciduous plants.
-     real(r8) :: phen_moist_threshold   ! For semi-deciduous, this is the threshold above 
+     real(r8) :: phen_moist_threshold   ! For semi-deciduous, this is the threshold above
                                         !    which flushing will be complete.  This depends
                                         !    on the sign. If positive, these are soil
                                         !    volumetric water content [m3/m3]. If negative,
                                         !    the values are soil matric potential [mm].
-                                        !    Ignored for hard-deciduous and evergreen 
+                                        !    Ignored for hard-deciduous and evergreen
                                         !    plants.
      real(r8) :: phen_doff_time         ! Minimum number of days that plants must remain
                                         !   leafless before flushing leaves again.
@@ -1165,7 +1165,7 @@ contains
     ! and thus %nchilldays will never go from zero to 1.  The following logic
     ! when coupled with this fact will essentially prevent cold-deciduous
     ! plants from re-emerging in areas without at least some cold days
-    
+
     if( (currentSite%cstatus == phen_cstat_notcold)  .and. &
         (currentSite%cndaysleafoff > 400)) then   ! remove leaves after a whole year,
                                                   ! when there is no 'off' period.
@@ -1182,7 +1182,7 @@ contains
 
 
 
-    ! Loop through every PFT to assign the elongation factor. 
+    ! Loop through every PFT to assign the elongation factor.
     ! Add PFT look to account for different PFT rooting depth profiles.
     pft_elong_loop: do ipft=1,numpft
 
@@ -1204,9 +1204,9 @@ contains
        nlevroot = max(2,min(ubound(currentSite%zi_soil,1),bc_in%max_rooting_depth_index_col))
 
        ! The top most layer is typically very thin (~ 2cm) and dries rather quickly. Despite
-       ! being thin, it can have a non-negligible rooting fraction (e.g., using 
+       ! being thin, it can have a non-negligible rooting fraction (e.g., using
        ! exponential_2p_root_profile with default parameters make the top layer to contain
-       ! about 7% of the total fine root density).  To avoid overestimating dryness, we 
+       ! about 7% of the total fine root density).  To avoid overestimating dryness, we
        ! ignore the top layer when calculating the memory.
        rootfrac_notop = sum(currentSite%rootfrac_scr(2:nlevroot))
        if ( rootfrac_notop <= nearzero ) then
@@ -1225,13 +1225,13 @@ contains
        currentSite%smp_memory   (1,ipft)  = 0._r8
        do j = 2,nlevroot
           if(check_layer_water(bc_in%h2o_liqvol_sl(j),bc_in%tempk_sl(j)) ) then
-             currentSite%smp_memory   (1,ipft) = currentSite%smp_memory   (1,ipft) + & 
+             currentSite%smp_memory   (1,ipft) = currentSite%smp_memory   (1,ipft) + &
                   bc_in%smp_sl            (j) * &
                   currentSite%rootfrac_scr(j)  / &
                   rootfrac_notop
           else
              ! Nominal extreme suction for frozen or unreasonably dry soil
-             currentSite%smp_memory   (1,ipft) = currentSite%smp_memory   (1,ipft) + & 
+             currentSite%smp_memory   (1,ipft) = currentSite%smp_memory   (1,ipft) + &
                   smp_lwr_bound * &
                   currentSite%rootfrac_scr(j)  / &
                   rootfrac_notop
@@ -1278,7 +1278,7 @@ contains
        ! for drought deciduous (local parameter). The sum term accounts for the
        ! total leaf life span of this cohort.
        ! Note we only use canopy leaf lifespan here and assume  that understory cohorts
-       ! would  behave the same as canopy cohorts with regards to phenology. 
+       ! would  behave the same as canopy cohorts with regards to phenology.
        ndays_pft_leaf_lifespan = &
           nint(ndays_per_year*min(decid_leaf_long_max,sum(prt_params%leaf_long(ipft,:))))
 
@@ -1301,10 +1301,10 @@ contains
        case_drought_phen: select case (prt_params%stress_decid(ipft))
        case (ihard_stress_decid)
           !---~---
-          !    Default ("hard") drought deciduous phenology. The decision on whether to 
+          !    Default ("hard") drought deciduous phenology. The decision on whether to
           ! abscise (shed) or flush leaves is in principle defined by the soil moisture
-          ! in the rooting zone.  However, we must also account the time since last 
-          ! abscission or flushing event, to avoid excessive "flickering" of the leaf 
+          ! in the rooting zone.  However, we must also account the time since last
+          ! abscission or flushing event, to avoid excessive "flickering" of the leaf
           ! elongation factor if soil moisture is right at the threshold.
           !
           ! (MLO thought: maybe we should define moisture equivalents of GDD and chilling
@@ -1342,7 +1342,7 @@ contains
 
 
           !---~---
-          ! Revision of the conditions, added an if/elseif/else structure to ensure only 
+          ! Revision of the conditions, added an if/elseif/else structure to ensure only
           ! up to one change occurs at any given time. Also, prevent changes until the
           ! soil moisture memory is populated (the outer if check).
           !---~---
@@ -1387,7 +1387,7 @@ contains
 
              elseif ( prolonged_on_period ) then
                 ! LEAF OFF: DROUGHT DECIDUOUS LIFESPAN
-                ! Are the leaves rouhgly at the end of their lives? If so, shed leaves 
+                ! Are the leaves rouhgly at the end of their lives? If so, shed leaves
                 ! even if it is not dry.
                 currentSite%dstatus(ipft)      = phen_dstat_timeoff    !alter status of site to 'leaves off'
                 currentSite%dleafoffdate(ipft) = model_day_int         !record leaf on date
@@ -1588,7 +1588,7 @@ contains
 
     real(r8) :: fnrt_drop_fraction       ! Fine root relative drop fraction (0 = no drop, 1 = as much as leaves)
     real(r8) :: stem_drop_fraction       ! Stem drop relative fraction (0 = no drop, 1 = as much as leaves)
-    real(r8) :: l2fr                     ! Leaf to fineroot biomass multiplier 
+    real(r8) :: l2fr                     ! Leaf to fineroot biomass multiplier
 
     integer  :: ipft                     ! Plant functional type index
     real(r8), parameter :: leaf_drop_fraction  = 1.0_r8
@@ -1615,7 +1615,9 @@ contains
 
           fnrt_drop_fraction = prt_params%phen_fnrt_drop_fraction(ipft)
           stem_drop_fraction = prt_params%phen_stem_drop_fraction(ipft)
-          l2fr               = prt_params%allom_l2fr(ipft)
+          l2fr = currentCohort%l2fr ! Reading the L2FR from current cohort rather than parameter file
+          !l2fr               = prt_params%allom_l2fr(ipft)
+
 
           ! MLO. To avoid duplicating code for drought and cold deciduous PFTs, we first
           !      check whether or not it's time to flush or time to shed leaves, then
@@ -1648,15 +1650,15 @@ contains
 
 
 
-          ! Elongation factor for leaves is always the same as the site- and 
+          ! Elongation factor for leaves is always the same as the site- and
           ! PFT-dependent factor computed in subroutine phenology. For evergreen
-          ! PFTs, this value should be always 1.0. 
+          ! PFTs, this value should be always 1.0.
           currentCohort%efleaf_coh = currentSite%elong_factor(ipft)
 
           ! Find the effective "elongation factor" for fine roots and stems. The effective elongation
-          ! factor is a combination of the PFT leaf elongation factor (efleaf_coh) and the tissue drop 
+          ! factor is a combination of the PFT leaf elongation factor (efleaf_coh) and the tissue drop
           ! fraction relative to leaves (xxxx_drop_fraction). When xxxx_drop_fraction is 0, the biomass
-          ! of tissue xxxx will not be impacted by phenology. If xxxx_drop_fraction is 1, the biomass 
+          ! of tissue xxxx will not be impacted by phenology. If xxxx_drop_fraction is 1, the biomass
           ! of tissue xxxx will be as impacted by phenology as leaf biomass. Intermediate values will
           ! allow a more moderate impact of phenology in tissue xxxx relative to leaves.
           currentCohort%effnrt_coh = 1.0_r8 - (1.0_r8 - currentCohort%efleaf_coh ) * fnrt_drop_fraction
@@ -1709,7 +1711,7 @@ contains
                    call PRTPhenologyFlush(currentCohort%prt, ipft, fnrt_organ, &
                                           store_c_transfer_frac*fnrt_deficit_c/total_deficit_c)
 
-                   ! MLO - stem_drop_fraction is a PFT parameter, do we really need this 
+                   ! MLO - stem_drop_fraction is a PFT parameter, do we really need this
                    !       check for woody/non-woody PFT?
                    if ( prt_params%woody(ipft) == ifalse ) then
                       call PRTPhenologyFlush(currentCohort%prt, ipft, sapw_organ, &
@@ -1739,7 +1741,7 @@ contains
 
              ! Find the effective fraction to drop. This fraction must be calculated every time
              ! because we must account for partial abscission. The simplest approach is to simply
-             ! use the ratio between the target and the original biomass of each pool. The 
+             ! use the ratio between the target and the original biomass of each pool. The
              ! max(tissue_c,nearzero) is overly cautious, because leaf_c = 0 would imply that
              ! leaves are already off, and this wouldn't be considered shedding time.
              eff_leaf_drop_fraction   = max( 0.0_r8, min( 1.0_r8,1.0_r8 - target_leaf_c   / max( leaf_c  , nearzero ) ) )
@@ -1945,13 +1947,13 @@ contains
     ! calculate leaf carbon from target treelai
     canopylai(:) = 0._r8
     leaf_c = leafc_from_treelai(tlai, tsai, pft, c_area, cohort_n, canopy_layer, vcmax25top)
-    
+
     ! check that the inverse calculation of leafc from treelai is the same as the
     ! standard calculation of treelai from leafc. Maybe can delete eventually?
 
     call tree_lai_sai(leaf_c, pft, c_area, cohort_n, canopy_layer, canopylai, vcmax25top, &
                           dbh, crown_damage, 1.0_r8, 1.0_r8, 11, check_treelai, dummy_treesai)
-    
+
     if (abs(tlai - check_treelai) > area_error_2) then !this is not as precise as nearzero
       write(fates_log(),*) 'error in validate treelai', tlai, check_treelai, tlai - check_treelai
       write(fates_log(),*) 'tree_lai inputs: ', pft, c_area, cohort_n, canopy_layer, vcmax25top
@@ -1991,7 +1993,7 @@ contains
     !  translates them into a FATES structure with one patch and one cohort per PFT.
     !  The leaf area of the cohort is modified each day to match that asserted by the HLM
 
-   
+
     ! ARGUMENTS
     type(fates_cohort_type), intent(inout), target :: currentCohort ! cohort object
     real(r8),                intent(in)            :: tlai          ! target leaf area index from SP inputs [m2/m2]
@@ -2039,7 +2041,7 @@ contains
   end subroutine assign_cohort_SP_properties
 
   ! =====================================================================================
-  
+
   subroutine SeedUpdate( currentSite )
 
     ! -----------------------------------------------------------------------------------
@@ -2116,7 +2118,7 @@ contains
              ! of seeds [kg] released by the plant, per the mass_fraction
              ! specified as input.  This routine will also remove the mass
              ! from the parteh state-variable.
-             
+
              call PRTReproRelease(currentCohort%prt,repro_organ,element_id, &
                   1.0_r8, seed_prod)
 
@@ -2159,18 +2161,18 @@ contains
                 ! If we are using the Tree Recruitment Scheme (TRS) with or w/o seedling dynamics
                 if ( any(hlm_regeneration_model == [TRS_regeneration, TRS_no_seedling_dyn]) .and. &
                      prt_params%allom_dbh_maxheight(pft) > min_max_dbh_for_trees) then
-                   
-                   ! Send a fraction of reproductive carbon to litter to account for 
+
+                   ! Send a fraction of reproductive carbon to litter to account for
                    ! non-seed reproductive carbon (e.g. flowers, fruit, etc.)
-                   litt%seed_decay(pft) = litt%seed_in_local(pft) * (1.0_r8 - EDPftvarcon_inst%repro_frac_seed(pft)) 
-                   
+                   litt%seed_decay(pft) = litt%seed_in_local(pft) * (1.0_r8 - EDPftvarcon_inst%repro_frac_seed(pft))
+
                    ! Note: The default regeneration scheme sends all reproductive carbon to seed
                 end if !Use TRS
-                
+
                 ! If there is forced external seed rain, we calculate the input mass flux
                 ! from the different elements, using the mean stoichiometry of new
                 ! recruits for the current patch and lowest canopy position
-                
+
                 select case(element_id)
                 case(carbon12_element)
                    seed_stoich = 1._r8
@@ -2183,15 +2185,15 @@ contains
                    write(fates_log(), *) 'while defining forced external seed mass flux'
                    call endrun(msg=errMsg(sourcefile, __LINE__))
                 end select
-                
+
                 ! Seed input from external sources (user param seed rain, or dispersal model)
                 ! Include both prescribed seed_suppl and seed_in dispersed from neighbouring gridcells
                 seed_in_external = seed_stoich*(currentSite%seed_in(pft)/area + EDPftvarcon_inst%seed_suppl(pft)*years_per_day) ![kg/m2/day]
                 litt%seed_in_extern(pft) = litt%seed_in_extern(pft) + seed_in_external
-                
+
                 ! Seeds entering externally [kg/site/day]
                 site_mass%seed_in = site_mass%seed_in + seed_in_external*currentPatch%area
-             end if !use this pft  
+             end if !use this pft
           enddo
 
           currentPatch => currentPatch%younger
@@ -2203,7 +2205,7 @@ contains
           site_mass%seed_out = site_mass%seed_out + site_seed_rain(pft)*site_disp_frac(pft) ![kg/site/day]
           currentSite%seed_out(pft) = currentSite%seed_out(pft) + site_seed_rain(pft)*site_disp_frac(pft) ![kg/site/day]
        end do
- 
+
     end do el_loop
 
     return
@@ -2217,27 +2219,27 @@ contains
     ! 1. Flux from seed pool into leaf litter pool
     ! 2. If the TRS with seedling dynamics is on (hlm_regeneration_model = 3)
     !    then we calculate seedling mortality here (i.e. flux from seedling pool
-    !    (into leaf litter pool)   
+    !    (into leaf litter pool)
     !
     ! !ARGUMENTS
     type(litter_type) :: litt
     type(fates_patch_type), intent(in) :: currentPatch ! ahb added this
-    type(bc_in_type), intent(in) :: bc_in ! ahb added this    
+    type(bc_in_type), intent(in) :: bc_in ! ahb added this
     !
     ! !LOCAL VARIABLES:
     integer  ::  pft
     real(r8) ::  seedling_layer_par          ! cumulative sum of PAR at the seedling layer (MJ)
-                                             ! over prior window of days defined by 
+                                             ! over prior window of days defined by
                                              ! fates_trs_seedling_mort_par_timescale
     real(r8) ::  seedling_light_mort_rate    ! daily seedling mortality rate from light stress
     real(r8) ::  seedling_h2o_mort_rate      ! daily seedling mortality rate from moisture stress
     real(r8) ::  seedling_mdds               ! moisture deficit days accumulated in the seedling layer
-   
+
     !----------------------------------------------------------------------
 
-    
+
     ! 1. Seed mortality (i.e. flux from seed bank to litter)
-    
+
     ! default value from Liscke and Loffler 2006 ; making this a PFT-specific parameter
     ! decays the seed pool according to exponential model
     ! seed_decay_rate is in yr-1
@@ -2245,9 +2247,9 @@ contains
     ! Assume that decay rates are same for all chemical species
 
     !=====================================================================================
-    do pft = 1,numpft 
-    
-       ! If the TRS is switched off or the pft can't get big enough to be considered a tree 
+    do pft = 1,numpft
+
+       ! If the TRS is switched off or the pft can't get big enough to be considered a tree
        ! then use FATES default regeneration.
        if ( hlm_regeneration_model == default_regeneration .or. &
             prt_params%allom_dbh_maxheight(pft) < min_max_dbh_for_trees ) then
@@ -2259,45 +2261,45 @@ contains
        end if
 
        ! If the TRS is switched on and the pft is a tree then add non-seed reproductive biomass
-       ! to the seed decay flux. This was added to litt%seed_decay in the previously called SeedIn 
+       ! to the seed decay flux. This was added to litt%seed_decay in the previously called SeedIn
        ! subroutine
        if ( any(hlm_regeneration_model == [TRS_regeneration, TRS_no_seedling_dyn]) .and. &
             prt_params%allom_dbh_maxheight(pft) > min_max_dbh_for_trees ) then
-          
+
           litt%seed_decay(pft) = litt%seed_decay(pft) + &! From non-seed reproductive biomass (added in
                ! in the SeedIn subroutine.
                litt%seed(pft) * EDPftvarcon_inst%seed_decay_rate(pft)*years_per_day
-          
-       end if 
+
+       end if
 
 
        ! If the TRS is switched on with seedling dynamics (hlm_regeneration_model = 2)
        ! then calculate seedling mortality.
        if_trs_germ_decay: if ( hlm_regeneration_model == TRS_regeneration .and. &
             prt_params%allom_dbh_maxheight(pft) > min_max_dbh_for_trees ) then
-          
+
           !----------------------------------------------------------------------
           ! Seedling mortality (flux from seedling pool to litter)
           ! Note: The TRS uses the litt%seed_germ data struture to track seedlings
           !
           ! Step 1. Calculate the daily seedling mortality rate from light stress
           !
-          ! Calculate the cumulative light at the seedling layer over a prior number of 
+          ! Calculate the cumulative light at the seedling layer over a prior number of
           ! days determined by the "fates_tres_seedling_mort_par_timescale" parameter.
 
-          seedling_layer_par = currentPatch%sdlng_mort_par%GetMean() * megajoules_per_joule * & 
-               sec_per_day * sdlng_mort_par_timescale 
-          
+          seedling_layer_par = currentPatch%sdlng_mort_par%GetMean() * megajoules_per_joule * &
+               sec_per_day * sdlng_mort_par_timescale
+
           ! Calculate daily seedling mortality rate from light
           seedling_light_mort_rate = exp( EDPftvarcon_inst%seedling_light_mort_a(pft) * &
-               seedling_layer_par + EDPftvarcon_inst%seedling_light_mort_b(pft) ) 
-        
+               seedling_layer_par + EDPftvarcon_inst%seedling_light_mort_b(pft) )
+
           ! Step 2. Calculate the daily seedling mortality rate from moisture stress
-          
+
           ! Get the current seedling moisture deficit days (tracked as a pft-specific exponential
           ! average)
-          seedling_mdds = currentPatch%sdlng_mdd(pft)%p%GetMean()     
-          
+          seedling_mdds = currentPatch%sdlng_mdd(pft)%p%GetMean()
+
           ! Calculate seedling mortality as a function of moisture deficit days (mdd)
           ! If the seedling mmd value is below a critical threshold then moisture-based mortality is zero
           if (seedling_mdds < EDPftvarcon_inst%seedling_mdd_crit(pft)) then
@@ -2307,23 +2309,23 @@ contains
                   EDPftvarcon_inst%seedling_h2o_mort_b(pft) * seedling_mdds + &
                   EDPftvarcon_inst%seedling_h2o_mort_c(pft)
           end if ! mdd threshold check
-          
+
           ! Step 3. Sum modes of mortality (including background mortality) and send dead seedlings
-          ! to litter        
+          ! to litter
           litt%seed_germ_decay(pft) = (litt%seed_germ(pft) * seedling_light_mort_rate) + &
                (litt%seed_germ(pft) * seedling_h2o_mort_rate) + &
                (litt%seed_germ(pft) * EDPftvarcon_inst%background_seedling_mort(pft) &
                * years_per_day)
-       
+
        else
-          
+
           litt%seed_germ_decay(pft) = litt%seed_germ(pft) * &
                EDPftvarcon_inst%seed_decay_rate(pft)*years_per_day
 
        end if if_trs_germ_decay
-       
+
     enddo
-    
+
     return
   end subroutine SeedDecay
 
@@ -2331,7 +2333,7 @@ contains
   subroutine SeedGermination( litt, cold_stat, drought_stat, bc_in, currentPatch )
     !
     ! !DESCRIPTION:
-    !  Flux from seed bank into the seedling pool    
+    !  Flux from seed bank into the seedling pool
     !
     ! !USES:
 
@@ -2345,7 +2347,7 @@ contains
     !
     ! !LOCAL VARIABLES:
     integer :: pft
-    real(r8), parameter ::  max_germination = 1.0_r8 ! Cap on germination rates. 
+    real(r8), parameter ::  max_germination = 1.0_r8 ! Cap on germination rates.
                                                     ! KgC/m2/yr Lishcke et al. 2009
 
     !Light and moisture-sensitive seedling emergence variables (ahb)
@@ -2373,31 +2375,31 @@ contains
     ! is seed_decay_rate(p)/germination_rate(p)
     ! and thus the mortality rate (in units of individuals) is the product of
     ! that times the ratio of (hypothetical) seed mass to recruit biomass
-    
+
     !==============================================================================================
     do pft = 1,numpft
 
        ! If the TRS's seedling dynamics is switched off, then we use FATES's default approach
-       ! to germination 
+       ! to germination
        if_tfs_or_def: if ( hlm_regeneration_model == default_regeneration .or. &
             hlm_regeneration_model == TRS_no_seedling_dyn .or. &
             prt_params%allom_dbh_maxheight(pft) < min_max_dbh_for_trees ) then
 
-          litt%seed_germ_in(pft) =  min(litt%seed(pft) * EDPftvarcon_inst%germination_rate(pft), &  
+          litt%seed_germ_in(pft) =  min(litt%seed(pft) * EDPftvarcon_inst%germination_rate(pft), &
                max_germination)*years_per_day
 
           ! If TRS seedling dynamics is switched on we calculate seedling emergence (i.e. germination)
           ! as a pft-specific function of understory light and soil moisture.
        else if ( hlm_regeneration_model == TRS_regeneration .and. &
-            prt_params%allom_dbh_maxheight(pft) > min_max_dbh_for_trees ) then	    
+            prt_params%allom_dbh_maxheight(pft) > min_max_dbh_for_trees ) then
 
           ! Step 1. Calculate how germination rate is modified by understory light
-          ! This applies to photoblastic germinators (e.g. many tropical pioneers) 
+          ! This applies to photoblastic germinators (e.g. many tropical pioneers)
 
           ! Calculate mean PAR at the seedling layer (MJ m-2 day-1) over the prior 24 hours
           seedling_layer_par = currentPatch%seedling_layer_par24%GetMean() * sec_per_day * megajoules_per_joule
 
-          ! Calculate the photoblastic germination rate modifier (Eq. 3 Hanbury-Brown et al., 2022) 
+          ! Calculate the photoblastic germination rate modifier (Eq. 3 Hanbury-Brown et al., 2022)
           photoblastic_germ_modifier = seedling_layer_par / &
                (seedling_layer_par + EDPftvarcon_inst%par_crit_germ(pft))
 
@@ -2407,11 +2409,11 @@ contains
 
           ! Get running mean of soil matric potential (mm of H2O suction) at the seedling rooting depth
           ! This running mean based on pft-specific seedling rooting depth.
-          seedling_layer_smp = currentPatch%sdlng_emerg_smp(pft)%p%GetMean()    
+          seedling_layer_smp = currentPatch%sdlng_emerg_smp(pft)%p%GetMean()
 
           ! Calculate a soil wetness index (1 / -soil matric pontential (MPa) ) used by the TRS
-          ! to calculate seedling mortality from moisture stress. 
-          wetness_index = 1.0_r8 / (seedling_layer_smp * (-1.0_r8) * mpa_per_mm_suction)          
+          ! to calculate seedling mortality from moisture stress.
+          wetness_index = 1.0_r8 / (seedling_layer_smp * (-1.0_r8) * mpa_per_mm_suction)
 
           ! Step 3. Calculate the seedling emergence rate based on soil moisture and germination
           ! rate modifier (Step 1). See Eq. 4 of Hanbury-Brown et al., 2022
@@ -2420,7 +2422,7 @@ contains
           if ( seedling_layer_smp .GE. EDPftvarcon_inst%seedling_psi_emerg(pft) ) then
              seedling_emerg_rate = photoblastic_germ_modifier * EDPftvarcon_inst%a_emerg(pft) * &
                   wetness_index**EDPftvarcon_inst%b_emerg(pft)
-          else 
+          else
 
              seedling_emerg_rate = 0.0_r8
 
@@ -2430,7 +2432,7 @@ contains
           litt%seed_germ_in(pft) = litt%seed(pft) * seedling_emerg_rate
 
        end if if_tfs_or_def
-    
+
       !set the germination only under the growing season...c.xu
 
       if ((prt_params%season_decid(pft) == itrue ) .and. &
@@ -2474,10 +2476,10 @@ contains
       integer                           :: el                 ! loop counter for element
       integer                           :: element_id         ! element index consistent with definitions in PRTGenericMod
       integer                           :: iage               ! age loop counter for leaf age bins
-      integer                           :: crowndamage        ! crown damage class of the cohort [1 = undamaged, >1 = damaged]  
+      integer                           :: crowndamage        ! crown damage class of the cohort [1 = undamaged, >1 = damaged]
       real(r8)                          :: height             ! new cohort height [m]
       real(r8)                          :: dbh                ! new cohort DBH [cm]
-      real(r8)                          :: cohort_n           ! new cohort density 
+      real(r8)                          :: cohort_n           ! new cohort density
       real(r8)                          :: l2fr               ! leaf to fineroot biomass ratio [0-1]
       real(r8)                          :: c_leaf             ! target leaf biomass [kgC]
       real(r8)                          :: c_fnrt             ! target fine root biomass [kgC]
@@ -2495,14 +2497,14 @@ contains
       real(r8)                          :: m_struct           ! structural mass (element agnostic) [kg]
       real(r8)                          :: m_store            ! storage mass (element agnostic) [kg]
       real(r8)                          :: m_repro            ! reproductive mass (element agnostic) [kg]
-      real(r8)                          :: efleaf_coh         
-      real(r8)                          :: effnrt_coh 
-      real(r8)                          :: efstem_coh 
+      real(r8)                          :: efleaf_coh
+      real(r8)                          :: effnrt_coh
+      real(r8)                          :: efstem_coh
       real(r8)                          :: mass_avail         ! mass of each nutrient/carbon available in the seed_germination pool [kg]
-      real(r8)                          :: mass_demand        ! total mass demanded by the plant to achieve the stoichiometric 
-                                          !    targets of all the organs in the recruits. Used for both [kg per plant] and [kg per cohort] 
-      real(r8)                          :: stem_drop_fraction ! 
-      real(r8)                          :: fnrt_drop_fraction ! 
+      real(r8)                          :: mass_demand        ! total mass demanded by the plant to achieve the stoichiometric
+                                          !    targets of all the organs in the recruits. Used for both [kg per plant] and [kg per cohort]
+      real(r8)                          :: stem_drop_fraction !
+      real(r8)                          :: fnrt_drop_fraction !
       real(r8)                          :: sdlng2sap_par      ! running mean of PAR at the seedling layer [MJ/m2/day]
       real(r8)                          :: seedling_layer_smp ! soil matric potential at seedling rooting depth [mm H2O suction]
       integer, parameter                :: recruitstatus = 1  ! whether the newly created cohorts are recruited or initialized
@@ -2542,7 +2544,7 @@ contains
             l2fr               = currentSite%rec_l2fr(ft, currentPatch%NCL_p)
             crowndamage        = 1 ! new recruits are undamaged
 
-            ! calculate DBH from initial height 
+            ! calculate DBH from initial height
             call h2d_allom(height, ft, dbh)
 
             ! default assumption is that leaves are on
@@ -2559,7 +2561,7 @@ contains
                effnrt_coh  = 1.0_r8 - fnrt_drop_fraction
                efstem_coh  = 1.0_r8 - stem_drop_fraction
                leaf_status = leaves_off
-            end if 
+            end if
 
             ! Or.. if the plant is drought deciduous, make sure leaf status is consistent with the
             ! leaf elongation factor.
@@ -2576,8 +2578,8 @@ contains
                ! whenever the elongation factor is non-zero.  If the elongation factor is zero, then leaves are in
                ! the "off" state.
                if (efleaf_coh > 0.0_r8) then
-                  leaf_status = leaves_on 
-               else 
+                  leaf_status = leaves_on
+               else
                   leaf_status = leaves_off
                end if
             end select
@@ -2649,11 +2651,11 @@ contains
                         sec_per_day*megajoules_per_joule
 
                      mass_avail = currentPatch%area*                           &
-                        currentPatch%litter(el)%seed_germ(ft)*                 & 
+                        currentPatch%litter(el)%seed_germ(ft)*                 &
                         EDPftvarcon_inst%seedling_light_rec_a(ft)*             &
-                        sdlng2sap_par**EDPftvarcon_inst%seedling_light_rec_b(ft) 
+                        sdlng2sap_par**EDPftvarcon_inst%seedling_light_rec_b(ft)
 
-                     ! If soil moisture is below pft-specific seedling  moisture stress threshold the 
+                     ! If soil moisture is below pft-specific seedling  moisture stress threshold the
                      ! recruitment does not occur.
                      ilayer_seedling_root = minloc(abs(bc_in%z_sisl(:) -       &
                         EDPftvarcon_inst%seedling_root_depth(ft)), dim=1)
@@ -2662,7 +2664,7 @@ contains
 
                      if (seedling_layer_smp < EDPftvarcon_inst%seedling_psi_crit(ft)) then
                         mass_avail = 0.0_r8
-                     end if 
+                     end if
 
                   end if ! End use TRS with seedling dynamics
 
@@ -2719,7 +2721,7 @@ contains
                      m_repro  = 0._r8
                   end select
 
-                  
+
                   select case(hlm_parteh_mode)
                   case (prt_carbon_allom_hyp, prt_cnp_flex_allom_hyp)
 
@@ -2762,7 +2764,7 @@ contains
                      currentPatch%litter(el)%seed_germ(ft) - cohort_n / currentPatch%area *   &
                      (m_struct + m_leaf + m_fnrt + m_sapw + m_store + m_repro)
                   end if
-                  
+
                end do
 
                ! cycle through the initial conditions, and makes sure that they are all initialized
@@ -2876,7 +2878,7 @@ contains
     site_mass => currentSite%mass_balance(element_pos(element_id))
 
     ! Transfer litter from turnover of living plants
-    
+
     currentCohort => currentPatch%shortest
     do while(associated(currentCohort))
 
@@ -2887,9 +2889,9 @@ contains
        store_m_turnover  = currentCohort%prt%GetTurnover(store_organ,element_id)
        fnrt_m_turnover   = currentCohort%prt%GetTurnover(fnrt_organ,element_id)
        repro_m_turnover  = currentCohort%prt%GetTurnover(repro_organ,element_id)
-       
 
-       
+
+
        store_m         = currentCohort%prt%GetState(store_organ,element_id)
        fnrt_m          = currentCohort%prt%GetState(fnrt_organ,element_id)
        repro_m         = currentCohort%prt%GetState(repro_organ,element_id)
@@ -3297,16 +3299,16 @@ contains
     enddo
 
   end subroutine CWDOut
-  
+
   subroutine UpdateRecruitL2FR(csite)
-    
+
 
     ! When CNP is active, the l2fr (target leaf to fine-root biomass multiplier)
     ! is dynamic. We therefore update what the l2fr for recruits
     ! are, taking an exponential moving average of all plants that
     ! are within recruit size limitations (less than recruit size + delta)
     ! and less than the max_count cohort.
-    
+
     type(ed_site_type) :: csite
     type(fates_patch_type), pointer :: cpatch
     type(fates_cohort_type), pointer :: ccohort
@@ -3320,11 +3322,11 @@ contains
     real(r8), parameter :: max_delta = 5.0_r8  ! dbh tolerance, cm, consituting a recruit
     real(r8), parameter :: smth_wgt = 1._r8/300.0_r8
     integer, parameter :: max_count = 3
-    
+
     ! Difference in dbh (cm) to consider a plant was recruited fairly recently
 
     if(hlm_parteh_mode .ne. prt_cnp_flex_allom_hyp) return
-    
+
     rec_n(1:numpft,1:nclmax) = 0._r8
     rec_l2fr0(1:numpft,1:nclmax) = 0._r8
 
@@ -3332,7 +3334,7 @@ contains
     do while(associated(cpatch))
 
        rec_count(1:numpft,1:nclmax) = 0
-       
+
        ccohort => cpatch%shortest
        cloop: do while(associated(ccohort))
 
@@ -3381,16 +3383,16 @@ contains
     integer  :: ft                       ! functional type index
     integer  :: cl                       ! canopy layer index
     real(r8) :: rec_l2fr_pft             ! Actual l2fr of a pft in it's patch
-    
+
     ! Update the total plant stoichiometry of a new recruit, based on the updated
     ! L2FR values
 
     if(hlm_parteh_mode .ne. prt_cnp_flex_allom_hyp) return
-    
+
     cpatch => csite%youngest_patch
     do while(associated(cpatch))
        cl = cpatch%ncl_p
-       
+
        do ft = 1,numpft
           rec_l2fr_pft = csite%rec_l2fr(ft,cl)
           cpatch%nitr_repro_stoich(ft) = &
@@ -3406,15 +3408,15 @@ contains
           ccohort%pc_repro = NewRecruitTotalStoichiometry(ccohort%pft,rec_l2fr_pft,phosphorus_element)
           ccohort => ccohort%taller
        end do cloop
-       
+
        cpatch => cpatch%older
     end do
-       
+
     return
   end subroutine UpdateRecruitStoich
 
   ! ======================================================================
-  
+
   subroutine SetRecruitL2FR(csite)
 
 
@@ -3422,9 +3424,9 @@ contains
     type(fates_patch_type), pointer :: cpatch
     type(fates_cohort_type), pointer :: ccohort
     integer :: ft,cl
-    
+
     if(hlm_parteh_mode .ne. prt_cnp_flex_allom_hyp) return
-    
+
     cpatch => csite%youngest_patch
     do while(associated(cpatch))
        ccohort => cpatch%shortest
@@ -3441,7 +3443,7 @@ contains
 
        cpatch => cpatch%older
     end do
-    
+
     return
   end subroutine SetRecruitL2FR
 

--- a/parteh/PRTAllometricCNPMod.F90
+++ b/parteh/PRTAllometricCNPMod.F90
@@ -28,7 +28,7 @@ module PRTAllometricCNPMod
   use PRTGenericMod , only  : num_organ_types
   use PRTGenericMod , only  : prt_cnp_flex_allom_hyp
   use PRTGenericMod , only  : StorageNutrientTarget
-  
+
   use FatesAllometryMod   , only : bleaf
   use FatesAllometryMod   , only : bsap_allom
   use FatesAllometryMod   , only : bfineroot
@@ -70,8 +70,11 @@ module PRTAllometricCNPMod
   use EDPftvarcon, only : EDPftvarcon_inst
   use FatesInterfaceTypesMod, only : hlm_regeneration_model
 
+  use elm_varctl          , only : nyears_ad_carbon_only, spinup_state
+  use elm_time_manager    , only: get_curr_date, get_curr_time_string
 
-  
+
+
   implicit none
   private
 
@@ -105,31 +108,31 @@ module PRTAllometricCNPMod
 
   ! Total number of state variables
   integer, parameter :: num_vars    = 18
-  
-  
+
+
   ! Global identifiers for the two stoichiometry values
   integer,public, parameter :: stoich_growth_min = 1     ! Flag for stoichiometry associated with
                                                          ! minimum needed for growth
-  
+
   ! This is deprecated until a reasonable hypothesis is in place (RGK)
-  integer,public, parameter :: stoich_max = 2            ! Flag for stoichiometry associated with 
+  integer,public, parameter :: stoich_max = 2            ! Flag for stoichiometry associated with
                                                          ! maximum for that organ
-  
+
   ! This is the ordered list of organs used in this module
   ! -------------------------------------------------------------------------------------
 
   integer, parameter                        :: num_organs = 6
-  
+
   ! Converting from local to global organ id
-  integer, parameter,dimension(num_organs) :: l2g_organ_list = & 
+  integer, parameter,dimension(num_organs) :: l2g_organ_list = &
      [leaf_organ, fnrt_organ, sapw_organ, store_organ, repro_organ, struct_organ]
 
 
-  
+
   ! These are local indices associated with organs and quantities
   ! that can be integrated (namely, growth respiration during stature growth
   ! and dbh)
-  
+
   integer, parameter :: leaf_id = 1
   integer, parameter :: fnrt_id = 2
   integer, parameter :: sapw_id = 3
@@ -141,7 +144,7 @@ module PRTAllometricCNPMod
   integer, parameter :: num_intgr_vars = 7
 
 
-  
+
   ! -------------------------------------------------------------------------------------
   ! Input/Output Boundary Indices (These are public, and therefore
   !       each boundary condition across all modules must
@@ -186,7 +189,7 @@ module PRTAllometricCNPMod
   integer, public, parameter :: acnp_bc_out_id_nefflux = 2  ! Daily exudation of N  [kg]
   integer, public, parameter :: acnp_bc_out_id_pefflux = 3  ! Daily exudation of P  [kg]
   integer, public, parameter :: acnp_bc_out_id_limiter = 4  ! The minimum of the Nutrient ratio over c ratio
-  
+
   integer, parameter         :: num_bc_out             = 4  ! Total number of
 
 
@@ -199,7 +202,7 @@ module PRTAllometricCNPMod
   integer,private, parameter :: intgr_parm_effnrt  = 6
   integer,private, parameter :: intgr_parm_efstem  = 7
   integer,private, parameter :: num_intgr_parm     = 7
-  
+
   ! -------------------------------------------------------------------------------------
   ! Define the size of the coorindate vector.  For this hypothesis, there is only
   ! one pool per each species x organ combination, except for leaves (WHICH HAVE AGE)
@@ -228,15 +231,15 @@ module PRTAllometricCNPMod
   ! Flags to select using the equivalent carbon method of co-limitation,
   ! or to just grow with available carbon and let it fix itself on the
   ! next step
-  
+
   integer, parameter  :: grow_lim_conly = 1  ! Just use C to decide stature on this step
   integer, parameter  :: grow_lim_estNP = 2  ! Estimate equivalent C from N and P
   integer, parameter  :: grow_lim_type = grow_lim_estNP
-    
-  ! Following growth, if desired, you can prioritize that 
+
+  ! Following growth, if desired, you can prioritize that
   ! reproductive tissues get balanced CNP
   logical, parameter :: prioritize_repro_nutr_growth = .true.
-  
+
   ! If this parameter is true, then the fine-root l2fr optimization
   ! scheme will remove biomass from roots without restriction if the
   ! l2fr is getting smaller.
@@ -253,7 +256,7 @@ module PRTAllometricCNPMod
      procedure :: DailyPRT     => DailyPRTAllometricCNP
      procedure :: FastPRT      => FastPRTAllometricCNP
      procedure :: GetNutrientTarget => GetNutrientTargetCNP
-     
+
      ! Extended functions specific to Allometric CNP
      procedure :: CNPPrioritizedReplacement
      procedure :: CNPStatureGrowth
@@ -278,9 +281,9 @@ module PRTAllometricCNPMod
 
    character(len=*), parameter, private :: sourcefile = __FILE__
    logical, parameter :: debug = .false.
-   
+
    public :: InitPRTGlobalAllometricCNP
-   
+
 
 contains
 
@@ -306,7 +309,7 @@ contains
      if (istat/=0) call endrun(msg='allocate stat/=0:'//trim(smsg)//errMsg(sourcefile, __LINE__))
      allocate(prt_global_acnp%state_descriptor(num_vars), stat=istat, errmsg=smsg)
      if (istat/=0) call endrun(msg='allocate stat/=0:'//trim(smsg)//errMsg(sourcefile, __LINE__))
-     
+
      prt_global_acnp%hyp_name = 'Allometric Flexible C+N+P'
 
      prt_global_acnp%hyp_id = prt_cnp_flex_allom_hyp
@@ -375,12 +378,12 @@ contains
     ! and nutrient cycling are not yet compatable though
     ! hence, we simply return from any phase but phase 1
 
-    
+
     ! Pointers to in-out bcs
     real(r8),pointer :: dbh          ! Diameter at breast height [cm]
     real(r8),pointer :: resp_excess   ! Respiration of any un-allocatable C
     real(r8),pointer :: l2fr         ! Leaf to fineroot ratio of target biomass
-    
+
     ! Input only bcs
     integer          :: ipft         ! Plant Functional Type index
     real(r8)         :: c_gain       ! Daily carbon balance for this cohort [kgC]
@@ -430,8 +433,8 @@ contains
     ! damage module. Since this is incompatible with CNP
     ! Ignore all subsequent calls after the first
     if (phase.ne.1) return
-    
-    
+
+
     ! In/out boundary conditions
     resp_excess => this%bc_inout(acnp_bc_inout_id_resp_excess)%rval
     dbh         => this%bc_inout(acnp_bc_inout_id_dbh)%rval
@@ -447,7 +450,7 @@ contains
     resp_excess  = 0._r8
     resp_excess0 = resp_excess
 
-    
+
     ! integrator variables
 
     ! Copy the input only boundary conditions into readable local variables
@@ -472,7 +475,7 @@ contains
     if(p_uptake_mode.eq.prescribed_p_uptake) then
        p_gain = 1.e3_r8
     end if
-    
+
     n_gain0      = n_gain
     p_gain0      = p_gain
     c_gain0      = c_gain
@@ -502,8 +505,8 @@ contains
     ! and then attempt to get them up to stoichiometry targets.
     ! ===================================================================================
 
-    
-    
+
+
     ! Remember the original C,N,P states to help with final
     ! evaluation of how much was allocated
     ! -----------------------------------------------------------------------------------
@@ -517,8 +520,8 @@ contains
        i_var = prt_global%sp_organ_map(i_org,phosphorus_element)
        state_p0(i_org)  =  this%variables(i_var)%val(1)
     end do
-    
-    
+
+
     ! Output only boundary conditions
     c_efflux    => this%bc_out(acnp_bc_out_id_cefflux)%rval;  c_efflux = 0._r8
     n_efflux    => this%bc_out(acnp_bc_out_id_nefflux)%rval;  n_efflux = 0._r8
@@ -539,15 +542,15 @@ contains
 
     p_gain = p_gain + sum(this%variables(store_p_id)%val(:))
     this%variables(store_p_id)%val(:) = 0._r8
-    
-    
+
+
     ! ===================================================================================
     ! Step 2.  Prioritized allocation to replace tissues from turnover, and/or pay
     ! any un-paid maintenance respiration from storage.
     ! ===================================================================================
-    
+
     call this%CNPPrioritizedReplacement(c_gain, n_gain, p_gain, target_c)
-       
+
     sum_c = 0._r8
     do i = 1,num_organs
        i_org = l2g_organ_list(i)
@@ -563,10 +566,10 @@ contains
        end do
        call endrun(msg=errMsg(sourcefile, __LINE__))
     end if
-    
+
     ! ===================================================================================
     ! Step 3. Grow out the stature of the plant by allocating to tissues beyond
-    ! current targets. 
+    ! current targets.
     ! Attempts have been made to get all pools and species closest to allometric
     ! targets based on prioritized relative demand and allometry functions.
     ! ===================================================================================
@@ -590,7 +593,7 @@ contains
     end if
 
     ! ===================================================================================
-    ! Step 3. 
+    ! Step 3.
     ! At this point, at least 1 of the 3 resources have been used up.
     ! Allocate the remaining resources, or as a last resort, efflux them.
     ! ===================================================================================
@@ -616,7 +619,7 @@ contains
           call endrun(msg=errMsg(sourcefile, __LINE__))
        end if
     end if
-    
+
     if( abs(c_gain) > calloc_abs_error) then
        write(fates_log(),*) 'Allocation scheme should had used up all mass gain pools'
        write(fates_log(),*) 'Any mass that cannot be allocated should be effluxed'
@@ -627,11 +630,11 @@ contains
     ! Perform a final tally on what was used (allocated)
     ! Since this is also a check against what was available
     ! we include what is lost through respiration of excess storage
-    
+
     allocated_c = (resp_excess-resp_excess0) + c_efflux
     allocated_n = n_efflux
     allocated_p = p_efflux
-    
+
     ! Update the allocation flux diagnostic arrays for each 3 elements
     do i = 1,num_organs
 
@@ -642,27 +645,27 @@ contains
             this%variables(i_var)%net_alloc(1) + (this%variables(i_var)%val(1) - state_c0(i_org))
 
        allocated_c = allocated_c + (this%variables(i_var)%val(1) - state_c0(i_org))
-       
+
        i_var = prt_global%sp_organ_map(i_org,nitrogen_element)
        this%variables(i_var)%net_alloc(1) = &
             this%variables(i_var)%net_alloc(1) + (this%variables(i_var)%val(1) - state_n0(i_org))
 
        allocated_n = allocated_n + (this%variables(i_var)%val(1) - state_n0(i_org))
-       
+
        i_var = prt_global%sp_organ_map(i_org,phosphorus_element)
        this%variables(i_var)%net_alloc(1) = &
             this%variables(i_var)%net_alloc(1) + (this%variables(i_var)%val(1) - state_p0(i_org))
 
        allocated_p = allocated_p + (this%variables(i_var)%val(1) - state_p0(i_org))
-       
+
     end do
-    
+
     if(debug) then
 
        ! Error Check: Do a final balance between how much mass
        ! we had to work with, and how much was allocated
-       
-       if ( abs(allocated_c - (c_gain0-c_gain)) > calloc_abs_error .or. & 
+
+       if ( abs(allocated_c - (c_gain0-c_gain)) > calloc_abs_error .or. &
             abs(allocated_n - (n_gain0-n_gain)) > calloc_abs_error .or. &
             abs(allocated_p - (p_gain0-p_gain)) > calloc_abs_error ) then
           write(fates_log(),*) 'CNP allocation scheme did not balance mass.'
@@ -683,7 +686,7 @@ contains
     ! and pass that back as an output, otherwise
     ! we set the gains to what we started with so that
     ! it can be used again for mass balance checking and diagnostics
-    
+
     if(n_uptake_mode.eq.prescribed_n_uptake) then
        n_gain = n_gain0-n_gain
     else
@@ -699,32 +702,32 @@ contains
 
     ! If fine-roots are allocated above their
     ! target (perhaps with some buffer, but perhaps not)
-    ! then 
+    ! then
     call this%TrimFineRoot()
 
     return
   end subroutine DailyPRTAllometricCNP
 
-  
+
   function SafeLog(val) result(logval)
 
     ! The log functions used to transform storage ratios
     ! need not be large. Even a ratio of 10 is sending a strong signal to the
     ! root adaptation algorithm to change course pretty strongly. We set
     ! bounds of e3 here to prevent numerical overflows and underflows
-    
+
     real(r8) :: val
     real(r8) :: logval
     real(r8), parameter :: safelog_min = 0.001_r8  !Don't pass anything smaller to a log
     real(r8), parameter :: safelog_max = 1000._r8
 
     logval = log(max(safelog_min,min(safelog_max,val)))
-    
+
   end function SafeLog
 
-  
+
   ! =====================================================================================
-  
+
   subroutine CNPAdjustFRootTargets(this, target_c, target_dcdd)
 
     class(cnp_allom_prt_vartypes) :: this
@@ -744,7 +747,7 @@ contains
     real(r8) :: cn_ratio, cp_ratio ! ratio of relative C storage over relative N or P storage
     real(r8) :: dcxdt_ratio        ! log change (derivative) of the maximum of the N/C and P/C storage ratio
     real(r8) :: cx_logratio        ! log Maximum of the C/N and C/P storage ratio
-    real(r8), pointer :: cx_int    ! Integration of the cx_logratio 
+    real(r8), pointer :: cx_int    ! Integration of the cx_logratio
     real(r8), pointer :: cx0       ! The log of the cx ratio from previous time-step
     real(r8), pointer :: ema_dcxdt ! the EMA of the change in log storage ratio
 
@@ -802,7 +805,7 @@ contains
        ! Calculate the relative phosphorus storage fraction,
        ! over the relative carbon storage fraction.
 
-       store_nut_max = this%GetNutrientTarget(phosphorus_element,store_organ,stoich_growth_min) 
+       store_nut_max = this%GetNutrientTarget(phosphorus_element,store_organ,stoich_growth_min)
 
        store_nut_act = max(0.001_r8*store_nut_max, &
             this%GetState(store_organ, phosphorus_element) + &
@@ -871,19 +874,19 @@ contains
   ! =====================================================================================
 
   subroutine TrimFineRoot(this)
-    
+
     ! The following section allows forceful turnover of fine-roots if a new L2FR is generated
     ! that is lower than the previous l2fr. The maintenance turnover (background) rate
     ! will automatically accomodate a lower l2fr, but if the change is large it will
     ! not keep pace.  Note 1: however, that the algorithm for calculating l2fr will prevent
     ! large drops in l2fr (unless that safegaurd is removed). Note 2: this section may also
     ! generate mass check errors in the main CNPAllocation routine, this is because the "val" is
-    ! changing but the net_allocated is not reciprocating, which is expected. 
-    
+    ! changing but the net_allocated is not reciprocating, which is expected.
+
     ! Keep a buffer above the L2FR in the hopes that natural turnover will catch
     ! up.
     class(cnp_allom_prt_vartypes) :: this
-       
+
     real(r8) :: fnrt_flux_c
     real(r8) :: turn_flux_c
     real(r8) :: store_flux_c
@@ -892,9 +895,9 @@ contains
     real(r8) :: target_fnrt_c
     real(r8),parameter :: nday_buffer = 0._r8
     real(r8),parameter :: fnrt_opt_eff = 0._r8  ! If we want to transfer resources to storage
-    
+
     if(.not.use_unrestricted_contraction)return
-    
+
     associate( ipft         => this%bc_in(acnp_bc_in_id_pft)%ival,  &
          l2fr         => this%bc_inout(acnp_bc_inout_id_l2fr)%rval, &
          dbh          => this%bc_inout(acnp_bc_inout_id_dbh)%rval,  &
@@ -936,17 +939,17 @@ contains
     end associate
     return
   end subroutine TrimFineRoot
-  
+
   ! =====================================================================================
-    
+
   subroutine CNPPrioritizedReplacement(this,c_gain, n_gain, p_gain, target_c)
-    
-      
+
+
     ! -----------------------------------------------------------------------------------
     ! Alternative allocation hypothesis for the prioritized replacement phase.
     ! This is more similar to the current (04/2020) carbon only hypothesis.
     ! -----------------------------------------------------------------------------------
-    
+
     class(cnp_allom_prt_vartypes) :: this
     real(r8), intent(inout) :: c_gain
     real(r8), intent(inout) :: n_gain
@@ -959,7 +962,7 @@ contains
     real(r8), dimension(num_organs) :: deficit_c ! Deficit to get to target from current    [kg]
     real(r8), dimension(num_organs) :: deficit_n ! Deficit to get to target from current    [kg]
     real(r8), dimension(num_organs) :: deficit_p ! Deficit to get to target from current    [kg]
-    
+
     integer  :: i, ii, i_org             ! Loop indices (mostly for organs)
     integer  :: i_var                    ! variable index
     integer  :: i_pri                    ! loop index for priority
@@ -984,8 +987,8 @@ contains
                                  ! the total number organs plus 1, which allows
                                  ! each organ to have its own level, and ignore
                                  ! the specialized priority 1
-    
-    
+
+
     leaf_status     = this%bc_in(acnp_bc_in_id_lstat)%ival
     elongf_leaf     = this%bc_in(acnp_bc_in_id_efleaf)%rval
     elongf_fnrt     = this%bc_in(acnp_bc_in_id_effnrt)%rval
@@ -993,7 +996,7 @@ contains
     ipft            = this%bc_in(acnp_bc_in_id_pft)%ival
     canopy_trim     = this%bc_in(acnp_bc_in_id_ctrim)%rval
 
-    
+
     n_max_priority = maxval(prt_params%organ_param_id(:))
     if(n_max_priority>10 .or. n_max_priority<0)then
        write(fates_log(),*) 'was unable to interpret prt_params%organ_param_id'
@@ -1019,7 +1022,7 @@ contains
     !
     ! -----------------------------------------------------------------------------------
 
-    
+
     ! -----------------------------------------------------------------------------------
     ! Preferential transfer of available carbon and nutrients into the highest
     ! priority pools, and maintenance respiration. We will loop through the available
@@ -1030,7 +1033,7 @@ contains
 
     curpri_org(:) = fates_unset_int    ! reset "current-priority" organ ids
     i = 0
-    do ii = 1, size(prt_params%organ_id,1) 
+    do ii = 1, size(prt_params%organ_id,1)
 
        ! universal organ index from PRTGenericMod
        i_org = prt_params%organ_id(ii)
@@ -1054,7 +1057,7 @@ contains
 
     end do
 
-      
+
     ! Number of pools in the current priority level
     n_curpri_org = i
 
@@ -1075,12 +1078,12 @@ contains
     end do
 
     sum_c_flux = max(0._r8,min(sum_c_demand,this%variables(store_c_id)%val(1)+c_gain))
-    
+
     if (sum_c_flux> nearzero ) then
-       
+
        ! We pay this even if we don't have the carbon
        ! Just don't pay so much carbon that storage+carbon_balance can't pay for it
-       
+
        do i = 1,n_curpri_org
 
           i_org = curpri_org(i)
@@ -1088,10 +1091,10 @@ contains
 
           c_flux = sum_c_flux*(prt_params%leaf_stor_priority(ipft) * &
                sum(this%variables(i_var)%turnover(:))/sum_c_demand)
-          
+
           ! Add carbon to the pool
           this%variables(i_var)%val(1) = this%variables(i_var)%val(1) + c_flux
-          
+
           ! Remove from daily  carbon gain
           c_gain = c_gain - c_flux
 
@@ -1100,36 +1103,36 @@ contains
 
     ! Determine nutrient demand and make tansfers
     do i = 1, n_curpri_org
-       
+
        i_org = curpri_org(i)
-       
+
        ! Update the nitrogen deficits
        ! Note that the nitrogen target is tied to the stoichiometry of the growing pool only (pos = 1)
 
        target_n = this%GetNutrientTarget(nitrogen_element,i_org,stoich_growth_min)
        deficit_n(i) = max(0.0_r8, target_n - this%GetState(i_org, nitrogen_element,1))
-       
+
        ! Update the phosphorus deficits (which are based off of carbon actual..)
        ! Note that the phsophorus target is tied to the stoichiometry of thegrowing pool only (also)
        target_p = this%GetNutrientTarget(phosphorus_element,i_org,stoich_growth_min)
        deficit_p(i) = max(0.0_r8, target_p - this%GetState(i_org, phosphorus_element,1))
 
     end do
-    
+
     ! Allocate nutrients at this priority level
     ! Nitrogen
     call ProportionalNutrAllocation(this,deficit_n(1:n_curpri_org), &
          n_gain, nitrogen_element, curpri_org(1:n_curpri_org))
-    
+
     ! Phosphorus
     call ProportionalNutrAllocation(this,deficit_p(1:n_curpri_org), &
          p_gain, phosphorus_element, curpri_org(1:n_curpri_org))
-    
+
     ! -----------------------------------------------------------------------------------
     ! IV. if carbon balance is negative, re-coup the losses from storage
     !       if it is positive, give some love to storage carbon
     ! -----------------------------------------------------------------------------------
-    
+
     if( c_gain < 0.0_r8 ) then
 
        ! Storage will have to pay for any negative gains
@@ -1137,26 +1140,26 @@ contains
        c_gain                 = c_gain                + store_c_flux
 
        this%variables(store_c_id)%val(1) = this%variables(store_c_id)%val(1) - store_c_flux
-       
+
     else
 
        ! This is just a cap, don't fill up more than is needed (shouldn't even apply)
        store_below_target     = max(target_c(store_organ) - this%variables(store_c_id)%val(1),0._r8)
-       
+
        ! This is the desired need for carbon
        store_target_fraction  = max(this%variables(store_c_id)%val(1)/target_c(store_organ),0._r8)
        store_demand           = max(c_gain*(exp(-1.*store_target_fraction**4._r8) - exp( -1.0_r8 )),0._r8)
 
        ! The flux is the (positive) minimum of all three
        store_c_flux           = min(store_below_target,store_demand)
-       
+
        c_gain                 = c_gain  - store_c_flux
 
        this%variables(store_c_id)%val(1) = this%variables(store_c_id)%val(1) + store_c_flux
-   
+
    end if
-   
-    
+
+
     ! -----------------------------------------------------------------------------------
     !  If carbon is still available, allocate to remaining high
     !        carbon balance is guaranteed to be >=0 beyond this point
@@ -1166,9 +1169,9 @@ contains
     ! Bring all pools, in priority order, up to allometric targets if possible
     ! Repeat priority order 1 as well.
     ! -----------------------------------------------------------------------------------
-    
+
     priority_loop: do i_pri = 1, n_max_priority
-       
+
        curpri_org(:) = fates_unset_int    ! "current-priority" organ indices
 
        i = 0
@@ -1178,17 +1181,17 @@ contains
           curpri_org(1) = store_organ
           i=1
        end if
-          
+
        ! Loop over all organs in the CNP routine, which
-       do ii = 1, size(prt_params%organ_id,1) 
+       do ii = 1, size(prt_params%organ_id,1)
 
           ! universal organ index from PRTGenericMod
           i_org = prt_params%organ_id(ii)
-          
+
           ! The priority code associated with this organ
-          
+
           priority_code = int(prt_params%alloc_priority(ipft,ii))
-          
+
           ! Don't allow allocation to leaves if they are in an "off" status.
           ! (this prevents accidental re-flushing on the day they drop)
           if( any(leaf_status == [leaves_off,leaves_shedding]) .and. &
@@ -1206,7 +1209,7 @@ contains
           i_org = curpri_org(i)
           deficit_c(i) = max(0._r8,this%GetDeficit(carbon12_element,i_org,target_c(i_org)))
        end do
-          
+
        ! Bring carbon up to target first, this order is required
        ! because we need to know the resulting carbon concentrations
        ! before  we set the allometric targets for the nutrients
@@ -1216,71 +1219,71 @@ contains
           i_org = curpri_org(i)
           sum_c_demand = sum_c_demand + deficit_c(i)
        end do
-       
+
        sum_c_flux = min(c_gain, sum_c_demand)
-       
+
        ! Transfer carbon into pools if there is any
        if (sum_c_flux>nearzero) then
           do i = 1, n_curpri_org
-             
+
              i_org = curpri_org(i)
 
              c_flux  =  sum_c_flux*deficit_c(i)/sum_c_demand
-             
+
              ! Update the carbon pool
              i_var = prt_global%sp_organ_map(i_org,carbon12_element)
              this%variables(i_var)%val(1) = this%variables(i_var)%val(1) + c_flux
-             
+
              ! Update carbon pools deficit
              deficit_c(i) = max(0._r8,deficit_c(i) - c_flux)
-             
+
              ! Reduce the carbon gain
              c_gain      = c_gain - c_flux
-             
+
           end do
        end if
 
        ! Determine nutrient demand and make tansfers
        do i = 1, n_curpri_org
-          
+
           i_org = curpri_org(i)
 
           ! Update the nitrogen deficits
           ! Note that the nitrogen target is tied to the stoichiometry of thegrowing pool only
           target_n = this%GetNutrientTarget(nitrogen_element,i_org,stoich_growth_min)
           deficit_n(i) = max(0.0_r8, target_n - this%GetState(i_org, nitrogen_element,1) )
-             
+
           ! Update the phosphorus deficits (which are based off of carbon actual..)
           ! Note that the phsophorus target is tied to the stoichiometry of thegrowing pool only (also)
           target_p = this%GetNutrientTarget(phosphorus_element,i_org,stoich_growth_min)
           deficit_p(i) = max(0.0_r8, target_p - this%GetState(i_org, phosphorus_element,1) )
 
        end do
-          
+
        ! Allocate nutrients at this priority level Nitrogen
        call ProportionalNutrAllocation(this,deficit_n(1:n_curpri_org), &
             n_gain, nitrogen_element, curpri_org(1:n_curpri_org))
-       
+
        ! Phosphorus
        call ProportionalNutrAllocation(this,deficit_p(1:n_curpri_org), &
             p_gain, phosphorus_element, curpri_org(1:n_curpri_org))
-       
+
 
     end do priority_loop
 
 
-    
-    
+
+
     return
   end subroutine CNPPrioritizedReplacement
 
-  
+
   ! =====================================================================================
-    
+
   subroutine CNPStatureGrowth(this,c_gain, n_gain, p_gain, &
                               target_c, target_dcdd)
-    
-    
+
+
     class(cnp_allom_prt_vartypes) :: this
     real(r8), intent(inout) :: c_gain      ! Total daily C gain that remains to be used
     real(r8), intent(inout) :: n_gain      ! Total N available for allocation
@@ -1331,7 +1334,7 @@ contains
                                                  ! of organs (local ids) in the mask
     integer,dimension(num_organs) :: mask_gorgans ! List of organ global indices in the mask
     integer                       :: n_mask_organs
-    
+
     ! Integrator error checking
     integer  :: i_var
     integer  :: nbins
@@ -1349,11 +1352,11 @@ contains
     real(r8) :: struct_c_target_tp1
     real(r8) :: store_c_target_tp1
     real(r8) :: sapw_area
-    
+
     ! Integegrator variables
     ! These are not global because we want a unique instance for each time the routine is called
     ! ----------------------------------------------------------------------------------------
-    
+
     real(r8),dimension(num_intgr_vars) :: state_array      ! Vector of carbon pools passed to integrator
     real(r8),dimension(num_intgr_vars) :: state_array_out  ! Vector of carbon pools passed back from integrator
     logical,dimension(num_intgr_vars)  :: state_mask       ! Mask of active pools during integration
@@ -1363,11 +1366,11 @@ contains
 
     real(r8)            :: intgr_params(num_intgr_parm)
 
-    
+
     real(r8) :: neq_cgain, peq_cgain  ! N and P equivalent c_gain spent on growth
     real(r8) :: cnp_gain              ! used as a check to see efficiency of limited growth
-    
-    
+
+
 
     leaf_status = this%bc_in(acnp_bc_in_id_lstat)%ival
     elongf_leaf = this%bc_in(acnp_bc_in_id_efleaf)%rval
@@ -1380,7 +1383,7 @@ contains
     canopy_trim = this%bc_in(acnp_bc_in_id_ctrim)%rval
     l2fr        = this%bc_inout(acnp_bc_inout_id_l2fr)%rval ! This variable is not updated in this
                                                             ! routine, and is therefore not a pointer
-    
+
     if( c_gain <= calloc_abs_error ) then
        limiter = c_limited
        if((n_gain <= 0.1_r8*calloc_abs_error) .or. &
@@ -1391,7 +1394,7 @@ contains
     end if
 
     limiter = 0
-    
+
     ! If any of these resources is essentially tapped out,
     ! then there is no point in performing growth
     ! It also seems impossible that we would be in a leaf-off status
@@ -1406,7 +1409,7 @@ contains
         any(leaf_status == [leaves_off,leaves_shedding]) ) then
        return
     end if
-       
+
     intgr_params(:)                  = fates_unset_r8
     intgr_params(intgr_parm_ctrim)   = this%bc_in(acnp_bc_in_id_ctrim)%rval
     intgr_params(intgr_parm_pft)     = real(this%bc_in(acnp_bc_in_id_pft)%ival,r8)
@@ -1418,7 +1421,7 @@ contains
     state_mask(:) = .false.
     mask_organs(:) = fates_unset_int
     mask_gorgans(:) = fates_unset_int
-    
+
     ! Go through and flag the integrating variables as either pools that
     ! are growing in this iteration, or not.   At this point, if carbon for growth
     ! remains, it means that all pools are up to, or above the target.  If
@@ -1430,9 +1433,9 @@ contains
     do i = 1, num_organs
 
        i_org = l2g_organ_list(i)
-       
+
        cdeficit = this%GetDeficit(carbon12_element,i_org,target_c(i_org))
-       
+
        if ( cdeficit > calloc_abs_error ) then
           ! In this case, we somehow still have carbon to play with,
           ! yet one of the pools is below its current target
@@ -1461,7 +1464,7 @@ contains
              mask_organs(ii) = i
              mask_gorgans(ii) = i_org
           end if
-          
+
        end if
     end do
 
@@ -1480,7 +1483,7 @@ contains
           call endrun(msg=errMsg(sourcefile, __LINE__))
        end if
     end if
-    
+
     ! fraction of carbon going towards reproduction. reproductive carbon is
     ! just different from the other pools. It is not based on proportionality,
     ! so its mask is set differently.  We (inefficiently) just included
@@ -1499,7 +1502,7 @@ contains
        else
           repro_c_frac = prt_params%seed_alloc(ipft) + prt_params%seed_alloc_mature(ipft)
        end if
-    
+
     ! If the TRS is switched on (with or w/o seedling dynamics) then reproductive allocation is
     ! a pft-specific function of dbh. This allows for the representation of different
     ! reproductive schedules (Wenk and Falster, 2015)
@@ -1511,12 +1514,12 @@ contains
        (1 + exp(prt_params%repro_alloc_b(ipft) + prt_params%repro_alloc_a(ipft)*dbh*mm_per_cm)))
 
     else
-       
+
        write(fates_log(),*) 'unknown seed allocation and regeneration model, exiting'
        write(fates_log(),*) 'hlm_regeneration_model: ',hlm_regeneration_model
        call endrun(msg=errMsg(sourcefile, __LINE__))
-       
-    end if ! regeneration switch 
+
+    end if ! regeneration switch
 
 
     if(repro_c_frac>nearzero)then
@@ -1537,14 +1540,14 @@ contains
     ! First objective is to find the extrapolated proportions of carbon going to
     ! each pool. This has nothing to do with carbon conservation, it is just used
     ! to make a rough prediction of how much nutrient is needed to match carbon
-    
+
     total_dcostdd = 0._r8
 
     do i = 1, n_mask_organs
        i_org = mask_gorgans(ii)
        total_dcostdd = total_dcostdd + target_dcdd(i_org)
     end do
-    
+
     ! We can either proceed with stature growth by using all of the carbon
     ! available, or we can try to estimate the limitations of N and P
     ! and thereby reduce the amount of C we are willing to use to try
@@ -1562,7 +1565,7 @@ contains
 
        neq_cgain = n_gain/avg_nc
        peq_cgain = p_gain/avg_pc
-       
+
        if(c_gain<neq_cgain) then
 
           if(c_gain < peq_cgain) then
@@ -1574,7 +1577,7 @@ contains
              c_gstature = peq_cgain
              cnp_gain = p_gain
           end if
-          
+
        else
           if(neq_cgain < peq_cgain) then
              limiter = n_limited
@@ -1585,54 +1588,54 @@ contains
              c_gstature = peq_cgain
              cnp_gain = p_gain
           end if
-          
+
        end if
-       
+
     end if
 
-    
+
    if_stature_growth: if(c_gstature > nearzero) then
 
        ! Initialize the adaptive integrator arrays and flags
        ! -----------------------------------------------------------------------------------
-       
+
       if(ODESolve == 2) then
          this%ode_opt_step = c_gstature
       end if
-      
+
       ! If this flag is set to 0, then
       ! we have a successful integration
       ierr             = 1
       nsteps           = 0
       totalC           = c_gstature
-      
+
       ! Fill the state array with element masses for each organ
       do i = 1, num_organs
          i_org = l2g_organ_list(i)
          i_var = prt_global%sp_organ_map(i_org,carbon12_element)
          state_array(i) = this%variables(i_var)%val(1)
       end do
-      
+
       state_mask(dbh_id)       = .true.
       state_array(dbh_id)      = dbh
 
       do_solve_check: do while( ierr .ne. 0 )
-         
+
          deltaC = min(totalC,this%ode_opt_step)
          if(ODESolve == 1) then
-            
+
             call RKF45(AllomCNPGrowthDeriv,state_array,state_mask,deltaC,totalC, &
                  max_trunc_error,intgr_params,state_array_out,this%ode_opt_step,step_pass)
-            
+
          elseif(ODESolve == 2) then
-            
+
             call Euler(AllomCNPGrowthDeriv,state_array,state_mask, &
                  deltaC,totalC,intgr_params,state_array_out)
 
             ! Here we check to see if the solution is reasonably
             ! close to allometry, we also have to add up all leaf bins
             ! for this check.
-            
+
             leafc_tp1 = state_array_out(leaf_id)
             i_var     = prt_global%sp_organ_map(leaf_organ,carbon12_element)
             nbins     = prt_global%state_descriptor(i_var)%num_pos
@@ -1652,7 +1655,7 @@ contains
             else
                this%ode_opt_step = 0.5_r8*deltaC
             end if
-            
+
          else
             write(fates_log(),*) 'An integrator was chosen that DNE'
             write(fates_log(),*) 'ODESolve = ',ODESolve
@@ -1660,24 +1663,24 @@ contains
          end if
 
          nsteps = nsteps + 1
-         
+
          if(step_pass)  then
             totalC            = totalC - deltaC
             state_array(:)    = state_array_out(:)
          end if
-          
+
          ! TotalC should eventually be whittled down to near-zero
          ! --------------------------------------------------------------------------------
          if_completed_solve:  if( (totalC < calloc_abs_error) )then
-            
+
             ierr           = 0
-            
+
             ! Sum up the total flux predicted by the integrator,
             ! which SHOULD be c_gstature, except
             ! for integration errors.  To make carbon
             ! perfectly preserved, we calculate this bias
             ! and make a linear (proportional) correction to all pools.
-            
+
             sum_c_flux = 0.0_r8
             do ii = 1, n_mask_organs
                i     = mask_organs(ii)
@@ -1685,35 +1688,35 @@ contains
                i_var = prt_global%sp_organ_map(i_org,carbon12_element)
                sum_c_flux = sum_c_flux + (state_array(i) - this%variables(i_var)%val(1))
             end do
-            
+
             ! This is a correction factor that forces
             ! mass conservation
             c_flux_adj = c_gstature/sum_c_flux
-            
+
             do ii = 1, n_mask_organs
-               
+
                i     = mask_organs(ii)
                i_org = mask_gorgans(ii)
                i_var = prt_global%sp_organ_map(i_org,carbon12_element)
-               
+
                ! Calculate adjusted flux
                c_flux   = (state_array(i) - this%variables(i_var)%val(1))*c_flux_adj
-               
+
                ! update the carbon pool (in all pools flux goes into the first pool)
                this%variables(i_var)%val(1) = this%variables(i_var)%val(1) + c_flux
-               
+
                ! Remove carbon from the daily gain
                c_gain = c_gain - c_flux
-               
+
             end do
-            
+
             ! Update dbh
-            dbh = state_array(dbh_id)       
-            
+            dbh = state_array(dbh_id)
+
          else
 
             if_step_exceedance: if (nsteps > max_substeps ) then
-               
+
                write(fates_log(),*) 'CNP Plant Growth Integrator could not find'
                write(fates_log(),*) 'a solution in less than ',max_substeps,' tries'
                write(fates_log(),*) 'Aborting'
@@ -1739,7 +1742,7 @@ contains
                sapwc_tp1   = state_array_out(sapw_id)
                storec_tp1  = state_array_out(store_id)
                structc_tp1 = state_array_out(struct_id)
-               
+
                call bleaf(dbh_tp1,ipft,crown_damage,canopy_trim, elongf_leaf, leaf_c_target_tp1)
                call bfineroot(dbh_tp1,ipft,canopy_trim,l2fr, elongf_fnrt, fnrt_c_target_tp1)
                call bsap_allom(dbh_tp1,ipft,crown_damage,canopy_trim, elongf_stem, sapw_area,sapw_c_target_tp1)
@@ -1756,9 +1759,9 @@ contains
                call endrun(msg=errMsg(sourcefile, __LINE__))
 
             end if if_step_exceedance
-               
+
          end if if_completed_solve
-         
+
       end do do_solve_check
 
       ! Prioritize nutrient transfer to the reproductive pool
@@ -1773,19 +1776,19 @@ contains
          target_n = this%GetNutrientTarget(nitrogen_element,repro_organ,stoich_growth_min)
          deficit_n(1) = this%GetDeficit(nitrogen_element,repro_organ,target_n)
          n_flux = max(0._r8,min(n_gain,deficit_n(1)))
-         
+
          target_p = this%GetNutrientTarget(phosphorus_element,repro_organ,stoich_growth_min)
          deficit_p(1) = this%GetDeficit(phosphorus_element,repro_organ,target_p)
          p_flux = max(0._r8,min(p_gain,deficit_p(1)))
-         
+
          this%variables(repro_n_id)%val(1) = this%variables(repro_n_id)%val(1) + n_flux
          this%variables(repro_p_id)%val(1) = this%variables(repro_p_id)%val(1) + p_flux
 
          n_gain = n_gain - n_flux
          p_gain = p_gain - p_flux
-         
+
       end if
-      
+
       ! -----------------------------------------------------------------------------------
       ! Nutrient Fluxes proportionally to each pool (these should be fully actualized)
       ! (this also removes from the gain pools)
@@ -1797,24 +1800,24 @@ contains
 
          i     = mask_organs(ii)
          i_org = mask_gorgans(ii)
-         
+
          target_n = this%GetNutrientTarget(nitrogen_element,i_org,stoich_growth_min)
          target_p = this%GetNutrientTarget(phosphorus_element,i_org,stoich_growth_min)
 
          deficit_n(ii) = this%GetDeficit(nitrogen_element,i_org,target_n)
          sum_n_demand = sum_n_demand+max(0._r8,deficit_n(ii))
-         
+
          deficit_p(ii) = this%GetDeficit(phosphorus_element,i_org,target_p)
          sum_p_demand = sum_p_demand+max(0._r8,deficit_p(ii))
-         
+
       end do
 
       ! TODO: mask_organs should be a vector of global organs
-      
+
       ! Nitrogen
-      call ProportionalNutrAllocation(this,deficit_n(1:n_mask_organs), & 
+      call ProportionalNutrAllocation(this,deficit_n(1:n_mask_organs), &
            n_gain, nitrogen_element,mask_gorgans(1:n_mask_organs))
-      
+
       ! Phosphorus
       call ProportionalNutrAllocation(this,deficit_p(1:n_mask_organs), &
            p_gain, phosphorus_element,mask_gorgans(1:n_mask_organs))
@@ -1823,7 +1826,7 @@ contains
 
     return
   end subroutine CNPStatureGrowth
-  
+
   ! =====================================================================================
 
   subroutine CNPAllocateRemainder(this, c_gain,n_gain,p_gain, &
@@ -1833,13 +1836,13 @@ contains
     class(cnp_allom_prt_vartypes) :: this
     real(r8), intent(inout) :: c_gain
     real(r8), intent(inout) :: n_gain
-    real(r8), intent(inout) :: p_gain 
+    real(r8), intent(inout) :: p_gain
     real(r8), intent(inout) :: c_efflux
     real(r8), intent(inout) :: n_efflux
     real(r8), intent(inout) :: p_efflux
     real(r8)  :: target_c(:)
     real(r8) :: target_dcdd(:)
-    
+
     integer  :: i
     real(r8), dimension(num_organs) :: deficit_n
     real(r8), dimension(num_organs) :: deficit_p
@@ -1853,21 +1856,24 @@ contains
     integer, pointer  :: limiter
     real(r8)          :: canopy_trim
     integer           :: crown_damage
-    
+
+    character(len=256)   :: dateTimeString
+    integer ::  yr, mon, day, sec
+
     dbh         => this%bc_inout(acnp_bc_inout_id_dbh)%rval
     canopy_trim = this%bc_in(acnp_bc_in_id_ctrim)%rval
     ipft        = this%bc_in(acnp_bc_in_id_pft)%ival
     resp_excess => this%bc_inout(acnp_bc_inout_id_resp_excess)%rval
     limiter     => this%bc_out(acnp_bc_out_id_limiter)%ival
     crown_damage = this%bc_in(acnp_bc_in_id_cdamage)%ival
-    
+
     ! -----------------------------------------------------------------------------------
     ! If nutrients are still available, then we can bump up the values in the pools
     !  towards the OPTIMAL target values.
     ! -----------------------------------------------------------------------------------
 
     do i = 1, num_organs
-       
+
        ! Update the nitrogen and phosphorus deficits
        target_n = this%GetNutrientTarget(nitrogen_element,l2g_organ_list(i),stoich_growth_min)
        target_p = this%GetNutrientTarget(phosphorus_element,l2g_organ_list(i),stoich_growth_min)
@@ -1879,18 +1885,18 @@ contains
 
        deficit_n(i) = max(0._r8,this%GetDeficit(nitrogen_element,l2g_organ_list(i),target_n))
        deficit_p(i) = max(0._r8,this%GetDeficit(phosphorus_element,l2g_organ_list(i),target_p))
-          
+
     end do
-    
+
     ! -----------------------------------------------------------------------------------
     ! Nutrient Fluxes proportionally to each pool (these should be fully actualized)
     ! (this also removes from the gain pools)
     ! -----------------------------------------------------------------------------------
-    
+
     ! Nitrogen
-    call ProportionalNutrAllocation(this,deficit_n(1:num_organs), & 
+    call ProportionalNutrAllocation(this,deficit_n(1:num_organs), &
          n_gain, nitrogen_element, l2g_organ_list(1:num_organs))
-    
+
     ! Phosphorus
     call ProportionalNutrAllocation(this,deficit_p(1:num_organs), &
          p_gain, phosphorus_element, l2g_organ_list(1:num_organs))
@@ -1898,8 +1904,15 @@ contains
 
     ! This routine updates the l2fr (leaf 2 fine-root multiplier) variable
     ! It will also update the target
-    call this%CNPAdjustFRootTargets(target_c,target_dcdd)
-        
+
+    ! turn on the dynamic L2FR post supplemental N period
+    call get_curr_date(yr, mon, day, sec)
+    if (spinup_state == 1 .and. yr .gt. nyears_ad_carbon_only) then
+      call this%CNPAdjustFRootTargets(target_c,target_dcdd)
+    else if (spinup_state /= 1) then
+      call this%CNPAdjustFRootTargets(target_c,target_dcdd)
+   end if
+
     ! -----------------------------------------------------------------------------------
     ! If carbon is still available, lets cram some into storage overflow
     ! We will do this last, because we wanted the non-overflow storage
@@ -1909,12 +1922,12 @@ contains
     if(c_gain>calloc_abs_error) then
 
        if(store_c_overflow == retain_c_store_overflow)then
-          
+
           total_c_flux = c_gain
           ! Transfer excess carbon into storage overflow
           this%variables(store_c_id)%val(1) = this%variables(store_c_id)%val(1) + total_c_flux
           c_gain              = c_gain - total_c_flux
-          
+
        elseif(store_c_overflow == burn_c_store_overflow) then
 
           ! Update carbon based allometric targets
@@ -1922,29 +1935,29 @@ contains
 
           ! Allow some overflow
           store_c_target = store_c_target * (1._r8 + prt_params%store_ovrflw_frac(ipft))
-          
+
           total_c_flux = max(0._r8,min(c_gain, store_c_target - this%variables(store_c_id)%val(1) ))
-          
+
           ! Transfer excess carbon INTO storage overflow
           this%variables(store_c_id)%val(1) = this%variables(store_c_id)%val(1) + total_c_flux
           c_gain              = c_gain - total_c_flux
 
           resp_excess = resp_excess + c_gain
           c_gain      = 0._r8
-          
+
        elseif(store_c_overflow == exude_c_store_overflow)then
-                 
+
           ! Update carbon based allometric targets
           call bstore_allom(dbh,ipft,crown_damage,canopy_trim, store_c_target)
-          
+
           ! Estimate the overflow
           store_c_target = store_c_target * (1._r8 + prt_params%store_ovrflw_frac(ipft))
-          
+
           total_c_flux = max(0.0, min(c_gain, store_c_target - this%variables(store_c_id)%val(1)))
           ! Transfer excess carbon into storage overflow
           this%variables(store_c_id)%val(1) = this%variables(store_c_id)%val(1) + total_c_flux
           c_gain = c_gain - total_c_flux
-          
+
        end if
 
     end if
@@ -1964,8 +1977,8 @@ contains
        this%variables(store_p_id)%val(1) = this%variables(store_p_id)%val(1) + p_gain
        p_gain                            = 0
     end if
-    
-    
+
+
 
     ! Figure out what to do with excess carbon and nutrients
     ! 1) excude through roots cap at 0 to flush out imprecisions
@@ -1975,14 +1988,14 @@ contains
     ! don't efflux anything, we will use the remainder
     ! n_gain and p_gain to specify the demand as what was used
     ! and what was uptaken
-    
+
     if(n_uptake_mode.eq.prescribed_n_uptake) then
        n_efflux  = 0._r8
     else
        n_efflux = n_gain
        n_gain   = 0._r8
     end if
-    
+
     if(p_uptake_mode.eq.prescribed_p_uptake) then
        p_efflux = 0._r8
     else
@@ -1992,8 +2005,8 @@ contains
 
     c_efflux = c_gain
     c_gain   = 0.0_r8
-    
-    
+
+
 
     nullify(dbh)
 
@@ -2019,7 +2032,7 @@ contains
 
 
   ! =====================================================================================
-  
+
   function GetDeficit(this,element_id,organ_id,target_m) result(deficit_m)
 
     class(cnp_allom_prt_vartypes) :: this
@@ -2029,7 +2042,7 @@ contains
 
     integer  :: i_var
     real(r8) :: deficit_m
-    
+
     i_var = prt_global%sp_organ_map(organ_id,element_id)
 
     if(element_id.eq.carbon12_element) then
@@ -2037,20 +2050,20 @@ contains
     else
        deficit_m = target_m - this%variables(i_var)%val(1)
     end if
-       
+
     return
   end function GetDeficit
-  
+
   ! =====================================================================================
 
   function GetNutrientTargetCNP(this,element_id,organ_id,stoich_mode) result(target_m)
-    
+
     class(cnp_allom_prt_vartypes) :: this
     integer, intent(in)           :: element_id
     integer, intent(in)           :: organ_id
     integer, intent(in),optional  :: stoich_mode
     real(r8)                      :: target_m    ! Target amount of nutrient for this organ [kg]
-    
+
     real(r8)         :: target_c
     real(r8),pointer :: dbh
     real(r8)         :: canopy_trim
@@ -2079,12 +2092,12 @@ contains
     nc_repro    = this%bc_in(acnp_bc_in_id_nc_repro)%rval
     pc_repro    = this%bc_in(acnp_bc_in_id_pc_repro)%rval
     crown_damage = this%bc_in(acnp_bc_in_id_cdamage)%ival
-    
+
     ! Storage of nutrients are assumed to have different compartments than
     ! for carbon, and thus their targets are not associated with a tissue
     ! but is more represented as a fraction of the maximum amount of nutrient
     ! that can be bound in non-reproductive tissues
-    
+
     if(organ_id == store_organ) then
 
        call bleaf(dbh,ipft,crown_damage,canopy_trim, elongf_leaf, leaf_c_target)
@@ -2098,18 +2111,18 @@ contains
        ! non-reproductive organs
 
        if( element_id == nitrogen_element) then
-          
+
           target_m = StorageNutrientTarget(ipft, element_id, &
                leaf_c_target*prt_params%nitr_stoich_p1(ipft,prt_params%organ_param_id(leaf_organ)), &
                fnrt_c_target*prt_params%nitr_stoich_p1(ipft,prt_params%organ_param_id(fnrt_organ)), &
-               sapw_c_target*prt_params%nitr_stoich_p1(ipft,prt_params%organ_param_id(sapw_organ)), & 
+               sapw_c_target*prt_params%nitr_stoich_p1(ipft,prt_params%organ_param_id(sapw_organ)), &
                struct_c_target*prt_params%nitr_stoich_p1(ipft,prt_params%organ_param_id(struct_organ)))
        else
-          
+
           target_m = StorageNutrientTarget(ipft, element_id, &
                leaf_c_target*prt_params%phos_stoich_p1(ipft,prt_params%organ_param_id(leaf_organ)), &
                fnrt_c_target*prt_params%phos_stoich_p1(ipft,prt_params%organ_param_id(fnrt_organ)), &
-               sapw_c_target*prt_params%phos_stoich_p1(ipft,prt_params%organ_param_id(sapw_organ)), & 
+               sapw_c_target*prt_params%phos_stoich_p1(ipft,prt_params%organ_param_id(sapw_organ)), &
                struct_c_target*prt_params%phos_stoich_p1(ipft,prt_params%organ_param_id(struct_organ)))
 
        end if
@@ -2119,7 +2132,7 @@ contains
        if( stoich_mode == stoich_max ) then
           target_m = target_m*(1._r8 + prt_params%store_ovrflw_frac(ipft))
        end if
-       
+
     elseif(organ_id == repro_organ) then
 
        target_c = this%variables(i_cvar)%val(1)
@@ -2128,7 +2141,7 @@ contains
        else
           target_m = target_c * pc_repro
        end if
-       
+
     else
 
 
@@ -2137,12 +2150,12 @@ contains
           write(fates_log(),*) 'for non-reproductive and non-storage organs'
           call endrun(msg=errMsg(sourcefile, __LINE__))
        end if
-       
+
        ! In all cases, we want the first index because for non-leaves
        ! that is the only index, and for leaves, that is the newly
        ! growing index.
        target_c = this%variables(i_cvar)%val(1)
-    
+
        if( stoich_mode == stoich_growth_min ) then
           if( element_id == nitrogen_element) then
              target_m = target_c * prt_params%nitr_stoich_p1(ipft,prt_params%organ_param_id(organ_id))
@@ -2173,9 +2186,9 @@ contains
   end function GetNutrientTargetCNP
 
 
-  
+
   ! =====================================================================================
-  
+
   subroutine ProportionalNutrAllocation(this,deficit_m, gain_m, element_id, list)
 
     ! -----------------------------------------------------------------------------------
@@ -2202,32 +2215,32 @@ contains
     real(r8) :: sum_flux
 
     num_organs = size(list,dim=1)
-       
+
     sum_deficit = 0._r8
     do i = 1, num_organs
        i_org = list(i)
        sum_deficit = sum_deficit + max(0._r8,deficit_m(i))
     end do
-    
+
     if (sum_deficit>nearzero) then
-       
+
        sum_flux = min(gain_m, sum_deficit)
-       
+
        do i = 1, num_organs
           i_org = list(i)
-          
+
           flux  = sum_flux * max(0._r8,deficit_m(i))/sum_deficit
 
           i_var = prt_global%sp_organ_map(i_org,element_id)
           this%variables(i_var)%val(1) = this%variables(i_var)%val(1) + flux
-          
+
           deficit_m(i) = deficit_m(i) - flux
           gain_m      = gain_m - flux
-          
+
       end do
-      
+
     end if
-    
+
     if(debug) then
        if(gain_m < -calloc_abs_error) then
           write(fates_log(),*) 'Somehow we have negative nutrient gain'
@@ -2236,7 +2249,7 @@ contains
           call endrun(msg=errMsg(sourcefile, __LINE__))
        end if
     end if
-    
+
     return
   end subroutine ProportionalNutrAllocation
 
@@ -2274,7 +2287,7 @@ contains
       integer  :: ipft             ! PFT index
       real(r8) :: canopy_trim      ! Canopy trimming function (boundary condition [0-1]
       integer  :: crown_damage     ! Damage class
-      real(r8) :: l2fr             ! leaf to fineroot biomass multiplier 
+      real(r8) :: l2fr             ! leaf to fineroot biomass multiplier
       real(r8) :: leaf_c_target    ! target leaf biomass, dummy var (kgC)
       real(r8) :: fnrt_c_target    ! target fine-root biomass, dummy var (kgC)
       real(r8) :: sapw_c_target    ! target sapwood biomass, dummy var (kgC)
@@ -2333,14 +2346,14 @@ contains
 
            ! If the TRS is switched off then we use FATES's default reproductive allocation.
            if ( hlm_regeneration_model == default_regeneration .or. &
-                prt_params%allom_dbh_maxheight(ipft) < min_max_dbh_for_trees ) then ! The Tree Recruitment Scheme 
+                prt_params%allom_dbh_maxheight(ipft) < min_max_dbh_for_trees ) then ! The Tree Recruitment Scheme
                                                                              ! is only for trees
               if (dbh <= prt_params%dbh_repro_threshold(ipft)) then
                  repro_fraction = prt_params%seed_alloc(ipft)
               else
                  repro_fraction = prt_params%seed_alloc(ipft) + prt_params%seed_alloc_mature(ipft)
               end if
-   
+
            ! If the TRS is switched on (with or w/o seedling dynamics) then reproductive allocation is
            ! a pft-specific function of dbh. This allows for the representation of different
            ! reproductive schedules (Wenk and Falster, 2015)
@@ -2354,8 +2367,8 @@ contains
               write(fates_log(),*) 'unknown seed allocation and regeneration model, exiting'
               write(fates_log(),*) 'hlm_regeneration_model: ',hlm_regeneration_model
               call endrun(msg=errMsg(sourcefile, __LINE__))
-           end if ! regeneration switch 
-          
+           end if ! regeneration switch
+
         else ! mask repro
            repro_fraction = 0._r8
         end if !mask repro
@@ -2410,9 +2423,9 @@ contains
               write(fates_log(),*) 'repro fraction: ',repro_fraction
               call endrun(msg=errMsg(sourcefile, __LINE__))
            end if
-           
+
            dCdx(dbh_id)      = (1.0_r8/total_dcostdd)*(1.0_r8 - repro_fraction)
-           
+
         else
 
            if(repro_fraction<nearzero) then
@@ -2427,9 +2440,9 @@ contains
               write(fates_log(),*) 'repro fraction: ',repro_fraction
               call endrun(msg=errMsg(sourcefile, __LINE__))
            end if
-              
+
            dCdx(repro_id) = 1._r8
-           
+
         end if
 
       end associate
@@ -2438,8 +2451,8 @@ contains
    end function AllomCNPGrowthDeriv
 
    ! =====================================================================================
-   
-   
+
+
    subroutine EstimateGrowthNC(this,target_c,target_dcdd,state_mask,avg_nc,avg_pc)
 
      ! This routine predicts the effective nutrient/carbon allocation ratio
@@ -2459,24 +2472,24 @@ contains
      real(r8) :: store_nc
      real(r8) :: store_pc
      real(r8) :: repro_w,leaf_w,fnrt_w,sapw_w,struct_w,store_w
-     
-     associate(dbh    => this%bc_inout(acnp_bc_inout_id_dbh)%rval, & 
+
+     associate(dbh    => this%bc_inout(acnp_bc_inout_id_dbh)%rval, &
           ipft        => this%bc_in(acnp_bc_in_id_pft)%ival, &
           nc_repro    => this%bc_in(acnp_bc_in_id_nc_repro)%rval, &
           pc_repro    => this%bc_in(acnp_bc_in_id_pc_repro)%rval)
-     
+
      if(state_mask(repro_id)) then
-        
+
         ! If the TRS is switched off then we use FATES's default reproductive allocation.
         if ( hlm_regeneration_model == default_regeneration .or. &
-             prt_params%allom_dbh_maxheight(ipft) < min_max_dbh_for_trees ) then ! The Tree Recruitment Scheme 
+             prt_params%allom_dbh_maxheight(ipft) < min_max_dbh_for_trees ) then ! The Tree Recruitment Scheme
                                                                                  ! is only for trees
            if (dbh <= prt_params%dbh_repro_threshold(ipft)) then
               repro_c_frac = prt_params%seed_alloc(ipft)
            else
               repro_c_frac = prt_params%seed_alloc(ipft) + prt_params%seed_alloc_mature(ipft)
            end if
-   
+
         ! If the TRS is switched on (with or w/o seedling dynamics) then reproductive allocation is
         ! a pft-specific function of dbh. This allows for the representation of different
         ! reproductive schedules (Wenk and Falster, 2015)
@@ -2490,17 +2503,17 @@ contains
            write(fates_log(),*) 'unknown seed allocation and regeneration model, exiting'
            write(fates_log(),*) 'hlm_regeneration_model: ',hlm_regeneration_model
            call endrun(msg=errMsg(sourcefile, __LINE__))
-        end if ! regeneration switch 
+        end if ! regeneration switch
 
      else ! state mask
         repro_c_frac = 0._r8
      end if ! state mask
-        
+
      ! Estimate the total weight
      total_w = 0._r8
      avg_nc = 0._r8
      avg_pc = 0._r8
-     
+
      if(state_mask(leaf_id)) then
         leaf_w = target_dcdd(leaf_organ) * (1._r8 - repro_c_frac)
         total_w = total_w + leaf_w
@@ -2542,11 +2555,11 @@ contains
         ! repro_w = total_w * repro_c_frac/(1-repro_c_frac)
 
         if(1._r8 - repro_c_frac < nearzero) then
-           repro_w = repro_c_frac 
+           repro_w = repro_c_frac
         else
            repro_w = total_w * repro_c_frac/(1._r8 - repro_c_frac)
         end if
-        
+
         total_w = total_w  + repro_w
         avg_nc = avg_nc + repro_w * nc_repro
         avg_pc = avg_pc + repro_w * pc_repro
@@ -2556,7 +2569,7 @@ contains
      avg_pc = avg_pc / total_w
 
    end associate
-     
+
    return
  end subroutine EstimateGrowthNC
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
**Vegetation decline in CNP spinups: Is resetting of L2FR value after senescence a probable reason?** 

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->
We see that the GPP, NPP, and LAI were declining rapidly during the AD Spinups during the RD and ECA runs both for evergreen needleleaf and cold-deciduous plant functional type but not for Carbon only runs (see Fig 1). 

Increasing the initial period of supplemental N supported vegetation productivity but the decline in productivity happens when supplemental N is stopped. 

Partial improvement was seen by commenting the call to [dynamic L2FR](https://github.com/NGEET/fates/blob/f0185f7c7033fa69c80d1ddb07cbcbf1f8be1adc/parteh/PRTAllometricCNPMod.F90#L1901) for initial few decades. We see an increase in vegetation productivity but it was low. Commenting the call to [dynamic L2FR](https://github.com/NGEET/fates/blob/f0185f7c7033fa69c80d1ddb07cbcbf1f8be1adc/parteh/PRTAllometricCNPMod.F90#L1901) throughout the AD spinup lead to increase in GPP but it was still much lower than expected (Fig 2).

We think that Fineroot biomass (FR) is dropping to near zero during the winter in the CNP simulations, especially in deciduous PFT when leaf-off is triggered (Fig 3). Near-zero winter FR might be preventing uptake of available N during periods of no leaves (or close enough). The big increase in FR each year will add a significant amount of real N demand (i.e. what's required for growth), contributing to the rapid depletion of the store. 

We also noticed that the L2FR was[ resetting to default parameter L2FR](https://github.com/NGEET/fates/blob/f0185f7c7033fa69c80d1ddb07cbcbf1f8be1adc/biogeochem/EDPhysiologyMod.F90#L1605) after every senescence event. Thus, L2FR value of previous timestep was not used in resource allocation (as intended by [subroutine CNPAdjustFrootTargets](https://github.com/NGEET/fates/blob/f0185f7c7033fa69c80d1ddb07cbcbf1f8be1adc/parteh/PRTAllometricCNPMod.F90#L728)) in following timestep.

In summary,

- L2FR in each cohort's data structure is initialized with the value from the parameter file, the [biomass targets in the CNP allocation routine are initially set here](https://gcc02.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FNGEET%2Ffates%2Fblob%2Ff0185f7c7033fa69c80d1ddb07cbcbf1f8be1adc%2Fparteh%2FPRTAllometricCNPMod.F90%23L493&data=05%7C02%7Csharmabd%40ornl.gov%7Cbe7994346c5244a75aa608dc75a8ec18%7Cdb3dbd434c4b45449f8a0553f9f5f25e%7C1%7C0%7C638514615667399324%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C0%7C%7C%7C&sdata=B5Vn23Yx1jgkffWaboFrQoXKHXIkmesWRhAEI2zwDFk%3D&reserved=0), before a first round of [growth happens](https://gcc02.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FNGEET%2Ffates%2Fblob%2Ff0185f7c7033fa69c80d1ddb07cbcbf1f8be1adc%2Fparteh%2FPRTAllometricCNPMod.F90%23L574&data=05%7C02%7Csharmabd%40ornl.gov%7Cbe7994346c5244a75aa608dc75a8ec18%7Cdb3dbd434c4b45449f8a0553f9f5f25e%7C1%7C0%7C638514615667406237%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C0%7C%7C%7C&sdata=aY4O5DbJ9ymMDwdU%2BbO9Ze3hveKunQcu3PMnwxymhXs%3D&reserved=0) in CNPStatureGrowth, which happens before [dynamic l2fr and target FR biomass is updated](https://gcc02.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FNGEET%2Ffates%2Fblob%2Ff0185f7c7033fa69c80d1ddb07cbcbf1f8be1adc%2Fparteh%2FPRTAllometricCNPMod.F90%23L1901&data=05%7C02%7Csharmabd%40ornl.gov%7Cbe7994346c5244a75aa608dc75a8ec18%7Cdb3dbd434c4b45449f8a0553f9f5f25e%7C1%7C0%7C638514615667412478%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C0%7C%7C%7C&sdata=IQUYfmDTA2Hbnd0Nw04EYHkrBymqXBZHIQlAsEDTdGo%3D&reserved=0) in another later second round of growth in CNPAllocateRemainder.

- L2FR is reset after every senescence event. 

- Solution (results in Fig 4): 

  - turning the dynamic L2FR off during the supplemental N period by conditional call to CNPAdjustFRootTargets on [this line](https://gcc02.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FNGEET%2Ffates%2Fblob%2Ff0185f7c7033fa69c80d1ddb07cbcbf1f8be1adc%2Fparteh%2FPRTAllometricCNPMod.F90%23L1901&data=05%7C02%7Csharmabd%40ornl.gov%7Cbe7994346c5244a75aa608dc75a8ec18%7Cdb3dbd434c4b45449f8a0553f9f5f25e%7C1%7C0%7C638514615667420792%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C0%7C%7C%7C&sdata=pRJ%2BdpuaGkWKUZwF00WSR6Oe57y0UizxeSqI00HJlu4%3D&reserved=0) (see Code 1 below).

  - Change how l2fr is read in physiology code from [this](https://github.com/NGEET/fates/blob/f0185f7c7033fa69c80d1ddb07cbcbf1f8be1adc/biogeochem/EDPhysiologyMod.F90#L1605) to Code 2 below.
Code 1: 

```
call get_curr_date(yr, mon, day, sec)                                       
if (spinup_state == 1 .and. yr .gt. nyears_ad_carbon_only) then             
    call this%CNPAdjustFRootTargets(target_c,target_dcdd)                   
else if (spinup_state /= 1) then                                                                                                                                                                                   
    call this%CNPAdjustFRootTargets(target_c,target_dcdd)                   
end if 
```   

Code 2:

`l2fr = currentCohort%l2fr`


**Figures**
<img width="468" alt="image" src="https://github.com/user-attachments/assets/81e028fd-3cb9-4657-97f0-861ca80da042" />
_Fig 1: GPP, NPP, and AR  in ad spins for cold deciduousPFT during Carbon only (top) and RD run (bottom). Similar plots are for needleleaf evergreen PFT._

<img width="468" alt="image" src="https://github.com/user-attachments/assets/bc5c968e-03ed-442e-96a5-0b927f2db8f4" />

_Fig 2: GPP, NPP, AR in ad spins for cold-deciduous PFT during RD Run with dynamic L2FR (default) and without dynamic L2FR._

<img width="468" alt="image" src="https://github.com/user-attachments/assets/334bffee-2b30-45a2-910b-d8b0a0adf221" />

_Fig 3: Leaf, Fineroot, and Store Carbon during the first 30 years of ad spinups for Carbon only (top), RD (middle), and ECA (bottom) runs for cold-deciduous PFT._

<img width="468" alt="image" src="https://github.com/user-attachments/assets/7db01cd8-5c0e-4db4-b30f-cb7f53b6b178" />

_Fig 4: GPP, NPP, and AR in ad spins for RD using cold deciduous PFT (top) and needleleaf evergreen PFT (bottom). Similar plots are for ECA._



### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->
Anthony Walker, ORNL (@walkeranthonyp)
Daniel Ricciuto, ORNL (@dmricciuto)

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [x] The in-code documentation has been updated with descriptive comments
- [ ] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided
- [ ] FATES-CLM6 Code Freeze: satellite phenology regression tests are b4b

*If satellite phenology regressions are **not** b4b, please hold merge and notify the FATES development team.*

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:* v2.1.0-13087-ge9afb7cb13

*FATES baseline hash-tag:* sci.1.68.2_api.31.0.0

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

