### PR TITLE
Event based  logging mortality fix

### DIFF
--- a/biogeochem/EDLoggingMortalityMod.F90
+++ b/biogeochem/EDLoggingMortalityMod.F90
@@ -15,6 +15,7 @@ module EDLoggingMortalityMod
 
    use FatesConstantsMod , only : r8 => fates_r8
    use FatesConstantsMod , only : rsnbl_math_prec
+   use FatesConstantsMod , only : fates_unset_int
    use FatesCohortMod    , only : fates_cohort_type
    use FatesPatchMod     , only : fates_patch_type
    use EDTypesMod        , only : site_massbal_type
@@ -251,6 +252,10 @@ contains
       ! todo: eventually set up distinct harvest practices, each with a set of input paramaeters
       ! todo: implement harvested carbon inputs
 
+
+      ! Valid values are  0,1,2  so initialize to a different value
+      cur_harvest_tag = fates_unset_int
+      
       ! The transition_landuse_from_off_to_on is for handling the special case of the first timestep after leaving potential
       ! vegetation mode. In this case, all prior historical land-use, including harvest, needs to be applied on that first day.
       ! So logging rates on that day are what is required to deforest exactly the amount of primary lands that will give the
@@ -288,6 +293,7 @@ contains
                ! 0=use fates logging parameters directly when logging_time == .true.
                ! this means harvest the whole cohort area
                harvest_rate = 1._r8
+               cur_harvest_tag = fates_bypass_harvest_debt
 
             else if (hlm_use_lu_harvest == itrue .and. hlm_harvest_units == hlm_harvest_area_fraction) then
                ! We are harvesting based on areal fraction, not carbon/biomass terms. 


### PR DESCRIPTION
FATES_MORTALITY_LOGGING_SZPF is currently zero during runs with event based logging (and possibly other harvest types). This seems to partly be a problem with the logic around logging being dependent on the local variable `cur_harvest_tag` which is  not  initialized but by chance sometimes defaults to 0 which is a valid option. This PR fixes the logic in the LoggingMortality_frac subroutine. However, the history output is still 0 suggesting there is a bug somewhere with `lmort_direct` being reset before it is passed to history. First noted in issue #1367 . 


### Collaborators:
@sshu88 @XiulinGao @glemieux 

### Expectation of Answer Changes:
This will change results for simulations using event based logging. 

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [ ] The in-code documentation has been updated with descriptive comments
- [ ] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

