### PR TITLE
Nocomp seed localization

### DIFF
--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -2101,7 +2101,7 @@ contains
        ! only on patches that allow that PFT to grow, then we need to add up all the patch areas
        ! for each nocomp PFT to normalize the seed fluxes with later.
        if (nocomp_seed_localization .and. hlm_use_nocomp .eq. itrue ) then
-          nocomp_patch_areas(0:numpft) = 0.r8
+          nocomp_patch_areas(0:numpft) = 0._r8
           currentPatch => currentSite%oldest_patch
           nocomp_patch_loop: do while (associated(currentPatch))
              nocomp_patch_areas(currentPatch%nocomp_pft_label) = nocomp_patch_areas(currentPatch%nocomp_pft_label) &


### PR DESCRIPTION
### Description:

This code makes it so that, in nocomp configurations only, any given PFT's seeds will all end up in patches where that PFT can grow.  The current behavior is that seeds are dispersed around on all patches, but they will only recruit on patches with that PFT's nocomp logic, so that, as a result, a lot of the seeds just decay.  The problem with the current logic is that if you imagine a gridcell where there is a PFT that has some tiny area that it is allowed to grow on, then most of that PFTs seeds end up unable to grow. So at the limit, as the nocomp area gets smaller for a given PFT on a given gridcell, it basically guarantees local extinction of that PFT at some point. My hunch is that this is responsible for some weird dynamics I have been seeing under spinup with constant land use, where PFTs can go extinct in the primary land patches of gridcells that have a lot of cropland on them.  I still have testing in the queue to see if this code actually fixes that problem. But in any case, it just seems wrong that, at the margin, we would penalize the likelihood of a PFT to maintain a viable population based just on the fractional area that we assign to it. I guess one counterargument would be that seed dispersal and recruitment really does degrade at the range limit of a given species due to habitat discontinuity and lack of dispersers. So I've written this as a hard-coded flag in the code for now, but happy to change it to a namelist flag if others think the counterarguments are strong or this introduces any weird behaviors (still TBD), or alternately delete the flag entirely if others think that the current logic is just wrong.

Note that revisiting some broader discussions we've had in the past of within-gridcell seed dispersal across patches is probably warranted, given that the implied length-scale of patches is likely different for patches that differ only in their disturbance history, versus also in their nocomp PFT and/or land-use labels if those are enabled in a given configuration. This is just the simplest modification I could think of to address this, much more complex ones are also possible. E.g., we may also want to have some fractional seed localization between patches with different land use types on a given gricell, or always localize some fraction of seeds to the parent cohort's patch, etc.

### Collaborators:
Discussed with @rgknox.
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
This will change answers in nocomp configurations, so I suggest not merging it until we have a bit better sense of how it qualitatively changes things.

<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [ ] The in-code documentation has been updated with descriptive comments
- [ ] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

