### PR TITLE
Have external seed rain only fall on a given PFT's nocomp patches

### DIFF
--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -2184,7 +2184,11 @@ contains
                 
                 ! Seed input from external sources (user param seed rain, or dispersal model)
                 ! Include both prescribed seed_suppl and seed_in dispersed from neighbouring gridcells
-                seed_in_external = seed_stoich*(currentSite%seed_in(pft)/area + EDPftvarcon_inst%seed_suppl(pft)*years_per_day) ![kg/m2/day]
+                seed_in_external = seed_stoich * currentSite%seed_in(pft)/area  ![kg/m2/day]
+                !only add external seed rain to a given PFT's nocomp patches
+                if ( (hlm_use_nocomp .eq. ifalse) .or. (hlm_use_nocomp .eq. itrue .and. currentPatch%nocomp_pft_label .eq. pft) ) then
+                   seed_in_external = seed_in_external + seed_stoich * EDPftvarcon_inst%seed_suppl(pft)*years_per_day ![kg/m2/day]
+                endif
                 litt%seed_in_extern(pft) = litt%seed_in_extern(pft) + seed_in_external
                 
                 ! Seeds entering externally [kg/site/day]


### PR DESCRIPTION
### Description:
In a nocomp configuration, if external seed rain is nonzero, it only really makes sense for the external seed rain to fall on patches of the PFT that the seeds are. Otherwise the seeds can't grow and just decay away. This code changes the external seed rain logic to only fall on those patches, and therefore minimize the downstream effects on things like soil carbon.

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
This should only change answers if nocomp is active and seed rain is on. otherwise it won't change answers.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [x] The in-code documentation has been updated with descriptive comments
- [x] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

