### PR TITLE
Add some biophysical variables by land-use type

### DIFF
--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -9,6 +9,7 @@ module FatesHistoryInterfaceMod
   use FatesConstantsMod        , only : mg_per_kg
   use FatesConstantsMod        , only : pi_const
   use FatesConstantsMod        , only : nearzero
+  use FatesConstantsMod        , only : rsnbl_math_prec
   use FatesConstantsMod        , only : t_water_freeze_k_1atm
   use FatesConstantsMod        , only : n_term_mort_types
   use FatesConstantsMod        , only : i_term_mort_type_cstarv
@@ -138,6 +139,7 @@ module FatesHistoryInterfaceMod
   use FatesSizeAgeTypeIndicesMod, only : get_cdamagesize_class_index
   use FatesSizeAgeTypeIndicesMod, only : get_cdamagesizepft_class_index
   use FatesSizeAgeTypeIndicesMod, only : coagetype_class_index
+  use FatesInterfaceTypesMod    , only : hlm_use_luh
 
   implicit none
   private          ! By default everything is private
@@ -362,6 +364,12 @@ module FatesHistoryInterfaceMod
   integer :: ih_burnedarea_si_landuse
   integer :: ih_gpp_si_landuse
   integer :: ih_npp_si_landuse
+  integer :: ih_tveg_si_landuse
+  integer :: ih_tsa_si_landuse
+  integer :: ih_sw_abs_si_landuse
+  integer :: ih_lw_net_si_landuse
+  integer :: ih_shflux_si_landuse
+  integer :: ih_lhflux_si_landuse
 
   ! land use by land use variables
   integer :: ih_disturbance_rate_si_lulu
@@ -824,6 +832,7 @@ module FatesHistoryInterfaceMod
      procedure :: update_history_dyn2
      procedure :: update_history_hifrq
      procedure :: update_history_hifrq1
+     procedure :: update_history_hifrq_landuse
      procedure :: update_history_hifrq2
      procedure :: update_history_hydraulics
      procedure :: update_history_nutrflux
@@ -4897,6 +4906,9 @@ contains
     
     if(hlm_hist_level_hifrq>0) then
        call update_history_hifrq1(this,nc,nsites,sites,bc_in,bc_out,dt_tstep)
+       if (hlm_use_luh .eq. itrue) then
+          call update_history_hifrq_landuse(this,nc,nsites,sites,bc_in)
+       end if
        if(hlm_hist_level_hifrq>1) then
           call update_history_hifrq2(this,nc,nsites,sites,bc_in,bc_out,dt_tstep)
        end if
@@ -5123,6 +5135,138 @@ contains
   end subroutine update_history_hifrq1
 
   ! ===============================================================================================
+
+  subroutine update_history_hifrq_landuse(this,nc,nsites,sites,bc_in)
+
+    !
+    ! Arguments
+    class(fates_history_interface_type)                 :: this
+    integer                 , intent(in)            :: nc   ! clump index
+    integer                 , intent(in)            :: nsites
+    type(ed_site_type)      , intent(inout), target :: sites(nsites)
+    type(bc_in_type)        , intent(in)            :: bc_in(nsites)
+
+    ! Locals
+    integer  :: s        ! The local site index
+    integer  :: io_si     ! The site index of the IO array
+
+    real(r8) :: landuse_statevector(n_landuse_cats)
+    real(r8) :: canopy_area_bylanduse(n_landuse_cats)
+    integer  :: i_lu
+    logical  :: foundbaregroundpatch
+
+    type(fates_patch_type),pointer  :: cpatch
+
+    associate( hio_tveg_si_landuse    => this%hvars(ih_tveg_si_landuse)%r82d,&
+         hio_tsa_si_landuse           => this%hvars(ih_tsa_si_landuse)%r82d,&
+         hio_sw_abs_si_landuse        => this%hvars(ih_sw_abs_si_landuse)%r82d,&
+         hio_lw_net_si_landuse        => this%hvars(ih_lw_net_si_landuse)%r82d,&
+         hio_shflux_si_landuse        => this%hvars(ih_shflux_si_landuse)%r82d,&
+         hio_lhflux_si_landuse        => this%hvars(ih_lhflux_si_landuse)%r82d)
+
+      do_sites: do s = 1,nsites
+
+         io_si  = sites(s)%h_gid
+
+         ! biophysical properties that are indexed by land use
+         landuse_statevector(:) = sites(s)%get_current_landuse_statevector() * AREA
+
+         ! get the total canopy area for each land use type
+         canopy_area_bylanduse(:) = 0._r8
+         cpatch => sites(s)%oldest_patch
+         do while(associated(cpatch))
+            if ( cpatch%land_use_label .ne. nocomp_bareground_land ) then
+               canopy_area_bylanduse(cpatch%land_use_label) = canopy_area_bylanduse(cpatch%land_use_label) + &
+                    cpatch%total_canopy_area
+            endif
+            cpatch => cpatch%younger
+         end do
+
+         cpatch => sites(s)%oldest_patch
+         do while(associated(cpatch))
+            if (cpatch%total_canopy_area .gt. rsnbl_math_prec) then
+               ! for TVEG, since it is only defined on vegetated area of vegetated patches, normalize by the total vegetated area
+               hio_tveg_si_landuse(io_si,cpatch%land_use_label) = hio_tveg_si_landuse(io_si,cpatch%land_use_label) + &
+                    bc_in(s)%t_veg_pa(cpatch%patchno) * cpatch%total_canopy_area/canopy_area_bylanduse(cpatch%land_use_label)
+
+               ! for the rest of these, first weight by the vegetated area of each patch over the total patch area for each land use type
+               hio_tsa_si_landuse(io_si,cpatch%land_use_label) = hio_tsa_si_landuse(io_si,cpatch%land_use_label) + &
+                    bc_in(s)%t2m_pa(cpatch%patchno) * cpatch%total_canopy_area/landuse_statevector(cpatch%land_use_label)
+
+               hio_sw_abs_si_landuse(io_si,cpatch%land_use_label) = hio_sw_abs_si_landuse(io_si,cpatch%land_use_label) + &
+                    bc_in(s)%swabs_pa(cpatch%patchno) * cpatch%total_canopy_area/landuse_statevector(cpatch%land_use_label)
+
+               hio_lw_net_si_landuse(io_si,cpatch%land_use_label) = hio_lw_net_si_landuse(io_si,cpatch%land_use_label) + &
+                    bc_in(s)%netlw_pa(cpatch%patchno) * cpatch%total_canopy_area/landuse_statevector(cpatch%land_use_label)
+
+               hio_shflux_si_landuse(io_si,cpatch%land_use_label) = hio_shflux_si_landuse(io_si,cpatch%land_use_label) + &
+                    bc_in(s)%shflux_pa(cpatch%patchno) * cpatch%total_canopy_area/landuse_statevector(cpatch%land_use_label)
+
+               hio_lhflux_si_landuse(io_si,cpatch%land_use_label) = hio_lhflux_si_landuse(io_si,cpatch%land_use_label) + &
+                    bc_in(s)%lhflux_pa(cpatch%patchno) * cpatch%total_canopy_area/landuse_statevector(cpatch%land_use_label)
+            endif
+            cpatch => cpatch%younger
+         end do
+
+         ! for all the land-use indexed variables, excpet for TVEG, also add in the component for the unvegetated area of each land use
+         foundbaregroundpatch = .false.
+         cpatch => sites(s)%oldest_patch
+         do while(associated(cpatch))
+            if (cpatch%land_use_label .eq. nocomp_bareground_land .and. .not. foundbaregroundpatch) then
+               foundbaregroundpatch = .true.
+               do i_lu = 1, n_landuse_cats
+                  if ( landuse_statevector(i_lu) .gt. rsnbl_math_prec ) then
+                     hio_tsa_si_landuse(io_si,i_lu) = hio_tsa_si_landuse(io_si,i_lu) + &
+                          bc_in(s)%t2m_pa(cpatch%patchno) * &
+                          (landuse_statevector(i_lu) - canopy_area_bylanduse(i_lu)) / landuse_statevector(i_lu)
+
+                     hio_sw_abs_si_landuse(io_si,i_lu) = hio_sw_abs_si_landuse(io_si,i_lu) + &
+                          bc_in(s)%swabs_pa(cpatch%patchno) * &
+                          (landuse_statevector(i_lu) - canopy_area_bylanduse(i_lu)) / landuse_statevector(i_lu)
+
+                     hio_lw_net_si_landuse(io_si,i_lu) = hio_lw_net_si_landuse(io_si,i_lu) + &
+                          bc_in(s)%netlw_pa(cpatch%patchno) * &
+                          (landuse_statevector(i_lu) - canopy_area_bylanduse(i_lu)) / landuse_statevector(i_lu)
+
+                     hio_shflux_si_landuse(io_si,i_lu) = hio_shflux_si_landuse(io_si,i_lu) + &
+                          bc_in(s)%shflux_pa(cpatch%patchno) * &
+                          (landuse_statevector(i_lu) - canopy_area_bylanduse(i_lu)) / landuse_statevector(i_lu)
+
+                     hio_lhflux_si_landuse(io_si,i_lu) = hio_lhflux_si_landuse(io_si,i_lu) + &
+                          bc_in(s)%lhflux_pa(cpatch%patchno) * &
+                          (landuse_statevector(i_lu) - canopy_area_bylanduse(i_lu)) / landuse_statevector(i_lu)
+                  end if
+               end do
+            end if
+            cpatch => cpatch%younger
+         end do
+
+         ! instead of leaving the values for unoccupied areas as zero, set as missing values
+         do i_lu = 1, n_landuse_cats
+
+            ! if a given land use type is not present, set the value as missing
+            if ( landuse_statevector(i_lu) .le. rsnbl_math_prec ) then
+               hio_tsa_si_landuse(io_si,i_lu) = hlm_hio_ignore_val
+               hio_sw_abs_si_landuse(io_si,i_lu) = hlm_hio_ignore_val
+               hio_lw_net_si_landuse(io_si,i_lu) = hlm_hio_ignore_val
+               hio_shflux_si_landuse(io_si,i_lu) = hlm_hio_ignore_val
+               hio_lhflux_si_landuse(io_si,i_lu) = hlm_hio_ignore_val
+            end if
+
+            ! for tveg, ignore if there is no vegetation present on any patches of a given land use type
+            if ( canopy_area_bylanduse(i_lu) .le. rsnbl_math_prec ) then
+               hio_tveg_si_landuse(io_si,i_lu) = hlm_hio_ignore_val
+            end if
+
+         end do
+
+      end do do_sites
+
+    end associate
+    return
+  end subroutine update_history_hifrq_landuse
+
+    ! ===============================================================================================
 
   subroutine update_history_hifrq2(this,nc,nsites,sites,bc_in,bc_out,dt_tstep)
 
@@ -8506,6 +8650,45 @@ contains
             use_default='active', &
             avgflag='A', vtype=site_r8, hlms='CLM:ALM', upfreq=group_hifr_simple, &
             ivar=ivar, initialize=initialize_variables, index = ih_tveg_si )
+
+       if (hlm_use_luh .eq. itrue) then
+          ! biophysics variables that are indexed by land use type
+          call this%set_history_var(vname='FATES_TVEG_LU', units='degrees Kelvin', &
+               long='fates instantaneous mean vegetation temperature by land use type', &
+               use_default='active', &
+               avgflag='A', vtype=site_landuse_r8, hlms='CLM:ALM', upfreq=group_hifr_simple, &
+               ivar=ivar, initialize=initialize_variables, index = ih_tveg_si_landuse )
+
+          call this%set_history_var(vname='FATES_TSA_LU', units='degrees Kelvin', &
+               long='fates instantaneous mean near-surface (2m) air temperature by land use type', &
+               use_default='active', &
+               avgflag='A', vtype=site_landuse_r8, hlms='CLM:ALM', upfreq=group_hifr_simple, &
+               ivar=ivar, initialize=initialize_variables, index = ih_tsa_si_landuse )
+
+          call this%set_history_var(vname='FATES_SWABS_LU', units='W m-2', &
+               long='fates absorbed shortwave radiation by land use type', &
+               use_default='active', &
+               avgflag='A', vtype=site_landuse_r8, hlms='CLM:ALM', upfreq=group_hifr_simple, &
+               ivar=ivar, initialize=initialize_variables, index = ih_sw_abs_si_landuse )
+
+          call this%set_history_var(vname='FATES_NETLW_LU', units='W m-2', &
+               long='fates net longwave flux by land use type', &
+               use_default='active', &
+               avgflag='A', vtype=site_landuse_r8, hlms='CLM:ALM', upfreq=group_hifr_simple, &
+               ivar=ivar, initialize=initialize_variables, index = ih_lw_net_si_landuse )
+
+          call this%set_history_var(vname='FATES_SHFLUX_LU', units='W m-2', &
+               long='fates sensible heat flux by land use type', &
+               use_default='active', &
+               avgflag='A', vtype=site_landuse_r8, hlms='CLM:ALM', upfreq=group_hifr_simple, &
+               ivar=ivar, initialize=initialize_variables, index = ih_shflux_si_landuse )
+
+          call this%set_history_var(vname='FATES_LHFLUX_LU', units='W m-2', &
+               long='fates latent heat flux by land use type', &
+               use_default='active', &
+               avgflag='A', vtype=site_landuse_r8, hlms='CLM:ALM', upfreq=group_hifr_simple, &
+               ivar=ivar, initialize=initialize_variables, index = ih_lhflux_si_landuse )
+       endif
 
        call this%set_history_var(vname='FATES_VIS_RAD_ERROR', units='-',          &
             long='mean two-stream solver error for VIS', use_default='active',            &

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -321,6 +321,12 @@ contains
        fates%bc_in(s)%hksat_sisl(:) = 0.0_r8
     end if
 
+    ! Diagnostic quantities for outputting FATES patch-resolved
+    fates%bc_in(s)%lhflux_pa(:)       = 0._r8
+    fates%bc_in(s)%shflux_pa(:)       = 0._r8
+    fates%bc_in(s)%swabs_pa(:)        = 0._r8
+    fates%bc_in(s)%netlw_pa(:)        = 0._r8
+    fates%bc_in(s)%t2m_pa(:)          = 0._r8
     
     ! Output boundaries
     fates%bc_out(s)%active_suction_sl(:) = .false.
@@ -552,6 +558,12 @@ contains
       end if
 
       ! Land use
+      ! Diagnostic quantities for outputting FATES patch-resolved
+      allocate(bc_in%lhflux_pa(0:maxpatch_total))
+      allocate(bc_in%shflux_pa(0:maxpatch_total))
+      allocate(bc_in%swabs_pa(0:maxpatch_total))
+      allocate(bc_in%netlw_pa(0:maxpatch_total))
+      allocate(bc_in%t2m_pa(0:maxpatch_total))
 
       ! harvest flag denote data from hlm,
       ! while the logging flag signifies only that logging is occurring (which could just be FATES logging)

--- a/main/FatesInterfaceTypesMod.F90
+++ b/main/FatesInterfaceTypesMod.F90
@@ -593,6 +593,13 @@ module FatesInterfaceTypesMod
       real(r8),allocatable :: h2o_liq_sisl(:)      ! Liquid water mass in each layer (kg/m2)
       real(r8) :: smpmin_si                        ! restriction for min of soil potential (mm)
 
+      ! Diagnostic quantities for outputting FATES patch-resolved
+      real(r8),allocatable :: lhflux_pa(:)         ! latent heat flux
+      real(r8),allocatable :: shflux_pa(:)         ! sensible heat flux
+      real(r8),allocatable :: swabs_pa(:)          ! shortwave absorbed radiation
+      real(r8),allocatable :: netlw_pa(:)          ! longwave net radiation
+      real(r8),allocatable :: t2m_pa(:)            ! 2m air temeprature
+
       ! Land use
       ! ---------------------------------------------------------------------------------
       real(r8),allocatable :: hlm_harvest_rates(:)    ! annual harvest rate per cat from hlm for a site


### PR DESCRIPTION
In order to look at biophysical effects of land use, it's useful to have a small number of relevant variables indexed by land use type.  This PR allows that, so that you can look at: vegetation temperature, surface air temperature, and a basic set of energy fluxes (SW, LW, SH, LH) separately for each land use type. I.e., they are output on the `fates_levlanduse` history dimension for each gridcell.

This requires HLM-side logic. I have a commit on E3SM that handles this at https://github.com/ckoven/E3SM/commit/5fd137b0c9a43858efd925efc6c82dc698ec47be (PR forthcoming)

Currently these are all output when the hi frequency history flag is set to 1; in principle this should actually be when the flag is set to 2, so that should probably change before bringing this PR in. (for the purpose of the experiments I am currently running, I want these and only these subgridscale high-frequency variables though.)

Also, the logic that averages in bare-ground-patch properties will only work for nocomp configurations.  Further work is needed to be correct for full-FATES configurations as well, but I got lost in how to index a given site's bare-ground patch when nocomp isn't on, so I need to come back to that.

Also, the patch-weighting logic for these variables is slightly different than for other patch-level variables (e.g., the `fates_levage' -indexed ones). This is for two reasons: (1) we need to average in some of the bare ground patch properties to weight things correctly, because the FATES and HLM patch areas mean different things, and (2) the land use areas are less generally dynamic than the age binned logic, and so there is less chance of weirdness when the averaging denominator changes abruptly.  So the upshot is that less postprocessing is needed for these (i.e they are simpler to work with), but also that they might not sum perfectly to the total site values because of changing denominators over time.

### Description:
fixes #1404.

### Collaborators:
discussed with @glemieux, @rgknox, @aswann 

### Expectation of Answer Changes:
This only adds new diagnostic variables, so should be bit for bit otherwise.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [ ] The in-code documentation has been updated with descriptive comments
- [ ] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

