### PR TITLE
SPITFIRE refactor of mortality

### DIFF
--- a/biogeophys/CMakeLists.txt
+++ b/biogeophys/CMakeLists.txt
@@ -1,5 +1,6 @@
 list(APPEND fates_sources
   FatesHydroWTFMod.F90
+  LeafBiophysicsMod.F90
   FatesPlantHydraulicsMod.F90)
 
 sourcelist_to_parent(fates_sources)

--- a/fire/SFEquationsMod.F90
+++ b/fire/SFEquationsMod.F90
@@ -599,6 +599,8 @@ module SFEquationsMod
     !
     !  DESCRIPTION:
     !  Helper function for CambialMortality
+    !  Calculates rate of cambial damage mortality [0-1]
+    !  Equation 19 in Thonicke et al. 2010
     !
 
     ! ARGUMENTS:

--- a/fire/SFEquationsMod.F90
+++ b/fire/SFEquationsMod.F90
@@ -33,6 +33,7 @@ module SFEquationsMod
   public :: FireIntensity
   public :: ScorchHeight
   public :: CrownFractionBurnt
+  public :: BarkThickness
   public :: CambialMortality
   public :: TotalFireMortality
   public :: CrownFireMortality
@@ -544,6 +545,22 @@ module SFEquationsMod
   end function BarkThickness
   
   !---------------------------------------------------------------------------------------
+  
+  real(r8) function CriticalResidenceTime(bark_thickness)
+    !
+    !  DESCRIPTION:
+    !  Calculates critical fire residence time for cambial damage [min]
+    !  Equation 19 in Thonicke et al. 2010
+    !
+  
+    ! ARGUMENTS:
+    real(r8), intent(in) :: bark_thickness ! bark thickness [cm]
+    
+    CriticalResidenceTime = 2.9_r8*bark_thickness**2.0_r8
+  
+  end function CriticalResidenceTime
+  
+  !---------------------------------------------------------------------------------------
     
   real(r8) function CambialMortality(bark_scalar, dbh, tau_l)
     !
@@ -560,12 +577,15 @@ module SFEquationsMod
     ! LOCALS:
     real(r8) :: bark_thickness ! bark thickness [cm]
     real(r8) :: tau_c          ! critical fire residence time for cambial damage [min]
-    real(r8) :: tau_r          ! tau_l/tau_c
+    real(r8) :: tau_r          ! relative fire residence time (actual / critical)
     
+    ! calculate bark thickness based of bark scalar parameter and DBH
     bark_thickness = BarkThickness(bark_scalar, dbh)
     
-    ! calculate critical residence time
-    tau_c = 2.9_r8*bark_thickness**2.0_r8
+    ! calculate critical residence time for cambial damage [min]
+    tau_c = CriticalResidenceTime(bark_thickness)
+    
+    ! relative residence time
     tau_r = tau_l/tau_c
   
     if (tau_r >= 2.0_r8) then
@@ -588,10 +608,12 @@ module SFEquationsMod
     !
 
     ! ARGUMENTS:
-    real(r8), intent(in) :: crown_kill            ! cm bark per cm dbh [cm/cm]
+    real(r8), intent(in) :: crown_kill            ! parameter for crown kill cm bark per cm dbh [cm/cm]
     real(r8), intent(in) :: fraction_crown_burned ! fraction of the crown burned [0-1]
     
     CrownFireMortality = crown_kill*fraction_crown_burned**3.0_r8
+    if (CrownFireMortality > 1.0_r8) CrownFireMortality = 1.0_r8
+    if (CrownFireMortality < nearzero) CrownFireMortality = 0.0_r8
     
   end function CrownFireMortality
   

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -63,11 +63,7 @@ contains
       call CalculateSurfaceRateOfSpread(currentSite)
       call CalculateSurfaceFireIntensity(currentSite)
       call CalculateAreaBurnt(currentSite)
-      
-      call crown_scorching(currentSite)
-      call crown_damage(currentSite)
-      call cambial_damage_kill(currentSite)
-      call post_fire_mortality(currentSite)
+      call CalculatePostFireMortality(currentSite)
     end if
 
   end subroutine DailyFireModel
@@ -473,257 +469,65 @@ contains
     ! LOCALS:
     type(fates_patch_type),  pointer :: currentPatch    ! patch object
     type(fates_cohort_type), pointer :: currentCohort   ! cohort object
-    real(r8)                         :: tree_ag_biomass ! total amount of above-ground tree biomass in patch [kgC/m2]
+    real(r8)                         :: crown_depth     ! crown depth [m]
+    integer                          :: i_pft           ! looping index
     
     currentPatch => currentSite%oldest_patch
-    do while (associated(currentPatch))
-      if (currentPatch%nocomp_pft_label /= nocomp_bareground .and. currentPatch%fire == 1) then
-        
-        ! sum up woody agoveground biomass on patch
-        tree_ag_biomass = 0.0_r8
-        currentCohort => currentPatch%tallest
-        do while (associated(currentCohort))
-          if (prt_params%woody(currentCohort%pft) == itrue) then
-            leaf_c = currentCohort%prt%GetState(leaf_organ, carbon12_element)
-            sapw_c = currentCohort%prt%GetState(sapw_organ, carbon12_element)
-            struct_c = currentCohort%prt%GetState(struct_organ, carbon12_element)
-            tree_ag_biomass = tree_ag_biomass + currentCohort%n*(leaf_c + prt_params%allom_agb_frac(currentCohort%pft)*(sapw_c + struct_c))
-          end if 
-          currentCohort => currentCohort%shorter
-        end do
-        
-        ! calculate scorch height [m]
-        currentPatch%Scorch_ht(:) = 0.0_r8
-        if (tree_ag_biomass > 0.0_r8) then 
+    do while (associated(currentPatch)) 
+      if (currentPatch%nocomp_pft_label /= nocomp_bareground) then
+        if (currentPatch%fire == 1) then
+          
+          ! calculate scorch height [m]
           do i_pft = 1, numpft
             if (prt_params%woody(i_pft) == itrue) then 
-              currentPatch%Scorch_ht(i_pft) = ScorchHeight(EDPftvarcon_inst%fire_alpha_SH(i_pft), currentPatch%FI)
+              currentPatch%Scorch_ht(i_pft) = ScorchHeight(EDPftvarcon_inst%fire_alpha_SH(i_pft), &
+                currentPatch%FI)
+            else
+              currentPatch%Scorch_ht(i_pft) = 0.0_r8
             end if
           end do
+          
+          ! calculate fire-related mortality
+          currentCohort => currentPatch%tallest
+          do while (associated(currentCohort))
+            
+            currentCohort%fraction_crown_burned = 0.0_r8
+            currentCohort%fire_mort = 0.0_r8
+            currentCohort%crownfire_mort = 0.0_r8
+            currentCohort%cambial_mort = 0.0_r8
+            
+            if (prt_params%woody(currentCohort%pft) == itrue) then
+              
+              ! calculate crown fraction burned [0-1]
+              call CrownDepth(currentCohort%height, currentCohort%pft, crown_depth) 
+              currentCohort%fraction_crown_burned = CrownFractionBurnt(currentPatch%Scorch_ht(currentCohort%pft),  &
+                currentCohort%height, crown_depth)
+                      
+              ! shrink canopy to account for burnt section
+              ! currentCohort%canopy_trim = min(currentCohort%canopy_trim, 1.0_r8 - currentCohort%fraction_crown_burned)
+              
+              ! calculate cambial mortality rate [0-1] 
+              currentCohort%cambial_mort = CambialMortality(EDPftvarcon_inst%bark_scaler(currentCohort%pft), & 
+                currentCohort%dbh, currentPatch%tau_l)
+
+              ! calculate crown fire mortality [0-1]
+              currentCohort%crownfire_mort = CrownFireMortality(EDPftvarcon_inst%crown_kill(currentCohort%pft), &
+                currentCohort%fraction_crown_burned)
+              
+              ! total fire mortality [0-1]
+              currentCohort%fire_mort = TotalFireMortality(currentCohort%crownfire_mort, &
+                currentCohort%cambial_mort)
+              
+            end if 
+            currentCohort => currentCohort%shorter
+          end do 
         end if 
-        
-        ! now calculate actual mortality
-        do while (associated(currentCohort))  
-          
-          currentCohort%fraction_crown_burned = 0.0_r8
-          currentCohort%fire_mort = 0.0_r8
-          currentCohort%crownfire_mort = 0.0_r8
-          currentCohort%cambial_damage_kill = 0.0_r8
-          
-          if (prt_params%woody(currentCohort%pft) == itrue) then 
-            
-            call CrownDepth(currentCohort%height, currentCohort%pft, crown_depth)
-            
-            ! calculate crown fraction burned
-            currentCohort%fraction_crown_burned = CrownFractionBurnt(currentPatch%Scorch_ht(currentCohort%pft),  &
-              currentCohort%height, crown_depth)
-              
-            ! calculate cambial mortality            
-            currentCohort%cambial_damage_kill = CambialMortality(EDPftvarcon_inst%bark_scaler(currentCohort%pft), & 
-              currentCohort%dbh, currentPatch%tau_l)
-            
-            ! calculate crown fire mortality
-            currentCohort%crownfire_mort = CrownFireMortality(EDPftvarcon_inst%crown_kill(currentCohort%pft), &
-              currentCohort%fraction_crown_burned)
-              
-            ! total fire mortality
-            currentCohort%fire_mort = TotalFireMortality(currentCohort%crownfire_mort,   &
-              currentCohort%cambial_mort)
-              
-          end if
-          currentCohort => currentCohort%shorter
-        end do 
-      end if
+      end if 
       currentPatch => currentPatch%younger
     end do 
-  
+    
   end subroutine CalculatePostFireMortality
   
   !---------------------------------------------------------------------------------------
-  
-  subroutine crown_scorching(currentSite) 
-
-  type(ed_site_type), intent(in), target :: currentSite
-
-  type(fates_patch_type),  pointer :: currentPatch
-  type(fates_cohort_type), pointer :: currentCohort
-
-  real(r8) ::  tree_ag_biomass ! total amount of above-ground tree biomass in patch. kgC/m2
-  real(r8) ::  leaf_c          ! leaf carbon      [kg]
-  real(r8) ::  sapw_c          ! sapwood carbon   [kg]
-  real(r8) ::  struct_c        ! structure carbon [kg]
-  integer  ::  i_pft
-
-  currentPatch => currentSite%oldest_patch
-  do while (associated(currentPatch)) 
-
-    if (currentPatch%nocomp_pft_label /= nocomp_bareground) then
-
-      tree_ag_biomass = 0.0_r8
-      if (currentPatch%fire == 1) then
-      
-        currentCohort => currentPatch%tallest
-        do while (associated(currentCohort))  
-          if (prt_params%woody(currentCohort%pft) == itrue) then
-            leaf_c = currentCohort%prt%GetState(leaf_organ, carbon12_element)
-            sapw_c = currentCohort%prt%GetState(sapw_organ, carbon12_element)
-            struct_c = currentCohort%prt%GetState(struct_organ, carbon12_element)
-            tree_ag_biomass = tree_ag_biomass + currentCohort%n*(leaf_c + prt_params%allom_agb_frac(currentCohort%pft)*(sapw_c + struct_c))
-          end if 
-          currentCohort => currentCohort%shorter
-        end do 
-
-        do i_pft = 1, numpft
-          if (tree_ag_biomass > 0.0_r8 .and. prt_params%woody(i_pft) == itrue) then 
-            ! Equation 16 in Thonicke et al. 2010 !Van Wagner 1973 EQ8 !2/3 Byram (1959)
-            currentPatch%Scorch_ht(i_pft) = EDPftvarcon_inst%fire_alpha_SH(i_pft)*(currentPatch%FI**0.667_r8)
-          else
-            currentPatch%Scorch_ht(i_pft) = 0.0_r8
-          end if
-        end do
-      end if 
-    end if 
-    currentPatch => currentPatch%younger
-  end do
-
-  end subroutine crown_scorching
-  
-  !---------------------------------------------------------------------------------------
-  
-  subroutine crown_damage(currentSite)
-
-    type(ed_site_type), intent(in), target :: currentSite
-    type(fates_patch_type) , pointer :: currentPatch
-    type(fates_cohort_type), pointer :: currentCohort
-    real(r8)                         :: crown_depth    ! Depth of crown in meters
-
-    currentPatch => currentSite%oldest_patch
-    do while (associated(currentPatch)) 
-
-      if (currentPatch%nocomp_pft_label /= nocomp_bareground) then
-        if (currentPatch%fire == 1) then
-          currentCohort => currentPatch%tallest
-          do while (associated(currentCohort))  
-            currentCohort%fraction_crown_burned = 0.0_r8
-            if (prt_params%woody(currentCohort%pft) == itrue) then 
-              ! Flames lower than bottom of canopy. 
-              ! c%height is height of cohort
-              call CrownDepth(currentCohort%height, currentCohort%pft, crown_depth)
-
-              if (currentPatch%Scorch_ht(currentCohort%pft) < (currentCohort%height-crown_depth)) then 
-                currentCohort%fraction_crown_burned = 0.0_r8
-              else
-                ! Flames part of way up canopy. 
-                ! Equation 17 in Thonicke et al. 2010. 
-                ! flames over bottom of canopy but not over top.
-                if((currentCohort%height > 0.0_r8) .and. (currentPatch%Scorch_ht(currentCohort%pft) >=  &
-                  (currentCohort%height-crown_depth))) then 
-                  currentCohort%fraction_crown_burned = (currentPatch%Scorch_ht(currentCohort%pft) - &
-                    (currentCohort%height - crown_depth))/crown_depth
-                else 
-                  ! Flames over top of canopy. 
-                  currentCohort%fraction_crown_burned =  1.0_r8 
-                end if
-              endif
-              ! Check for strange values. 
-              currentCohort%fraction_crown_burned = min(1.0_r8, max(0.0_r8,currentCohort%fraction_crown_burned))              
-            end if !trees only
-            !shrink canopy to account for burnt section.     
-            !currentCohort%canopy_trim = min(currentCohort%canopy_trim,(1.0_r8-currentCohort%fraction_crown_burned))
-            currentCohort => currentCohort%shorter
-          end do 
-        end if 
-      end if
-      currentPatch => currentPatch%younger
-    end do
-
-  end subroutine crown_damage
-  
-  !---------------------------------------------------------------------------------------
-
-  subroutine cambial_damage_kill(currentSite)
-    ! routine description.
-    ! returns the probability that trees dies due to cambial char
-    ! currentPatch%tau_l = duration of lethal stem heating (min). Calculated at patch level.
-
-    type(ed_site_type), intent(in), target :: currentSite
-
-    type(fates_patch_type) , pointer :: currentPatch
-    type(fates_cohort_type), pointer :: currentCohort
-
-    real(r8) :: tau_c !critical time taken to kill cambium (minutes) 
-    real(r8) :: bt    !bark thickness in cm.
-
-    currentPatch => currentSite%oldest_patch
-    do while(associated(currentPatch))
-      if (currentPatch%nocomp_pft_label /= nocomp_bareground) then
-        if (currentPatch%fire == 1) then
-          currentCohort => currentPatch%tallest
-          do while(associated(currentCohort))  
-            if ( prt_params%woody(currentCohort%pft) == itrue) then 
-              
-              ! Equation 21 in Thonicke et al 2010
-              bt = EDPftvarcon_inst%bark_scaler(currentCohort%pft)*currentCohort%dbh 
-              ! Equation 20 in Thonicke et al. 2010. 
-              tau_c = 2.9_r8*bt**2.0_r8
-              ! Equation 19 in Thonicke et al. 2010
-              
-              if ((currentPatch%tau_l/tau_c) >= 2.0_r8) then
-                currentCohort%cambial_mort = 1.0_r8
-              else
-                if ((currentPatch%tau_l/tau_c) > 0.22_r8) then
-                  currentCohort%cambial_mort = (0.563_r8*(currentPatch%tau_l/tau_c)) - 0.125_r8
-                else
-                  currentCohort%cambial_mort = 0.0_r8
-                endif
-              end if
-            end if 
-            currentCohort => currentCohort%shorter
-          end do 
-        end if 
-      end if
-      currentPatch => currentPatch%younger
-    end do
-    
-  end subroutine cambial_damage_kill
-  
-  !---------------------------------------------------------------------------------------
-
-  subroutine post_fire_mortality(currentSite)
-
-    type(ed_site_type), intent(in), target :: currentSite
-    type(fates_patch_type),  pointer :: currentPatch
-    type(fates_cohort_type), pointer :: currentCohort
-
-    currentPatch => currentSite%oldest_patch
-    do while (associated(currentPatch)) 
-
-      if (currentPatch%nocomp_pft_label /= nocomp_bareground) then
-        if (currentPatch%fire == 1) then 
-          currentCohort => currentPatch%tallest
-          do while(associated(currentCohort))  
-            
-            currentCohort%fire_mort = 0.0_r8
-            currentCohort%crownfire_mort = 0.0_r8
-            
-            if (prt_params%woody(currentCohort%pft) == itrue) then
-              ! Equation 22 in Thonicke et al. 2010. 
-              currentCohort%crownfire_mort = EDPftvarcon_inst%crown_kill(currentCohort%pft)*currentCohort%fraction_crown_burned**3.0_r8
-              ! Equation 18 in Thonicke et al. 2010. 
-              currentCohort%fire_mort = max(0._r8,min(1.0_r8,currentCohort%crownfire_mort+currentCohort%cambial_mort- &
-                (currentCohort%crownfire_mort*currentCohort%cambial_mort)))  !joint prob.   
-              else
-                currentCohort%fire_mort = 0.0_r8
-            end if 
-            currentCohort => currentCohort%shorter
-          end do
-        end if 
-      end if 
-      currentPatch => currentPatch%younger
-    end do
-
-  end subroutine post_fire_mortality
-
-  ! ======================================================================================
   
 end module SFMainMod

--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -26,10 +26,7 @@ module SFMainMod
   use EDtypesMod,             only : AREA
   use FatesLitterMod,         only : litter_type
   use FatesFuelClassesMod,    only : num_fuel_classes
-  use PRTGenericMod,          only : leaf_organ
   use PRTGenericMod,          only : carbon12_element
-  use PRTGenericMod,          only : sapw_organ
-  use PRTGenericMod,          only : struct_organ
   use FatesInterfaceTypesMod, only : numpft
   use FatesAllometryMod,      only : CrownDepth
   use FatesFuelClassesMod,    only : fuel_classes

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(functional_testing/math_utils fates_math_ftest)
 add_subdirectory(functional_testing/fire/fuel fates_fuel_ftest)
 add_subdirectory(functional_testing/fire/ros fates_ros_ftest)
 add_subdirectory(functional_testing/patch fates_patch_ftest)
+add_subdirectory(functional_testing/fire/mortality fates_firemort_ftest)
 
 ## Unit tests
 add_subdirectory(unit_testing/fire_weather_test fates_fire_weather_utest)

--- a/testing/functional_testing/fire/mortality/CMakeLists.txt
+++ b/testing/functional_testing/fire/mortality/CMakeLists.txt
@@ -1,0 +1,24 @@
+set(fire_mortality_test_sources 
+            FatesTestFireMortality.F90)
+            
+set(NETCDF_C_DIR ${NETCDF_C_PATH})
+set(NETCDF_FORTRAN_DIR ${NETCDF_F_PATH})
+
+FIND_PATH(NETCDFC_FOUND libnetcdf.a ${NETCDF_C_DIR}/lib)
+FIND_PATH(NETCDFF_FOUND libnetcdff.a ${NETCDF_FORTRAN_DIR}/lib)
+
+include_directories(${NETCDF_C_DIR}/include
+                    ${NETCDF_FORTRAN_DIR}/include)
+
+link_directories(${NETCDF_C_DIR}/lib
+                ${NETCDF_FORTRAN_DIR}/lib
+                ${PFUNIT_TOP_DIR}/lib)
+                
+add_executable(FATES_firemort_exe ${fire_mortality_test_sources})
+
+target_link_libraries(FATES_firemort_exe
+                  netcdf
+                  netcdff
+                  fates
+                  csm_share
+                  funit)

--- a/testing/functional_testing/fire/mortality/FatesTestFireMortality.F90
+++ b/testing/functional_testing/fire/mortality/FatesTestFireMortality.F90
@@ -1,0 +1,316 @@
+program FatesTestFireMortality
+  
+  use FatesConstantsMod,           only : r8 => fates_r8
+  use FatesArgumentUtils,          only : command_line_arg
+  use FatesUnitTestParamReaderMod, only : fates_unit_test_param_reader
+  use PRTParametersMod,            only : prt_params
+  
+  implicit none
+  
+  ! LOCALS:
+  type(fates_unit_test_param_reader) :: param_reader     ! param reader instance
+  character(len=:), allocatable      :: param_file       ! input parameter file
+  real(r8),         allocatable      :: tree_diameter(:) ! tree diameter at breast height [cm]
+  real(r8),         allocatable      :: tau_c(:,:)       ! critical residence time for cambial death [min]
+  real(r8),         allocatable      :: mortality(:,:,:) ! probability of fire mortality
+  real(r8),         allocatable      :: crown_kill(:)    ! fraction of crown volume burned
+  real(r8),         allocatable      :: tau_r_out(:)     ! relative fire residence time
+  integer                            :: num_pfts         ! number of pfts (from parameter files)
+  
+  ! CONSTANTS:
+  character(len=*), parameter :: out_file = 'fire_mortality_out.nc' ! output file 
+  
+  interface
+
+    subroutine TestTauC(num_pfts, tree_diameter, tau_c)
+
+      use FatesConstantsMod, only : r8 => fates_r8 
+      use FatesConstantsMod, only : itrue
+      use SFEquationsMod,    only : CriticalResidenceTime, BarkThickness
+      use EDPftvarcon,       only : EDPftvarcon_inst
+      use PRTParametersMod,  only : prt_params
+      implicit none
+      integer,               intent(in)  :: num_pfts
+      real(r8), allocatable, intent(out) :: tree_diameter(:)                
+      real(r8), allocatable, intent(out) :: tau_c(:,:) 
+
+    end subroutine TestTauC
+    
+    subroutine TestMortalityProb(num_pfts, mortality, crown_kill, tau_r_out)
+      use FatesConstantsMod, only : r8 => fates_r8
+      use FatesConstantsMod, only : itrue
+      use SFEquationsMod,    only : CriticalResidenceTime, BarkThickness
+      use SFEquationsMod,    only : TotalFireMortality, CrownFireMortality
+      use SFEquationsMod,    only : cambial_mort
+      use EDPftvarcon,       only : EDPftvarcon_inst
+      use PRTParametersMod,  only : prt_params
+      implicit none
+      integer,               intent(in)  :: num_pfts         
+      real(r8), allocatable, intent(out) :: mortality(:,:,:) 
+      real(r8), allocatable, intent(out) :: crown_kill(:)
+      real(r8), allocatable, intent(out) :: tau_r_out(:)
+    end subroutine TestMortalityProb
+    
+    subroutine WriteFireMortData(out_file, num_pfts, tree_diameter, tau_c, mortality, &
+        crown_kill, tau_r_out)
+
+      use FatesConstantsMod,   only : r8 => fates_r8
+      use FatesUnitTestIOMod,  only : OpenNCFile, CloseNCFile, RegisterNCDims
+      use FatesUnitTestIOMod,  only : RegisterVar, EndNCDef, WriteVar
+      use FatesUnitTestIOMod,  only : type_double
+      implicit none
+      character(len=*), intent(in) :: out_file
+      integer,          intent(in) :: num_pfts
+      real(r8),         intent(in) :: tree_diameter(:)
+      real(r8),         intent(in) :: tau_c(:,:)
+      real(r8),         intent(in) :: mortality(:,:,:) 
+      real(r8),         intent(in) :: crown_kill(:)
+      real(r8),         intent(in) :: tau_r_out(:)
+
+    end subroutine WriteFireMortData
+
+  end interface
+  
+  ! read in parameter file name and DATM file from command line
+  param_file = command_line_arg(1)
+  
+  ! read in parameter file
+  call param_reader%Init(param_file)
+  call param_reader%RetrieveParameters()
+  num_pfts = size(prt_params%wood_density, dim=1)
+  
+  ! calculate propagating flux
+  call TestTauC(num_pfts, tree_diameter, tau_c)
+  
+  ! calculate total fire mortality
+  call TestMortalityProb(num_pfts, mortality, crown_kill, tau_r_out)
+  
+  ! write output data
+  call WriteFireMortData(out_file, num_pfts, tree_diameter, tau_c, mortality, &
+    crown_kill, tau_r_out)
+  
+  ! deallocate arrays
+  if (allocated(tree_diameter)) deallocate(tree_diameter)
+  if (allocated(tau_c)) deallocate(tau_c)
+  if (allocated(mortality)) deallocate(mortality)
+  if (allocated(crown_kill)) deallocate(crown_kill)
+  if (allocated(tau_r_out)) deallocate(tau_r_out)
+
+end program FatesTestFireMortality
+
+!=========================================================================================
+
+subroutine TestTauC(num_pfts, tree_diameter, tau_c)
+  !
+  ! DESCRIPTION:
+  ! Calculates critical time for cambial kill over a range of diameter values and pfts
+  !
+  use FatesConstantsMod, only : r8 => fates_r8
+  use FatesConstantsMod, only : itrue
+  use SFEquationsMod,    only : CriticalResidenceTime, BarkThickness
+  use EDPftvarcon,       only : EDPftvarcon_inst
+  use PRTParametersMod,  only : prt_params
+  
+  implicit none
+  
+  ! ARGUMENTS:
+  integer,               intent(in)  :: num_pfts         ! number of pfts
+  real(r8), allocatable, intent(out) :: tree_diameter(:) ! tree diameter at breast height [cm]
+  real(r8), allocatable, intent(out) :: tau_c(:,:)       ! critical fire residence time for cambial kill [min]
+
+  ! CONSTANTS:
+  real(r8), parameter :: dbh_min = 2.5_r8  ! minimum dbh to calculate [cm]
+  real(r8), parameter :: dbh_max = 60.0_r8 ! maximum dbh to calculate [cm]
+  real(r8), parameter :: dbh_inc = 1.0_r8  ! dbh increment to scale [cm]
+  
+  ! LOCALS:
+  real(r8) :: bark_thickness ! bark thickness [cm]
+  integer  :: num_dbh        ! size of dbh array
+  integer  :: i, j           ! looping indices
+  
+  ! allocate arrays
+  num_dbh = int((dbh_max - dbh_min)/dbh_inc + 1)
+  allocate(tree_diameter(num_dbh))
+  allocate(tau_c(num_dbh, num_pfts))
+  
+  do i = 1, num_dbh
+  
+    tree_diameter(i) = dbh_min + dbh_inc*(i-1)
+    
+    do j = 1, num_pfts
+      if (prt_params%woody(j) == itrue) then 
+        bark_thickness = BarkThickness(EDPftvarcon_inst%bark_scaler(j), tree_diameter(i))
+        tau_c(i,j) = CriticalResidenceTime(bark_thickness)
+      else 
+        tau_c(i,j) = 0.0_r8
+      end if
+    end do
+  end do
+
+end subroutine TestTauC
+
+!=========================================================================================
+
+subroutine TestMortalityProb(num_pfts, mortality, crown_kill, tau_r_out)
+  !
+  ! DESCRIPTION:
+  ! Calculates mortality probability for a range of values of fraction crown killed and 
+  ! relative residence time
+  !
+  use FatesConstantsMod, only : r8 => fates_r8
+  use FatesConstantsMod, only : itrue
+  use SFEquationsMod,    only : CriticalResidenceTime, BarkThickness
+  use SFEquationsMod,    only : TotalFireMortality, CrownFireMortality
+  use SFEquationsMod,    only : cambial_mort
+  use EDPftvarcon,       only : EDPftvarcon_inst
+  use PRTParametersMod,  only : prt_params
+  
+  implicit none
+  
+  ! ARGUMENTS:
+  integer,               intent(in)  :: num_pfts         ! number of pfts
+  real(r8), allocatable, intent(out) :: mortality(:,:,:) ! probability of fire mortality
+  real(r8), allocatable, intent(out) :: crown_kill(:)    ! fraction of crown volume burned
+  real(r8), allocatable, intent(out) :: tau_r_out(:)     ! relative fire residence times
+
+  ! CONSTANTS:
+  real(r8), parameter               :: mort_min = 0.0_r8  ! minimum mortality rate to calculate
+  real(r8), parameter               :: mort_max = 1.0_r8  ! maximum mortality rate to calculate
+  real(r8), parameter               :: mort_inc = 0.05_r8 ! mortality rates to scale
+  real(r8), parameter, dimension(5) :: tau_r = (/0.22_r8, 0.4_r8, 0.66_r8, 1.0_r8, 2.0_r8/) ! relative fire residence times
+  
+  ! LOCALS:
+  real(r8) :: crownfire_mort      ! crown fire mortality
+  real(r8) :: cambial_damage_mort ! cambial damage mortality
+  integer  :: num_mort            ! size of dbh array
+  integer  :: i, j, k             ! looping indices
+  
+  ! allocate arrays
+  num_mort = int((mort_max - mort_min)/mort_inc + 1)
+  allocate(mortality(num_mort, num_pfts, size(tau_r)))
+  allocate(crown_kill(num_mort))
+  allocate(tau_r_out(size(tau_r)))
+  
+  do i = 1, num_mort
+  
+    crown_kill(i) = mort_min + mort_inc*(i-1)
+    
+    do j = 1, num_pfts
+      do k = 1, size(tau_r)
+        tau_r_out(k) = tau_r(k)
+        
+        if (prt_params%woody(j) == itrue) then
+          cambial_damage_mort = cambial_mort(tau_r(k))
+          crownfire_mort = CrownFireMortality(EDPftvarcon_inst%crown_kill(j), crown_kill(i))
+          mortality(i,j,k) = TotalFireMortality(crownfire_mort, cambial_damage_mort)
+        else 
+          mortality(i,j,k) = 0.0_r8
+        end if
+      end do
+    end do
+  end do
+
+end subroutine TestMortalityProb
+
+!=========================================================================================
+
+subroutine WriteFireMortData(out_file, num_pfts, tree_diameter, tau_c, mortality, &
+  crown_kill, tau_r_out)
+  !
+  ! DESCRIPTION:
+  ! writes out data from the test
+  !
+  use FatesConstantsMod,  only : r8 => fates_r8
+  use FatesUnitTestIOMod, only : OpenNCFile, CloseNCFile, RegisterNCDims
+  use FatesUnitTestIOMod, only : RegisterVar, EndNCDef, WriteVar
+  use FatesUnitTestIOMod, only : type_double
+  
+  implicit none
+  
+  ! ARGUMENTS:
+  character(len=*), intent(in) :: out_file
+  integer,          intent(in) :: num_pfts
+  real(r8),         intent(in) :: tree_diameter(:)
+  real(r8),         intent(in) :: tau_c(:,:)
+  real(r8),         intent(in) :: mortality(:,:,:)
+  real(r8),         intent(in) :: crown_kill(:)
+  real(r8),         intent(in) :: tau_r_out(:)
+  
+  ! LOCALS:
+  integer, allocatable :: pft_indices(:) ! array of pft indices to write out
+  integer              :: ncid           ! netcdf id
+  character(len=20)    :: dim_names(4)   ! dimension names
+  integer              :: dimIDs(4)      ! dimension IDs
+  integer              :: i              ! looping index
+  integer              :: dbhID, pftID
+  integer              :: taurID
+  integer              :: taucID
+  integer              :: mortID, crownkillID
+  
+  ! dimension names
+  dim_names = [character(len=20) :: 'dbh', 'pft', 'crown_kill', 'tau_r']
+  
+  ! create pft indices
+  allocate(pft_indices(num_pfts))
+  do i = 1, num_pfts
+    pft_indices(i) = i
+  end do
+
+  ! open file
+  call OpenNCFile(trim(out_file), ncid, 'readwrite')
+
+  ! register dimensions
+  call RegisterNCDims(ncid, dim_names, (/size(tree_diameter), num_pfts, size(crown_kill), &
+    size(tau_r_out)/), size(dim_names), dimIDs)
+
+  ! first register dimension variables
+  
+  ! register dbh 
+  call RegisterVar(ncid, dim_names(1), dimIDs(1:1), type_double,   &
+    [character(len=20)  :: 'units', 'long_name'],                  &
+    [character(len=150) :: 'cm', 'diameter at breast height'], 2, dbhID)
+    
+  ! register pft
+  call RegisterVar(ncid, dim_names(2), dimIDs(2:2), type_double,     &
+    [character(len=20)  :: 'units', 'long_name'],                    &
+    [character(len=150) :: '', 'plant functional type'], 2, pftID)
+    
+  ! register crown kill
+  call RegisterVar(ncid, dim_names(3), dimIDs(3:3), type_double,     &
+    [character(len=20)  :: 'units', 'long_name'],                      &
+    [character(len=150) :: '', 'fraction crown volume burned'], 2, crownkillID)
+  
+  ! register tau_r
+  call RegisterVar(ncid, dim_names(4), dimIDs(4:4), type_double,     &
+    [character(len=20)  :: 'units', 'long_name'],                      &
+    [character(len=150) :: '', 'relative fire residence time'], 2, taurID)
+    
+  ! then register actual variables
+
+  ! register tau_c
+  call RegisterVar(ncid, 'tau_c', dimIDs(1:2), type_double,                                 &
+    [character(len=20)  :: 'coordinates', 'units', 'long_name'],                            &
+    [character(len=150) :: 'pft dbh', 'min', 'critical residence time for cambial death'],  &
+    3, taucID)
+    
+  ! register total mortality
+  call RegisterVar(ncid, 'total_mortality', (/dimIDs(3), dimIDs(2), dimIDs(4)/), type_double, &
+    [character(len=20)  :: 'coordinates', 'units', 'long_name'],              &
+    [character(len=150) :: 'crown_kill pft tau_r', '', 'fire mortality'],  &
+    3, mortID)
+      
+  ! finish defining variables
+  call EndNCDef(ncid)
+
+  ! write out data
+  call WriteVar(ncid, dbhID, tree_diameter(:))
+  call WriteVar(ncid, pftID, pft_indices(:))
+  call WriteVar(ncid, crownkillID, crown_kill(:))
+  call WriteVar(ncid, taurID, tau_r_out(:))
+  call WriteVar(ncid, taucID, tau_c(:,:))
+  call WriteVar(ncid, mortID, mortality(:,:,:))
+  
+  ! close file
+  call CloseNCFile(ncid)
+
+end subroutine WriteFireMortData

--- a/testing/functional_testing/fire/mortality/FatesTestFireMortality.F90
+++ b/testing/functional_testing/fire/mortality/FatesTestFireMortality.F90
@@ -8,14 +8,18 @@ program FatesTestFireMortality
   implicit none
   
   ! LOCALS:
-  type(fates_unit_test_param_reader) :: param_reader     ! param reader instance
-  character(len=:), allocatable      :: param_file       ! input parameter file
-  real(r8),         allocatable      :: tree_diameter(:) ! tree diameter at breast height [cm]
-  real(r8),         allocatable      :: tau_c(:,:)       ! critical residence time for cambial death [min]
-  real(r8),         allocatable      :: mortality(:,:,:) ! probability of fire mortality
-  real(r8),         allocatable      :: crown_kill(:)    ! fraction of crown volume burned
-  real(r8),         allocatable      :: tau_r_out(:)     ! relative fire residence time
-  integer                            :: num_pfts         ! number of pfts (from parameter files)
+  type(fates_unit_test_param_reader) :: param_reader               ! param reader instance
+  character(len=:), allocatable      :: param_file                 ! input parameter file
+  real(r8),         allocatable      :: tree_diameter(:)           ! tree diameter at breast height [cm]
+  real(r8),         allocatable      :: tau_c(:,:)                 ! critical residence time for cambial death [min]
+  real(r8),         allocatable      :: mortality(:,:,:)           ! probability of fire mortality
+  real(r8),         allocatable      :: crown_kill(:)              ! fraction of crown volume burned
+  real(r8),         allocatable      :: tau_r_out(:)               ! relative fire residence time
+  real(r8),         allocatable      :: fire_mortality_bySH(:, :)  ! total fire mortality probability (by SH)
+  real(r8),         allocatable      :: fire_mortality_bytau(:, :) ! total fire mortality probability (by tau)
+  real(r8),         allocatable      :: SH(:)                      ! scorch height [m]
+  real(r8),         allocatable      :: tau_l(:)                   ! residence time of fire [min]
+  integer                            :: num_pfts                   ! number of pfts (from parameter files)
   
   ! CONSTANTS:
   character(len=*), parameter :: out_file = 'fire_mortality_out.nc' ! output file 
@@ -51,8 +55,20 @@ program FatesTestFireMortality
       real(r8), allocatable, intent(out) :: tau_r_out(:)
     end subroutine TestMortalityProb
     
+    subroutine TestFireMortalitySensitivity(fire_mortality_bySH, fire_mortality_bytau, &
+        SH_out, tau_l_out)
+      use FatesConstantsMod, only : r8 => fates_r8
+      use SFEquationsMod,    only : CrownFractionBurnt, CambialMortality
+      use SFEquationsMod,    only : CrownFireMortality, TotalFireMortality
+      implicit none
+      real(r8), allocatable, intent(out) :: fire_mortality_bySH(:,:)
+      real(r8), allocatable, intent(out) :: fire_mortality_bytau(:,:)
+      real(r8), allocatable, intent(out) :: SH_out(:)
+      real(r8), allocatable, intent(out) :: tau_l_out(:)
+    end subroutine TestFireMortalitySensitivity
+    
     subroutine WriteFireMortData(out_file, num_pfts, tree_diameter, tau_c, mortality, &
-        crown_kill, tau_r_out)
+        crown_kill, tau_r_out, fire_mortality_bySH, SH, fire_mortality_bytau, tau_l)
 
       use FatesConstantsMod,   only : r8 => fates_r8
       use FatesUnitTestIOMod,  only : OpenNCFile, CloseNCFile, RegisterNCDims
@@ -66,6 +82,10 @@ program FatesTestFireMortality
       real(r8),         intent(in) :: mortality(:,:,:) 
       real(r8),         intent(in) :: crown_kill(:)
       real(r8),         intent(in) :: tau_r_out(:)
+      real(r8),         intent(in) :: fire_mortality_bySH(:,:)
+      real(r8),         intent(in) :: SH(:)
+      real(r8),         intent(in) :: fire_mortality_bytau(:,:)
+      real(r8),         intent(in) :: tau_l(:)
 
     end subroutine WriteFireMortData
 
@@ -85,18 +105,91 @@ program FatesTestFireMortality
   ! calculate total fire mortality
   call TestMortalityProb(num_pfts, mortality, crown_kill, tau_r_out)
   
+  ! test sensitivity to SH and cambial kill
+  call TestFireMortalitySensitivity(fire_mortality_bySH, fire_mortality_bytau, SH, tau_l)
+  
   ! write output data
   call WriteFireMortData(out_file, num_pfts, tree_diameter, tau_c, mortality, &
-    crown_kill, tau_r_out)
-  
+    crown_kill, tau_r_out, fire_mortality_bySH, SH, fire_mortality_bytau, tau_l)
+    
   ! deallocate arrays
   if (allocated(tree_diameter)) deallocate(tree_diameter)
   if (allocated(tau_c)) deallocate(tau_c)
   if (allocated(mortality)) deallocate(mortality)
   if (allocated(crown_kill)) deallocate(crown_kill)
   if (allocated(tau_r_out)) deallocate(tau_r_out)
+  if (allocated(fire_mortality_bySH)) deallocate(fire_mortality_bySH)
+  if (allocated(fire_mortality_bytau)) deallocate(fire_mortality_bytau)
+  if (allocated(SH)) deallocate(SH)
+  if (allocated(tau_l)) deallocate(tau_l)
 
 end program FatesTestFireMortality
+
+!=========================================================================================
+
+subroutine TestFireMortalitySensitivity(fire_mortality_bySH, fire_mortality_bytau, SH_out, &
+  tau_l_out)
+  !
+  ! DESCRIPTION:
+  ! Calculates fire mortality for some input tree characteristics and fire behaviors - based
+  ! on scorch height
+  !
+  use FatesConstantsMod, only : r8 => fates_r8
+  use SFEquationsMod,    only : CrownFractionBurnt, CambialMortality
+  use SFEquationsMod,    only : CrownFireMortality, TotalFireMortality
+  
+  implicit none
+  
+  ! ARGUMENTS:
+  real(r8), allocatable, intent(out) :: fire_mortality_bySH(:,:)  ! total fire mortality (by SH)
+  real(r8), allocatable, intent(out) :: fire_mortality_bytau(:,:) ! total fire mortality (by tau)
+  real(r8), allocatable, intent(out) :: SH_out(:)                 ! scorch height of tree [m]
+  real(r8), allocatable, intent(out) :: tau_l_out(:)              ! residence times of fire [min]
+  
+  ! LOCALS:
+  integer  :: i, j                  ! looping indices
+  real(r8) :: fraction_crown_burned ! fraction of the crown burned
+  real(r8) :: cambial_mort          ! cambial mortality
+  real(r8) :: bark_scaler           ! cm bark per cm dbh
+  real(r8) :: crownfire_mort        ! crown fire mortality
+  
+  ! CONSTANTS:
+  real(r8), parameter, dimension(3) :: SH = (/5.0_r8, 10.0_r8, 20.0_r8/)                                       ! scorch heights of fire [m]
+  real(r8), parameter, dimension(3) :: tau_l = (/2.4_r8, 3.1_r8, 6.0_r8/)                                      ! residence times of fire [min]
+  real(r8), parameter, dimension(6) :: dbh = (/20.0_r8, 40.0_r8, 20.0_r8, 40.0_r8, 20.0_r8, 40.0_r8/)          ! diameters of trees [cm]
+  real(r8), parameter, dimension(6) :: crown_length = (/12.0_r8, 18.5_r8, 13.5_r8, 23.1_r8, 11.9_r8, 18.2_r8/) ! crown depth of trees [m]
+  real(r8), parameter, dimension(6) :: bark_thickness = (/1.1_r8, 2.2_r8, 0.9_r8, 1.7_r8, 0.3_r8, 0.6_r8/)     ! bark thickness of trees [cm]
+  real(r8), parameter, dimension(6) :: height = (/15.5_r8, 24.4_r8, 17.4_r8, 30.7_r8, 15.1_r8, 24.1_r8/)       ! height of trees [m]
+  real(r8), parameter               :: crown_kill_parameter = 0.775_r8 ! parameter for crown kill
+  
+  allocate(fire_mortality_bySH(size(SH), size(dbh)))
+  allocate(fire_mortality_bytau(size(tau_l), size(dbh)))
+  allocate(SH_out(size(SH)))
+  allocate(tau_l_out(size(tau_l)))
+  
+  do i = 1, size(SH)
+    SH_out(i) = SH(i)
+    do j = 1, size(dbh)
+      bark_scaler = bark_thickness(j)/dbh(j)
+      fraction_crown_burned = CrownFractionBurnt(SH(i), height(j), crown_length(j))
+      cambial_mort = CambialMortality(bark_scaler, dbh(j), 6.0_r8)
+      crownfire_mort = CrownFireMortality(crown_kill_parameter, fraction_crown_burned)
+      fire_mortality_bySH(i,j) = TotalFireMortality(crownfire_mort, cambial_mort)
+    end do 
+  end do
+  
+  do i = 1, size(tau_l)
+    tau_l_out(i) = tau_l(i)
+    do j = 1, size(dbh)
+      bark_scaler = bark_thickness(j)/dbh(j)
+      fraction_crown_burned = CrownFractionBurnt(10.0_r8, height(j), crown_length(j))
+      cambial_mort = CambialMortality(bark_scaler, dbh(j), tau_l(i))
+      crownfire_mort = CrownFireMortality(crown_kill_parameter, fraction_crown_burned)
+      fire_mortality_bytau(i,j) = TotalFireMortality(crownfire_mort, cambial_mort)
+    end do 
+  end do
+  
+end subroutine TestFireMortalitySensitivity
 
 !=========================================================================================
 
@@ -215,7 +308,7 @@ end subroutine TestMortalityProb
 !=========================================================================================
 
 subroutine WriteFireMortData(out_file, num_pfts, tree_diameter, tau_c, mortality, &
-  crown_kill, tau_r_out)
+  crown_kill, tau_r_out, fire_mortality_bySH, SH, fire_mortality_bytau, tau_l)
   !
   ! DESCRIPTION:
   ! writes out data from the test
@@ -223,7 +316,7 @@ subroutine WriteFireMortData(out_file, num_pfts, tree_diameter, tau_c, mortality
   use FatesConstantsMod,  only : r8 => fates_r8
   use FatesUnitTestIOMod, only : OpenNCFile, CloseNCFile, RegisterNCDims
   use FatesUnitTestIOMod, only : RegisterVar, EndNCDef, WriteVar
-  use FatesUnitTestIOMod, only : type_double
+  use FatesUnitTestIOMod, only : type_double, type_int
   
   implicit none
   
@@ -235,25 +328,39 @@ subroutine WriteFireMortData(out_file, num_pfts, tree_diameter, tau_c, mortality
   real(r8),         intent(in) :: mortality(:,:,:)
   real(r8),         intent(in) :: crown_kill(:)
   real(r8),         intent(in) :: tau_r_out(:)
+  real(r8),         intent(in) :: fire_mortality_bySH(:,:)
+  real(r8),         intent(in) :: SH(:)
+  real(r8),         intent(in) :: fire_mortality_bytau(:,:)
+  real(r8),         intent(in) :: tau_l(:)
   
   ! LOCALS:
-  integer, allocatable :: pft_indices(:) ! array of pft indices to write out
-  integer              :: ncid           ! netcdf id
-  character(len=20)    :: dim_names(4)   ! dimension names
-  integer              :: dimIDs(4)      ! dimension IDs
-  integer              :: i              ! looping index
+  integer, allocatable :: pft_indices(:)  ! array of pft indices to write out
+  integer, allocatable :: tree_indices(:) ! array of tree indices to write out
+  integer              :: ncid            ! netcdf id
+  character(len=20)    :: dim_names(7)    ! dimension names
+  integer              :: dimIDs(7)       ! dimension IDs
+  integer              :: i               ! looping index
   integer              :: dbhID, pftID
   integer              :: taurID
   integer              :: taucID
   integer              :: mortID, crownkillID
+  integer              :: SHID, firemortbySHID
+  integer              :: treeID, firemortbytauID
+  integer              :: taulID
   
   ! dimension names
-  dim_names = [character(len=20) :: 'dbh', 'pft', 'crown_kill', 'tau_r']
+  dim_names = [character(len=20) :: 'dbh', 'pft', 'crown_kill', 'tau_r', 'SH', 'treeID', 'tau_l']
   
   ! create pft indices
   allocate(pft_indices(num_pfts))
   do i = 1, num_pfts
     pft_indices(i) = i
+  end do
+  
+  ! create tree indices
+  allocate(tree_indices(size(fire_mortality_bySH, dim=2)))
+  do i = 1, size(fire_mortality_bySH, dim=2)
+    tree_indices(i) = i
   end do
 
   ! open file
@@ -261,7 +368,7 @@ subroutine WriteFireMortData(out_file, num_pfts, tree_diameter, tau_c, mortality
 
   ! register dimensions
   call RegisterNCDims(ncid, dim_names, (/size(tree_diameter), num_pfts, size(crown_kill), &
-    size(tau_r_out)/), size(dim_names), dimIDs)
+    size(tau_r_out), size(SH), size(tree_indices), size(tau_l)/), size(dim_names), dimIDs)
 
   ! first register dimension variables
   
@@ -271,19 +378,34 @@ subroutine WriteFireMortData(out_file, num_pfts, tree_diameter, tau_c, mortality
     [character(len=150) :: 'cm', 'diameter at breast height'], 2, dbhID)
     
   ! register pft
-  call RegisterVar(ncid, dim_names(2), dimIDs(2:2), type_double,     &
-    [character(len=20)  :: 'units', 'long_name'],                    &
+  call RegisterVar(ncid, dim_names(2), dimIDs(2:2), type_int,      &
+    [character(len=20)  :: 'units', 'long_name'],                  &
     [character(len=150) :: '', 'plant functional type'], 2, pftID)
     
   ! register crown kill
   call RegisterVar(ncid, dim_names(3), dimIDs(3:3), type_double,     &
-    [character(len=20)  :: 'units', 'long_name'],                      &
+    [character(len=20)  :: 'units', 'long_name'],                    &
     [character(len=150) :: '', 'fraction crown volume burned'], 2, crownkillID)
   
   ! register tau_r
-  call RegisterVar(ncid, dim_names(4), dimIDs(4:4), type_double,     &
+  call RegisterVar(ncid, dim_names(4), dimIDs(4:4), type_double,       &
     [character(len=20)  :: 'units', 'long_name'],                      &
     [character(len=150) :: '', 'relative fire residence time'], 2, taurID)
+    
+  ! register scorch height
+  call RegisterVar(ncid, dim_names(5), dimIDs(5:5), type_double,       &
+    [character(len=20)  :: 'units', 'long_name'],                      &
+    [character(len=150) :: 'm', 'scorch height'], 2, SHID)
+    
+  ! register tree ids
+  call RegisterVar(ncid, dim_names(6), dimIDs(6:6), type_int,        &
+    [character(len=20)  :: 'units', 'long_name'],                    &
+    [character(len=150) :: '', 'tree indices'], 2, treeID)
+    
+  ! register tau_l
+  call RegisterVar(ncid, dim_names(7), dimIDs(7:7), type_double,     &
+    [character(len=20)  :: 'units', 'long_name'],                    &
+    [character(len=150) :: 'min', 'residence time of fire'], 2, taulID)
     
   ! then register actual variables
 
@@ -295,9 +417,22 @@ subroutine WriteFireMortData(out_file, num_pfts, tree_diameter, tau_c, mortality
     
   ! register total mortality
   call RegisterVar(ncid, 'total_mortality', (/dimIDs(3), dimIDs(2), dimIDs(4)/), type_double, &
-    [character(len=20)  :: 'coordinates', 'units', 'long_name'],              &
-    [character(len=150) :: 'crown_kill pft tau_r', '', 'fire mortality'],  &
+    [character(len=20)  :: 'coordinates', 'units', 'long_name'],                              &
+    [character(len=150) :: 'crown_kill pft tau_r', '', 'fire mortality'],                     &
     3, mortID)
+    
+  ! register total mortality
+  call RegisterVar(ncid, 'fire_mortality_bySH', (/dimIDs(5), dimIDs(6)/), type_double, &
+    [character(len=20)  :: 'coordinates', 'units', 'long_name'],                       &
+    [character(len=150) :: 'SH treeID', '', 'fire mortality by SH'],                         &
+    3, firemortbySHID)
+    
+  ! register total mortality
+  call RegisterVar(ncid, 'fire_mortality_bytau', (/dimIDs(7), dimIDs(6)/), type_double, &
+    [character(len=20)  :: 'coordinates', 'units', 'long_name'],                       &
+    [character(len=150) :: 'tau_l treeID', '', 'fire mortality by tau'],                         &
+    3, firemortbytauID)
+      
       
   ! finish defining variables
   call EndNCDef(ncid)
@@ -309,6 +444,11 @@ subroutine WriteFireMortData(out_file, num_pfts, tree_diameter, tau_c, mortality
   call WriteVar(ncid, taurID, tau_r_out(:))
   call WriteVar(ncid, taucID, tau_c(:,:))
   call WriteVar(ncid, mortID, mortality(:,:,:))
+  call WriteVar(ncid, SHID, SH(:))
+  call WriteVar(ncid, taulID, tau_l(:))
+  call WriteVar(ncid, treeID, tree_indices(:))
+  call WriteVar(ncid, firemortbySHID, fire_mortality_bySH(:,:))
+  call WriteVar(ncid, firemortbytauID, fire_mortality_bytau(:,:))
   
   ! close file
   call CloseNCFile(ncid)

--- a/testing/functional_testing/fire/mortality/fire_mortality_test.py
+++ b/testing/functional_testing/fire/mortality/fire_mortality_test.py
@@ -51,9 +51,6 @@ class FireMortTest(FunctionalTest):
         self.plot_tau_c(mortality_dat, obs_dat, save_figs, plot_dir)
         
     @staticmethod
-    
-    
-    @staticmethod
     def plot_tau_c(ds, obs_dat, save_figs, plot_dir):
         
         data_frame = pd.DataFrame({

--- a/testing/functional_testing/fire/mortality/fire_mortality_test.py
+++ b/testing/functional_testing/fire/mortality/fire_mortality_test.py
@@ -7,7 +7,7 @@ import xarray as xr
 import pandas as pd
 import matplotlib.pyplot as plt
 from functional_class import FunctionalTest
-from utils import blank_plot
+from utils import blank_plot, get_color_palette
 
 class FireMortTest(FunctionalTest):
     """Fire mortality test class"""
@@ -34,3 +34,173 @@ class FireMortTest(FunctionalTest):
             save_figs (bool): whether or not to save the figures
             plot_dir (str): plot directory
         """
+        
+        # get output file
+        mortality_dat = xr.open_dataset(os.path.join(run_dir, self.out_file))
+        
+        # observational datasets 
+        obs_dat, sh_obs, tau_obs = self.get_obs_dfs()
+        
+        # plot observational comparisons
+        self.bar_plot(mortality_dat, obs_dat, sh_obs, 'SH', 'fire_mortality_bySH', 
+                      'Scorch Height (m)', save_figs, plot_dir)
+        
+        self.bar_plot(mortality_dat, obs_dat, tau_obs, 'tau_l', 'fire_mortality_bytau', 
+                      'Fire Residence Time (min)', save_figs, plot_dir)
+        
+        self.plot_tau_c(mortality_dat, obs_dat, save_figs, plot_dir)
+        
+    @staticmethod
+    
+    
+    @staticmethod
+    def plot_tau_c(ds, obs_dat, save_figs, plot_dir):
+        
+        data_frame = pd.DataFrame({
+            "dbh": np.tile(ds.dbh, len(ds.pft)),
+            "pft": np.repeat(ds.pft, len(ds.dbh)),
+            'tau_c': ds.tau_c.values.flatten()})
+        
+        max_dbh = data_frame["dbh"].max()
+        max_tau = data_frame["tau_c"].max()
+        
+        blank_plot(max_dbh, 0.0, max_tau, 0.0, draw_horizontal_lines=True)
+        
+        pfts = np.unique(data_frame.pft.values)
+        colors = get_color_palette(len(pfts))
+        for rank, pft in enumerate(pfts):
+            dat = data_frame[data_frame.pft == pft]
+            plt.plot(
+                dat.dbh.values,
+                dat['tau_c'].values,
+                lw=2,
+                color=colors[rank],
+                label=pft,
+            )
+        plt.scatter(obs_dat.diameter, obs_dat.tau_c, c='black', label='observations')
+        plt.xlabel("DBH (cm)", fontsize=11)
+        plt.ylabel("Critical Fire Residence Time for Cambial Burning (min)", fontsize=11)
+        plt.title("Critical fire resdience time", fontsize=11)
+        plt.legend(loc="upper left", title="PFT")
+        if save_figs:
+            fig_name = os.path.join(plot_dir, f"tauc_plot.png")
+            plt.savefig(fig_name)
+        
+    @staticmethod
+    def bar_plot(ds: xr.Dataset, tree_obs: pd.DataFrame, mortality_obs: pd.DataFrame, 
+                 xvar: str, mortality_var: str, xlab: str, save_figs: bool, plot_dir: str):
+        """Plots a bar plot based on input dataframe
+
+        Args:
+            df (xr.Dataset): input dataset
+            tree_obs (pd.DataFrame): dataframe with observations about trees
+            mortality_obs (pd.DataFrame): dataframe with observations about tree mortality
+            xvar (str): variable to plot on x axis
+            mortality_var (str): mortality variable
+            xlab (str): xlabel
+            save_figs (bool): whether or not to save figures
+            plot_dir (str): where to save figures
+        """
+        
+        data_frame = pd.DataFrame({
+            "treeID": np.repeat(ds.treeID, len(ds[xvar])),
+            xvar: np.tile(ds[xvar], len(ds.treeID)),
+            'fire_mortality': ds[mortality_var].values.flatten()})
+        data_frame['type'] = 'modeled'
+        df = pd.concat([data_frame, mortality_obs])
+        df = df.merge(tree_obs, on='treeID', how='inner')
+        
+        fig, axes = plt.subplots(nrows=2, ncols=3, figsize=(12, 6), sharey=True)
+        axes = axes.flatten()
+
+        bar_width = 0.3
+
+        # unique values for x-axis
+        x_values = np.unique(df[xvar])
+        x = np.arange(len(x_values))
+
+        legend_handles = []
+
+        # loop over unique treeIDs and create subplots
+        for i, treeID in enumerate(np.unique(df.treeID)):
+            
+            # extract data for this tree
+            dat = df[df.treeID == treeID]  
+
+            # extract modeled and observed fire mortality
+            modeled = dat[dat['type'] == 'modeled']
+            observed = dat[dat['type'] == 'observations']
+
+            # plot bars side-by-side
+            bars1 = axes[i].bar(x - bar_width/2, (modeled.fire_mortality)*100.0, 
+                                width=bar_width, label='Modeled', color='blue')
+            bars2 = axes[i].bar(x + bar_width/2, (observed.fire_mortality)*100.0, 
+                                width=bar_width, label='Observed', color='orange')
+            if i == 0:
+                legend_handles.extend([bars1[0], bars2[0]])
+
+            # for printing
+            tree_dbh = observed.diameter.values[0]
+            crown_length = observed.crown_length.values[0]
+            height = observed.height.values[0]
+            bark_thickness = observed.bark_thickness.values[0]
+            
+            # formatting
+            axes[i].set_title(f"dbh: {tree_dbh} cm\nheight: {height} m\ncrown length: {crown_length} m\nbark thickness: {bark_thickness} cm")
+            axes[i].set_xticks(x)
+            axes[i].set_xticklabels(x_values) 
+            axes[i].set_xlabel(xlab)
+            axes[i].set_ylabel('Fire Mortality')
+
+        fig.legend(legend_handles, ['Modeled', 'Observed'], loc='upper center', 
+                   bbox_to_anchor=(0.5, 1.05), ncol=2)
+        plt.tight_layout()
+        if save_figs:
+            fig_name = os.path.join(plot_dir, f"{xvar}_plot.png")
+            plt.savefig(fig_name)
+
+    
+    @staticmethod
+    def get_obs_dfs():
+        """Return some hard-coded observational datasets
+        Peterson & Ryan 1986 Environmental Management: 10(6)
+
+        Returns:
+            tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]: output plots
+        """
+        
+        obs_dat = pd.DataFrame({'species': ['douglas-fir', 'douglas-fir',
+                                    'grand fir', 'grand fir',
+                                    'subalpine fir', 'subalpine fir'],
+                        'treeID': [1, 2, 3, 4, 5, 6],
+                        'diameter': [20.0, 40.0, 20.0, 40.0, 20.0, 40.0],
+                        'height': [15.5, 24.4, 17.4, 30.7, 15.1, 24.1],
+                        'crown_length': [12.0, 18.5, 13.5, 23.1, 11.9, 18.2],
+                        'bark_thickness': [1.1, 2.2, 0.9, 1.7, 0.3, 0.6],
+                        'tau_c': [3.2, 13.4, 2.1, 8.3, 0.3, 1.0]})
+        
+        sh_obs = pd.DataFrame({'fire_mortality': [0.94, 0.0, 1.0, 0.0, 1.0, 1.0,
+                                          0.99, 0.03, 1.0, 0.13, 1.0, 1.0,
+                                          1.0, 0.72, 1.0, 0.71, 1.0, 1.0],
+                      'SH': [5.0, 5.0, 5.0, 5.0, 5.0, 5.0,
+                             10.0, 10.0, 10.0, 10.0, 10.0, 10.0,
+                             20.0, 20.0, 20.0, 20.0, 20.0, 20.0],
+                      'treeID': [1, 2, 3, 4, 5, 6,
+                                1, 2, 3, 4, 5, 6,
+                                1, 2, 3, 4, 5, 6]})
+        sh_obs['type'] = 'observations'
+        
+        tau_obs = pd.DataFrame({'fire_mortality': [0.74, 0.0, 0.82, 0.0, 1.0, 1.0,
+                                          0.83, 0.0, 0.9, 0.01, 1.0, 1.0,
+                                          0.99, 0.03, 1.0, 0.13, 1.0, 1.0],
+                      'tau_l': [2.4, 2.4, 2.4, 2.4, 2.4, 2.4,
+                             3.1, 3.1, 3.1, 3.1, 3.1, 3.1,
+                             6, 6, 6, 6, 6, 6],
+                      'treeID': [1, 2, 3, 4, 5, 6,
+                                1, 2, 3, 4, 5, 6,
+                                1, 2, 3, 4, 5, 6]})
+        tau_obs['type'] = 'observations'
+        
+        return obs_dat, sh_obs, tau_obs
+        
+    

--- a/testing/functional_testing/fire/mortality/fire_mortality_test.py
+++ b/testing/functional_testing/fire/mortality/fire_mortality_test.py
@@ -1,0 +1,36 @@
+"""
+Concrete class for running the ros functional test for FATES.
+"""
+import os
+import numpy as np
+import xarray as xr
+import pandas as pd
+import matplotlib.pyplot as plt
+from functional_class import FunctionalTest
+from utils import blank_plot
+
+class FireMortTest(FunctionalTest):
+    """Fire mortality test class"""
+
+    name = "fire_mortality"
+
+    def __init__(self, test_dict):
+        super().__init__(
+            FireMortTest.name,
+            test_dict["test_dir"],
+            test_dict["test_exe"],
+            test_dict["out_file"],
+            test_dict["use_param_file"],
+            test_dict["other_args"],
+        )
+        self.plot = True
+
+    def plot_output(self, run_dir: str, save_figs: bool, plot_dir: str):
+        """Plot output associated with fuel tests
+
+        Args:
+            run_dir (str): run directory
+            out_file (str): output file
+            save_figs (bool): whether or not to save the figures
+            plot_dir (str): plot directory
+        """

--- a/testing/functional_testing/math_utils/FatesTestMathUtils.F90
+++ b/testing/functional_testing/math_utils/FatesTestMathUtils.F90
@@ -15,6 +15,7 @@ program FatesTestQuadSolvers
   real(r8) :: a(n), b(n), c(n) ! coefficients for quadratic solvers
   real(r8) :: root1(n)         ! real part of first root of quadratic solver
   real(r8) :: root2(n)         ! real part of second root of quadratic solver
+  logical  :: err              ! error
 
   interface
 
@@ -42,7 +43,7 @@ program FatesTestQuadSolvers
   c = (/1.0_r8, 12.0_r8, 3.0_r8, 1.1_r8/)
 
   do i = 1, n
-    call QuadraticRootsNSWC(a(i), b(i), c(i), root1(i), root2(i))
+    call QuadraticRootsNSWC(a(i), b(i), c(i), root1(i), root2(i), err)
   end do
 
   call WriteQuadData(out_file, n, a, b, c, root1, root2)

--- a/testing/functional_tests.cfg
+++ b/testing/functional_tests.cfg
@@ -32,3 +32,10 @@ test_exe = FATES_patch_exe
 out_file = None
 use_param_file = True
 other_args = []
+
+[fire_mortality]
+test_dir = fates_firemort_ftest
+test_exe = FATES_firemort_exe
+out_file = fire_mortality_out.nc
+use_param_file = True
+other_args = []

--- a/testing/load_functional_tests.py
+++ b/testing/load_functional_tests.py
@@ -6,3 +6,4 @@ from functional_testing.math_utils.math_utils_test import QuadraticTest
 from functional_testing.fire.fuel.fuel_test import FuelTest 
 from functional_testing.fire.ros.ros_test import ROSTest  
 from functional_testing.patch.patch_test import PatchTest
+from functional_testing.fire.mortality.fire_mortality_test import FireMortTest

--- a/testing/testing_shr/FatesFactoryMod.F90
+++ b/testing/testing_shr/FatesFactoryMod.F90
@@ -7,6 +7,7 @@ module FatesFactoryMod
   use FatesConstantsMod,           only : isemi_stress_decid
   use FatesConstantsMod,           only : primaryland
   use FatesConstantsMod,           only : sec_per_day, days_per_year
+  use FatesConstantsMod,           only : default_regeneration
   use FatesGlobals,                only : fates_log
   use FatesGlobals,                only : endrun => fates_endrun
   use FatesCohortMod,              only : fates_cohort_type
@@ -55,7 +56,7 @@ module FatesFactoryMod
   use FatesInterfaceTypesMod,      only : hlm_parteh_mode
   use FatesInterfaceTypesMod,      only : nleafage
   use FatesSizeAgeTypeIndicesMod,  only : get_age_class_index
-  use EDParamsMod,                 only : regeneration_model
+  use FatesInterfaceTypesMod,      only : hlm_regeneration_model
   use SyntheticPatchTypes,         only : synthetic_patch_type
   use shr_log_mod,                 only : errMsg => shr_log_errMsg
 
@@ -106,6 +107,8 @@ module FatesFactoryMod
     do i = 1, nlevleaf
       dlower_vai(i) = sum(dinc_vai(1:i))
     end do
+    
+    hlm_regeneration_model = default_regeneration
         
   end subroutine InitializeGlobals
   
@@ -435,7 +438,7 @@ module FatesFactoryMod
     
     allocate(patch)
     call patch%Create(age, area, land_use_label_local, nocomp_pft_local, num_swb,        &
-      num_pft, num_levsoil, tod_local, regeneration_model)
+      num_pft, num_levsoil, tod_local, hlm_regeneration_model)
     
     patch%patchno = 1
     patch%younger => null()

--- a/testing/testing_shr/FatesUnitTestIOMod.F90
+++ b/testing/testing_shr/FatesUnitTestIOMod.F90
@@ -25,6 +25,7 @@ module FatesUnitTestIOMod
   interface WriteVar
     module procedure WriteVar1DReal
     module procedure WriteVar2DReal
+    module procedure WriteVar3DReal
     module procedure WriteVar1DInt
     module procedure WriteVar2DInt
     module procedure WriteVar1DChar
@@ -539,6 +540,24 @@ module FatesUnitTestIOMod
     call Check(nf90_put_var(ncid, varID, data(:,:)))
 
   end subroutine WriteVar2DReal
+  
+  
+  !  =====================================================================================
+
+  subroutine WriteVar3DReal(ncid, varID, data)
+    !
+    ! DESCRIPTION:
+    ! Write 2D real data
+    !
+
+    ! ARGUMENTS:
+    integer,  intent(in) :: ncid        ! netcdf file id
+    integer,  intent(in) :: varID       ! variable ID
+    real(r8), intent(in) :: data(:,:,:) ! data to write
+
+    call Check(nf90_put_var(ncid, varID, data(:,:,:)))
+
+  end subroutine WriteVar3DReal
 
   !  =====================================================================================
 

--- a/testing/unit_testing/fire_equations_test/test_FireEquations.pf
+++ b/testing/unit_testing/fire_equations_test/test_FireEquations.pf
@@ -988,4 +988,178 @@ module test_FireEquations
       
     end subroutine CrownFractionBurnt_ScorchHeightLow_ReturnsLessThanOne
     
+    @Test 
+    subroutine BarkThickness_NegativeBT_Errors(this)
+      ! test that if the bark thickness is negative, the function errors
+      class(TestFireEquations), intent(inout) :: this                  ! test object
+      real(r8)                                :: BT                    ! bark thickness [cm]
+      real(r8),                 parameter     :: bark_scalar = 0.01_r8 ! input bark scalar parameter
+      real(r8),                 parameter     :: dbh = -10.0_r8        ! diameter at breast height [cm]
+      character(len=:),         allocatable   :: expected_msg          ! expected error message for failure
+      
+      expected_msg = endrun_msg("bark thickness is negative")
+      
+      BT = BarkThickness(bark_scalar, dbh)
+      @assertExceptionRaised(expected_msg)
+      
+    end subroutine BarkThickness_NegativeBT_Errors
+    
+    @Test 
+    subroutine CambialMortality_TauRGreaterThanTwo_ReturnsOne(this)
+      ! test that the function returns 1.0 if tau_r >= 2.0
+      class(TestFireEquations), intent(inout) :: this                  ! test object
+      real(r8)                                :: CM                    ! cambial mortality [0-1]
+      real(r8),                 parameter     :: bark_scalar = 0.01_r8 ! input bark scalar parameter
+      real(r8),                 parameter     :: dbh = 10.0_r8         ! input tree diameter at breast height [cm]
+      real(r8),                 parameter     :: tau_l = 5.0_r8        ! input fire residence time [min]
+      
+      CM = CambialMortality(bark_scalar, dbh, tau_l)
+      @assertEqual(CF, 1.0_r8)
+      
+    end subroutine CambialMortality_TauRGreaterThanTwo_ReturnsOne
+      
+    @Test 
+    subroutine CambialMortality_TaulZero_ReturnsZero(this)
+      ! test that the function returns 0.0 if tau_l is zero
+      class(TestFireEquations), intent(inout) :: this                  ! test object
+      real(r8)                                :: CM                    ! cambial mortality [0-1]
+      real(r8),                 parameter     :: bark_scalar = 0.1_r8  ! input bark scalar parameter
+      real(r8),                 parameter     :: dbh = 10.0_r8         ! input tree diameter at breast height [cm]
+      real(r8),                 parameter     :: tau_l = 0.0_r8        ! input fire residence time [min]
+      
+      CM = CambialMortality(bark_scalar, dbh, tau_l)
+      @assertEqual(CF, 0.0_r8)
+      
+    end subroutine CambialMortality_TaulZero_ReturnsZero
+    
+    @Test 
+    subroutine CrownFireMortality_ZeroFractionBurned_ReturnsZero(this)
+      ! test that the function returns 0.0 if fraction_crown_burned is 0.0
+      class(TestFireEquations), intent(inout) :: this                        ! test object
+      real(r8)                                :: CM                          ! crown fire mortality [0-1]
+      real(r8),                 parameter     :: crown_kill = 0.1_r8         ! input crown kill parameter
+      real(r8),                 parameter     :: fraction_crown_burned = 0.0 ! input fraction burned [0-1]
+      
+      CM = CrownFireMortality(crown_kill, fraction_crown_burned)
+      @assertEqual(CF, 0.0_r8)
+      
+    end subroutine CrownFireMortality_ZeroFractionBurned_ReturnsZero
+    
+    @Test 
+    subroutine CrownFireMortality_FractionBurnedOne_ReturnsCrownKill(this)
+      ! test that the function returns crown_kill if fraction_crown_burned is 1.0
+      class(TestFireEquations), intent(inout) :: this                        ! test object
+      real(r8)                                :: CM                          ! crown fire mortality [0-1]
+      real(r8),                 parameter     :: crown_kill = 0.1_r8         ! input crown kill parameter
+      real(r8),                 parameter     :: fraction_crown_burned = 1.0 ! input fraction burned [0-1]
+      
+      CM = CrownFireMortality(crown_kill, fraction_crown_burned)
+      @assertEqual(CF, crown_kill)
+      
+    end subroutine CrownFireMortality_FractionBurnedOne_ReturnsCrownKill
+    
+    @Test 
+    subroutine CrownFireMortality_HighCrownKill_ReturnsOne(this)
+      ! test that the function returns 1.0 even if crown_kill is higher than 1.0
+      class(TestFireEquations), intent(inout) :: this                           ! test object
+      real(r8)                                :: CM                             ! crown fire mortality [0-1]
+      real(r8),                 parameter     :: crown_kill = 1.5_r8            ! input crown kill parameter
+      real(r8),                 parameter     :: fraction_crown_burned = 0.5_r8 ! input fraction burned [0-1]
+      
+      CM = CrownFireMortality(crown_kill, fraction_crown_burned)
+      @assertEqual(CF, 1.0_r8)
+      
+    end subroutine CrownFireMortality_HighCrownKill_ReturnsOne
+    
+    @Test 
+    subroutine TotalFireMortality_ReasonableValues_ReturnsReasonable(this)
+      ! test that the function returns correct values given reasonable inputs
+      class(TestFireEquations), intent(inout) :: this                         ! test object
+      real(r8)                                :: TM                           ! total fire mortality [0-1]
+      real(r8),                 parameter     :: crownfire_mort = 0.4_r8      ! input crown kill parameter
+      real(r8),                 parameter     :: cambial_damage_mort = 0.3_r8 ! input fraction burned [0-1]
+      
+      TM = TotalFireMortality(crownfire_mort, cambial_damage_mort)
+      @assertEqual(CF, 0.58_r8)
+      
+    end subroutine TotalFireMortality_ReasonableValues_ReturnsReasonable
+    
+    @Test 
+    subroutine TotalFireMortality_ZeroInputs_ReturnsZero(this)
+      ! test that the function returns zero if both input mortality rates are 0.0
+      class(TestFireEquations), intent(inout) :: this                         ! test object
+      real(r8)                                :: TM                           ! total fire mortality [0-1]
+      real(r8),                 parameter     :: crownfire_mort = 0.0_r8      ! input crown kill parameter
+      real(r8),                 parameter     :: cambial_damage_mort = 0.0_r8 ! input fraction burned [0-1]
+      
+      TM = TotalFireMortality(crownfire_mort, cambial_damage_mort)
+      @assertEqual(CF, 0.0_r8)
+      
+    end subroutine TotalFireMortality_ZeroInputs_ReturnsZero
+    
+    @Test 
+    subroutine TotalFireMortality_OneInputs_ReturnsOne(this)
+      ! test that the function returns one if both input mortality rates are 1.0
+      class(TestFireEquations), intent(inout) :: this                         ! test object
+      real(r8)                                :: TM                           ! total fire mortality [0-1]
+      real(r8),                 parameter     :: crownfire_mort = 1.0_r8      ! input crown kill parameter
+      real(r8),                 parameter     :: cambial_damage_mort = 1.0_r8 ! input fraction burned [0-1]
+      
+      TM = TotalFireMortality(crownfire_mort, cambial_damage_mort)
+      @assertEqual(CF, 1.0_r8)
+      
+    end subroutine TotalFireMortality_OneInputs_ReturnOne
+    
+    @Test 
+    subroutine TotalFireMortality_ZeroCrownFire_ReturnsCambial(this)
+      ! test that the function returns cambial_damage_mort if crownfire_mort = 0.0
+      class(TestFireEquations), intent(inout) :: this                         ! test object
+      real(r8)                                :: TM                           ! total fire mortality [0-1]
+      real(r8),                 parameter     :: crownfire_mort = 0.0_r8      ! input crown kill parameter
+      real(r8),                 parameter     :: cambial_damage_mort = 0.3_r8 ! input fraction burned [0-1]
+      
+      TM = TotalFireMortality(crownfire_mort, cambial_damage_mort)
+      @assertEqual(CF, cambial_damage_mort)
+      
+    end subroutine TotalFireMortality_ZeroCrownFire_ReturnsCambial
+    
+    @Test 
+    subroutine TotalFireMortality_ZeroCambial_ReturnsCrownFire(this)
+      ! test that the function returns crownfire_mort if cambial_damage_mort = 0.0
+      class(TestFireEquations), intent(inout) :: this                         ! test object
+      real(r8)                                :: TM                           ! total fire mortality [0-1]
+      real(r8),                 parameter     :: crownfire_mort = 0.4_r8      ! input crown kill parameter
+      real(r8),                 parameter     :: cambial_damage_mort = 0.0_r8 ! input fraction burned [0-1]
+      
+      TM = TotalFireMortality(crownfire_mort, cambial_damage_mort)
+      @assertEqual(CF, crownfire_mort)
+      
+    end subroutine TotalFireMortality_ZeroCambial_ReturnsCrownFire
+    
+    @Test 
+    subroutine TotalFireMortality_OverOneMort_ReturnsOne(this)
+      ! test that the function correctly caps mortality rate at 1.0
+      class(TestFireEquations), intent(inout) :: this                         ! test object
+      real(r8)                                :: TM                           ! total fire mortality [0-1]
+      real(r8),                 parameter     :: crownfire_mort = 1.4_r8      ! input crown kill parameter
+      real(r8),                 parameter     :: cambial_damage_mort = 1.4_r8 ! input fraction burned [0-1]
+      
+      TM = TotalFireMortality(crownfire_mort, cambial_damage_mort)
+      @assertEqual(CF, 1.0_r8)
+      
+    end subroutine TotalFireMortality_OverOneMort_ReturnsOne
+    
+    @Test 
+    subroutine TotalFireMortality_NegativeMortality_ReturnsZero(this)
+      ! test that the function correctly gives zero if somehow mortality rates are negative
+      class(TestFireEquations), intent(inout) :: this                          ! test object
+      real(r8)                                :: TM                            ! total fire mortality [0-1]
+      real(r8),                 parameter     :: crownfire_mort = -1.4_r8      ! input crown kill parameter
+      real(r8),                 parameter     :: cambial_damage_mort = -1.4_r8 ! input fraction burned [0-1]
+      
+      TM = TotalFireMortality(crownfire_mort, cambial_damage_mort)
+      @assertEqual(CF, 0.0_r8)
+      
+    end subroutine TotalFireMortality_NegativeMortality_ReturnsZero
+    
 end module test_FireEquations

--- a/testing/unit_testing/fire_equations_test/test_FireEquations.pf
+++ b/testing/unit_testing/fire_equations_test/test_FireEquations.pf
@@ -5,6 +5,7 @@ module test_FireEquations
   !
   use FatesConstantsMod,   only : r8 => fates_r8
   use FatesConstantsMod,   only : nearzero
+  use FatesUnitTestUtils,  only : endrun_msg
   use SFEquationsMod
   use funit
 
@@ -877,19 +878,6 @@ module test_FireEquations
     end subroutine FireSize_ZeroROS_ReturnsZero
     
     @Test 
-    subroutine ScorchHeight_BasicInputs_ReturnsReasonable(this)
-      ! test that the function correctly calculates scorch height for reasonable inputs
-      class(TestFireEquations), intent(inout) :: this              ! test object
-      real(r8)                                :: SH                ! sorch height [m]
-      real(r8),                 parameter     :: alpha_SH = 0.5_r8 ! input alpha_SH parameter
-      real(r8),                 parameter     :: FI = 1000.0_r8    ! input fire intensity [kW/m]
-      
-      SH = ScorchHeight(alpha_SH, FI)
-      @assertEqual(SH, 50.11526_r8, tolerance=low_tol)
-      
-    end subroutine ScorchHeight_BasicInputs_ReturnsReasonable
-    
-    @Test 
     subroutine ScorchHeight_FIZero_ReturnsZero(this)
       ! test that if fire intensity is zero, scorch height is zero
       class(TestFireEquations), intent(inout) :: this              ! test object
@@ -916,20 +904,17 @@ module test_FireEquations
     end subroutine ScorchHeight_AlphaZero_ReturnsZero
     
     @Test 
-    subroutine ScorchHeight_NegativeSH_Errors(this)
-      ! test that if the scorch height is negative, the function errors
+    subroutine ScorchHeight_FINegative_ReturnsZero(this)
+      ! test that if fire intensity is negative, scorch height is zero
       class(TestFireEquations), intent(inout) :: this              ! test object
       real(r8)                                :: SH                ! sorch height [m]
       real(r8),                 parameter     :: alpha_SH = 0.5_r8 ! input alpha_SH parameter
       real(r8),                 parameter     :: FI = -1000.0_r8   ! input fire intensity [kW/m]
-      character(len=:),         allocatable   :: expected_msg      ! expected error message for failure
-      
-      expected_msg = endrun_msg("scorch height is negative")
       
       SH = ScorchHeight(alpha_SH, FI)
-      @assertExceptionRaised(expected_msg)
+      @assertEqual(SH, 0.0_r8)
       
-    end subroutine ScorchHeight_NegativeSH_Errors
+    end subroutine ScorchHeight_FINegative_ReturnsZero
     
     @Test 
     subroutine CrownFractionBurnt_BasicInputs_CapsAtOne(this)
@@ -983,8 +968,8 @@ module test_FireEquations
       real(r8),                 parameter     :: crown_depth = 2.0_r8 ! input crown depth [m]
       
       CF = CrownFractionBurnt(SH, height, crown_depth)
-      @assertGreaterThanOrEqualTo(CF, 0.0_r8)
-      @assertLessThanOrEqualTo(CF, 1.0_r8)
+      @assertGreaterThanOrEqual(CF, 0.0_r8)
+      @assertLessThanOrEqual(CF, 1.0_r8)
       
     end subroutine CrownFractionBurnt_ScorchHeightLow_ReturnsLessThanOne
     
@@ -1014,7 +999,7 @@ module test_FireEquations
       real(r8),                 parameter     :: tau_l = 5.0_r8        ! input fire residence time [min]
       
       CM = CambialMortality(bark_scalar, dbh, tau_l)
-      @assertEqual(CF, 1.0_r8)
+      @assertEqual(CM, 1.0_r8)
       
     end subroutine CambialMortality_TauRGreaterThanTwo_ReturnsOne
       
@@ -1028,7 +1013,7 @@ module test_FireEquations
       real(r8),                 parameter     :: tau_l = 0.0_r8        ! input fire residence time [min]
       
       CM = CambialMortality(bark_scalar, dbh, tau_l)
-      @assertEqual(CF, 0.0_r8)
+      @assertEqual(CM, 0.0_r8)
       
     end subroutine CambialMortality_TaulZero_ReturnsZero
     
@@ -1041,7 +1026,7 @@ module test_FireEquations
       real(r8),                 parameter     :: fraction_crown_burned = 0.0 ! input fraction burned [0-1]
       
       CM = CrownFireMortality(crown_kill, fraction_crown_burned)
-      @assertEqual(CF, 0.0_r8)
+      @assertEqual(CM, 0.0_r8)
       
     end subroutine CrownFireMortality_ZeroFractionBurned_ReturnsZero
     
@@ -1054,20 +1039,20 @@ module test_FireEquations
       real(r8),                 parameter     :: fraction_crown_burned = 1.0 ! input fraction burned [0-1]
       
       CM = CrownFireMortality(crown_kill, fraction_crown_burned)
-      @assertEqual(CF, crown_kill)
+      @assertEqual(CM, crown_kill)
       
     end subroutine CrownFireMortality_FractionBurnedOne_ReturnsCrownKill
     
     @Test 
     subroutine CrownFireMortality_HighCrownKill_ReturnsOne(this)
-      ! test that the function returns 1.0 even if crown_kill is higher than 1.0
+      ! test that the function returns 1.0 even if crown_kill is very high
       class(TestFireEquations), intent(inout) :: this                           ! test object
       real(r8)                                :: CM                             ! crown fire mortality [0-1]
-      real(r8),                 parameter     :: crown_kill = 1.5_r8            ! input crown kill parameter
+      real(r8),                 parameter     :: crown_kill = 10.0_r8           ! input crown kill parameter
       real(r8),                 parameter     :: fraction_crown_burned = 0.5_r8 ! input fraction burned [0-1]
       
       CM = CrownFireMortality(crown_kill, fraction_crown_burned)
-      @assertEqual(CF, 1.0_r8)
+      @assertEqual(CM, 1.0_r8)
       
     end subroutine CrownFireMortality_HighCrownKill_ReturnsOne
     
@@ -1076,11 +1061,11 @@ module test_FireEquations
       ! test that the function returns correct values given reasonable inputs
       class(TestFireEquations), intent(inout) :: this                         ! test object
       real(r8)                                :: TM                           ! total fire mortality [0-1]
-      real(r8),                 parameter     :: crownfire_mort = 0.4_r8      ! input crown kill parameter
+      real(r8),                 parameter     :: crownfire_mort = 0.4_r8      ! crown fire mortality [0-1]
       real(r8),                 parameter     :: cambial_damage_mort = 0.3_r8 ! input fraction burned [0-1]
       
       TM = TotalFireMortality(crownfire_mort, cambial_damage_mort)
-      @assertEqual(CF, 0.58_r8)
+      @assertEqual(TM, 0.58_r8)
       
     end subroutine TotalFireMortality_ReasonableValues_ReturnsReasonable
     
@@ -1089,11 +1074,11 @@ module test_FireEquations
       ! test that the function returns zero if both input mortality rates are 0.0
       class(TestFireEquations), intent(inout) :: this                         ! test object
       real(r8)                                :: TM                           ! total fire mortality [0-1]
-      real(r8),                 parameter     :: crownfire_mort = 0.0_r8      ! input crown kill parameter
+      real(r8),                 parameter     :: crownfire_mort = 0.0_r8      ! crown fire mortality [0-1]
       real(r8),                 parameter     :: cambial_damage_mort = 0.0_r8 ! input fraction burned [0-1]
       
       TM = TotalFireMortality(crownfire_mort, cambial_damage_mort)
-      @assertEqual(CF, 0.0_r8)
+      @assertEqual(TM, 0.0_r8)
       
     end subroutine TotalFireMortality_ZeroInputs_ReturnsZero
     
@@ -1102,24 +1087,24 @@ module test_FireEquations
       ! test that the function returns one if both input mortality rates are 1.0
       class(TestFireEquations), intent(inout) :: this                         ! test object
       real(r8)                                :: TM                           ! total fire mortality [0-1]
-      real(r8),                 parameter     :: crownfire_mort = 1.0_r8      ! input crown kill parameter
+      real(r8),                 parameter     :: crownfire_mort = 1.0_r8      ! crown fire mortality [0-1]
       real(r8),                 parameter     :: cambial_damage_mort = 1.0_r8 ! input fraction burned [0-1]
       
       TM = TotalFireMortality(crownfire_mort, cambial_damage_mort)
-      @assertEqual(CF, 1.0_r8)
+      @assertEqual(TM, 1.0_r8)
       
-    end subroutine TotalFireMortality_OneInputs_ReturnOne
+    end subroutine TotalFireMortality_OneInputs_ReturnsOne
     
     @Test 
     subroutine TotalFireMortality_ZeroCrownFire_ReturnsCambial(this)
       ! test that the function returns cambial_damage_mort if crownfire_mort = 0.0
       class(TestFireEquations), intent(inout) :: this                         ! test object
       real(r8)                                :: TM                           ! total fire mortality [0-1]
-      real(r8),                 parameter     :: crownfire_mort = 0.0_r8      ! input crown kill parameter
+      real(r8),                 parameter     :: crownfire_mort = 0.0_r8      ! crown fire mortality [0-1]
       real(r8),                 parameter     :: cambial_damage_mort = 0.3_r8 ! input fraction burned [0-1]
       
       TM = TotalFireMortality(crownfire_mort, cambial_damage_mort)
-      @assertEqual(CF, cambial_damage_mort)
+      @assertEqual(TM, cambial_damage_mort)
       
     end subroutine TotalFireMortality_ZeroCrownFire_ReturnsCambial
     
@@ -1128,11 +1113,11 @@ module test_FireEquations
       ! test that the function returns crownfire_mort if cambial_damage_mort = 0.0
       class(TestFireEquations), intent(inout) :: this                         ! test object
       real(r8)                                :: TM                           ! total fire mortality [0-1]
-      real(r8),                 parameter     :: crownfire_mort = 0.4_r8      ! input crown kill parameter
+      real(r8),                 parameter     :: crownfire_mort = 0.4_r8      ! crown fire mortality [0-1]
       real(r8),                 parameter     :: cambial_damage_mort = 0.0_r8 ! input fraction burned [0-1]
       
       TM = TotalFireMortality(crownfire_mort, cambial_damage_mort)
-      @assertEqual(CF, crownfire_mort)
+      @assertEqual(TM, crownfire_mort)
       
     end subroutine TotalFireMortality_ZeroCambial_ReturnsCrownFire
     
@@ -1141,11 +1126,11 @@ module test_FireEquations
       ! test that the function correctly caps mortality rate at 1.0
       class(TestFireEquations), intent(inout) :: this                         ! test object
       real(r8)                                :: TM                           ! total fire mortality [0-1]
-      real(r8),                 parameter     :: crownfire_mort = 1.4_r8      ! input crown kill parameter
+      real(r8),                 parameter     :: crownfire_mort = 1.4_r8      ! crown fire mortality [0-1]
       real(r8),                 parameter     :: cambial_damage_mort = 1.4_r8 ! input fraction burned [0-1]
       
       TM = TotalFireMortality(crownfire_mort, cambial_damage_mort)
-      @assertEqual(CF, 1.0_r8)
+      @assertEqual(TM, 1.0_r8)
       
     end subroutine TotalFireMortality_OverOneMort_ReturnsOne
     
@@ -1158,7 +1143,7 @@ module test_FireEquations
       real(r8),                 parameter     :: cambial_damage_mort = -1.4_r8 ! input fraction burned [0-1]
       
       TM = TotalFireMortality(crownfire_mort, cambial_damage_mort)
-      @assertEqual(CF, 0.0_r8)
+      @assertEqual(TM, 0.0_r8)
       
     end subroutine TotalFireMortality_NegativeMortality_ReturnsZero
     

--- a/testing/unit_testing/fire_equations_test/test_FireEquations.pf
+++ b/testing/unit_testing/fire_equations_test/test_FireEquations.pf
@@ -876,4 +876,116 @@ module test_FireEquations
 
     end subroutine FireSize_ZeroROS_ReturnsZero
     
+    @Test 
+    subroutine ScorchHeight_BasicInputs_ReturnsReasonable(this)
+      ! test that the function correctly calculates scorch height for reasonable inputs
+      class(TestFireEquations), intent(inout) :: this              ! test object
+      real(r8)                                :: SH                ! sorch height [m]
+      real(r8),                 parameter     :: alpha_SH = 0.5_r8 ! input alpha_SH parameter
+      real(r8),                 parameter     :: FI = 1000.0_r8    ! input fire intensity [kW/m]
+      
+      SH = ScorchHeight(alpha_SH, FI)
+      @assertEqual(SH, 50.11526_r8, tolerance=low_tol)
+      
+    end subroutine ScorchHeight_BasicInputs_ReturnsReasonable
+    
+    @Test 
+    subroutine ScorchHeight_FIZero_ReturnsZero(this)
+      ! test that if fire intensity is zero, scorch height is zero
+      class(TestFireEquations), intent(inout) :: this              ! test object
+      real(r8)                                :: SH                ! sorch height [m]
+      real(r8),                 parameter     :: alpha_SH = 0.5_r8 ! input alpha_SH parameter
+      real(r8),                 parameter     :: FI = 0.0_r8       ! input fire intensity [kW/m]
+      
+      SH = ScorchHeight(alpha_SH, FI)
+      @assertEqual(SH, 0.0_r8)
+      
+    end subroutine ScorchHeight_FIZero_ReturnsZero
+    
+    @Test 
+    subroutine ScorchHeight_AlphaZero_ReturnsZero(this)
+      ! test that if the alpha parameter is zero, scorch height is zero
+      class(TestFireEquations), intent(inout) :: this              ! test object
+      real(r8)                                :: SH                ! sorch height [m]
+      real(r8),                 parameter     :: alpha_SH = 0.0_r8 ! input alpha_SH parameter
+      real(r8),                 parameter     :: FI = 1000.0_r8    ! input fire intensity [kW/m]
+      
+      SH = ScorchHeight(alpha_SH, FI)
+      @assertEqual(SH, 0.0_r8)
+      
+    end subroutine ScorchHeight_AlphaZero_ReturnsZero
+    
+    @Test 
+    subroutine ScorchHeight_NegativeSH_Errors(this)
+      ! test that if the scorch height is negative, the function errors
+      class(TestFireEquations), intent(inout) :: this              ! test object
+      real(r8)                                :: SH                ! sorch height [m]
+      real(r8),                 parameter     :: alpha_SH = 0.5_r8 ! input alpha_SH parameter
+      real(r8),                 parameter     :: FI = -1000.0_r8   ! input fire intensity [kW/m]
+      character(len=:),         allocatable   :: expected_msg      ! expected error message for failure
+      
+      expected_msg = endrun_msg("scorch height is negative")
+      
+      SH = ScorchHeight(alpha_SH, FI)
+      @assertExceptionRaised(expected_msg)
+      
+    end subroutine ScorchHeight_NegativeSH_Errors
+    
+    @Test 
+    subroutine CrownFractionBurnt_BasicInputs_CapsAtOne(this)
+      ! test that the function correctly caps crown fraction burnt at 1.0
+      class(TestFireEquations), intent(inout) :: this                 ! test object
+      real(r8)                                :: CF                   ! crown fraction burnt [0-1]
+      real(r8),                 parameter     :: SH = 10.0_r8         ! input scorch height [m]
+      real(r8),                 parameter     :: height = 4.0_r8      ! input tree height [m]
+      real(r8),                 parameter     :: crown_depth = 2.0_r8 ! input crown depth [m]
+      
+      CF = CrownFractionBurnt(SH, height, crown_depth)
+      @assertEqual(CF, 1.0_r8)
+      
+    end subroutine CrownFractionBurnt_BasicInputs_CapsAtOne
+    
+    @Test 
+    subroutine CrownFractionBurnt_CrownDepthZero_ReturnsZero(this)
+      ! test that the function sets crown fraction to zero if the crown depth is zero
+      class(TestFireEquations), intent(inout) :: this                 ! test object
+      real(r8)                                :: CF                   ! crown fraction burnt [0-1]
+      real(r8),                 parameter     :: SH = 10.0_r8         ! input scorch height [m]
+      real(r8),                 parameter     :: height = 4.0_r8      ! input tree height [m]
+      real(r8),                 parameter     :: crown_depth = 0.0_r8 ! input crown depth [m]
+      
+      CF = CrownFractionBurnt(SH, height, crown_depth)
+      @assertEqual(CF, 0.0_r8)
+      
+    end subroutine CrownFractionBurnt_CrownDepthZero_ReturnsZero
+    
+    @Test 
+    subroutine CrownFractionBurnt_ScorchHeightBelowCrownHeight_ReturnsZero(this)
+      ! test that the function sets crown fraction to zero if the scorch height is below crown height
+      class(TestFireEquations), intent(inout) :: this                 ! test object
+      real(r8)                                :: CF                   ! crown fraction burnt [0-1]
+      real(r8),                 parameter     :: SH = 2.0_r8          ! input scorch height [m]
+      real(r8),                 parameter     :: height = 4.0_r8      ! input tree height [m]
+      real(r8),                 parameter     :: crown_depth = 2.0_r8 ! input crown depth [m]
+      
+      CF = CrownFractionBurnt(SH, height, crown_depth)
+      @assertEqual(CF, 0.0_r8)
+      
+    end subroutine CrownFractionBurnt_ScorchHeightBelowCrownHeight_ReturnsZero
+    
+    @Test 
+    subroutine CrownFractionBurnt_ScorchHeightLow_ReturnsLessThanOne(this)
+      ! test that the function correctly calculates crownfraction burnt for SH below tree height but within the crown
+      class(TestFireEquations), intent(inout) :: this                 ! test object
+      real(r8)                                :: CF                   ! crown fraction burnt [0-1]
+      real(r8),                 parameter     :: SH = 3.0_r8          ! input scorch height [m]
+      real(r8),                 parameter     :: height = 4.0_r8      ! input tree height [m]
+      real(r8),                 parameter     :: crown_depth = 2.0_r8 ! input crown depth [m]
+      
+      CF = CrownFractionBurnt(SH, height, crown_depth)
+      @assertGreaterThanOrEqualTo(CF, 0.0_r8)
+      @assertLessThanOrEqualTo(CF, 1.0_r8)
+      
+    end subroutine CrownFractionBurnt_ScorchHeightLow_ReturnsLessThanOne
+    
 end module test_FireEquations


### PR DESCRIPTION
Refactors the SPITFIRE code for tree mortality.

### Description:
 Should be bit-for-bit. Just reorganizes the subroutines and creates some helper functions and unit tests

### Expectation of Answer Changes:
Should be bit 4 bit

### Checklist
All checklist items must be checked to enable merging this pull request:

*Contributor*
- [x] The in-code documentation has been updated with descriptive comments
- [x] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided


### Test Results:
Ran preliminary tests that were b4b- will run again

*CTSM (or) E3SM (specify which) test hash-tag:* `ctsm5.3.029`

*CTSM (or) E3SM (specify which) baseline hash-tag:* `ctsm5.3.029`

*FATES baseline hash-tag:* `sci.1.81.1_api.38.0.0`

*Test Output:*

