### PR TITLE
remove trunk_product_site variable

### DIFF
--- a/biogeochem/EDLoggingMortalityMod.F90
+++ b/biogeochem/EDLoggingMortalityMod.F90
@@ -1145,9 +1145,6 @@ contains
          ! This portion is known as "trunk_product_site
          
          if(element_id .eq. carbon12_element) then
-            currentSite%resources_management%trunk_product_site  = &
-                  currentSite%resources_management%trunk_product_site + &
-                  trunk_product_site
             
             currentSite%resources_management%delta_litter_stock  = &
                   currentSite%resources_management%delta_litter_stock + &

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -2595,8 +2595,6 @@ contains
     integer  :: pft                  ! loop index for plant functional types
     integer  :: dcmpy                ! loop index for decomposability pool
     integer  :: element_id           ! parteh compatible global element index
-    real(r8) :: trunk_product_site   ! flux of carbon in trunk products exported off site      [ kgC/site ]
-                                     ! (note we are accumulating over the patch, but scale is site level)
     real(r8) :: woodproduct_mass     ! mass that ends up in wood products [kg]
 
     !---------------------------------------------------------------------
@@ -2638,9 +2636,6 @@ contains
        end if
 
        do el = 1,num_elements
-
-          ! Zero some site level accumulator diagnsotics
-          trunk_product_site  = 0.0_r8
 
           element_id = element_list(el)
           site_mass  => currentSite%mass_balance(el)
@@ -2774,9 +2769,6 @@ contains
 
                    site_mass%burn_flux_to_atm = site_mass%burn_flux_to_atm + burned_mass
 
-                   trunk_product_site = trunk_product_site + &
-                        woodproduct_mass
-
                    ! Amount of trunk mass exported off site [kg/m2]
                    elflux_diags%exported_harvest = elflux_diags%exported_harvest + &
                         woodproduct_mass * area_inv
@@ -2792,15 +2784,6 @@ contains
 
              currentCohort => currentCohort%taller
           enddo
-
-          ! Update the amount of carbon exported from the site through logging.
-
-          if(element_id .eq. carbon12_element) then
-             currentSite%resources_management%trunk_product_site  = &
-                  currentSite%resources_management%trunk_product_site + &
-                  trunk_product_site
-          end if
-
 
        end do
 

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -3153,10 +3153,6 @@ contains
                (leaf_m + fnrt_m + store_m ) * &
                (dead_n_ilogging+dead_n_dlogging) *currentPatch%area
 
-          currentSite%resources_management%trunk_product_site = &
-               currentSite%resources_management%trunk_product_site + &
-               trunk_wood * logging_export_frac * currentPatch%area
-
           do c = 1,ncwd
              currentSite%resources_management%delta_litter_stock  = &
                   currentSite%resources_management%delta_litter_stock + &

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -359,7 +359,6 @@ contains
     ! Resources management (logging/harvesting, etc)
     site_in%resources_management%harvest_debt = 0.0_r8
     site_in%resources_management%harvest_debt_sec = 0.0_r8
-    site_in%resources_management%trunk_product_site  = 0.0_r8
 
     ! canopy spread
     site_in%spread = 0._r8

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -137,7 +137,6 @@ module EDTypesMod
   !************************************
   type, public :: ed_resources_management_type
     
-     real(r8) ::  trunk_product_site                       ! Actual  trunk product at site level KgC/site
      real(r8) ::  harvest_debt                             ! the amount of kgC per site that did not successfully harvested 
      real(r8) ::  harvest_debt_sec                         ! the amount of kgC per site from secondary patches that did
                                                            ! not successfully harvested

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -430,7 +430,6 @@ module FatesHistoryInterfaceMod
   integer :: ih_froot_mr_si
   integer :: ih_livestem_mr_si
   integer :: ih_livecroot_mr_si
-  integer :: ih_woodproduct_si
   integer :: ih_h2oveg_si
   integer :: ih_h2oveg_dead_si
   integer :: ih_h2oveg_recruit_si
@@ -2471,7 +2470,6 @@ contains
          hio_promotion_carbonflux_si       => this%hvars(ih_promotion_carbonflux_si)%r81d, &
          hio_canopy_mortality_carbonflux_si     => this%hvars(ih_canopy_mortality_carbonflux_si)%r81d, &
          hio_ustory_mortality_carbonflux_si => this%hvars(ih_understory_mortality_carbonflux_si)%r81d, &
-         hio_woodproduct_si                 => this%hvars(ih_woodproduct_si)%r81d, &
          hio_gdd_si                           => this%hvars(ih_gdd_si)%r81d, &
          hio_site_ncolddays_si                => this%hvars(ih_site_ncolddays_si)%r81d, &
          hio_site_nchilldays_si               => this%hvars(ih_site_nchilldays_si)%r81d, &
@@ -2544,10 +2542,6 @@ contains
          ! Model days elapsed since leaf on/off for cold-deciduous
          hio_cleafoff_si(io_si) = real(sites(s)%phen_model_date - sites(s)%cleafoffdate,r8)
          hio_cleafon_si(io_si)  = real(sites(s)%phen_model_date - sites(s)%cleafondate,r8)
-
-         ! track total wood product accumulation at the site level
-         hio_woodproduct_si(io_si) = sites(s)%resources_management%trunk_product_site &
-              * AREA_INV
 
          ! site-level fire variables:
 
@@ -6343,12 +6337,6 @@ contains
             upfreq=group_dyna_simple, ivar=ivar, initialize=initialize_variables,                 &
             index=ih_elai_si)
        
-       call this%set_history_var(vname='FATES_WOOD_PRODUCT', units='kg m-2',      &
-            long='total wood product from logging in kg carbon per m2 land area', &
-            use_default='active', avgflag='A', vtype=site_r8, hlms='CLM:ALM',   &
-            upfreq=group_dyna_simple, ivar=ivar, initialize=initialize_variables,                 &
-            index=ih_woodproduct_si)
-
        ! Fire Variables
 
        call this%set_history_var(vname='FATES_NESTEROV_INDEX', units='',          &

--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -110,7 +110,6 @@ module FatesRestartInterfaceMod
   integer :: ir_landuse_vector_gt_min_si
   integer :: ir_area_bareground_si
   integer :: ir_snow_depth_si
-  integer :: ir_trunk_product_si
   integer :: ir_landuse_config_si
   integer :: ir_ncohort_pa
   integer :: ir_canopy_layer_co
@@ -2113,7 +2112,6 @@ contains
            rio_landuse_vector_gt_min_si  => this%rvars(ir_landuse_vector_gt_min_si)%int1d, &
            rio_area_bareground_si      => this%rvars(ir_area_bareground_si)%r81d, &
            rio_snow_depth_si           => this%rvars(ir_snow_depth_si)%r81d, &
-           rio_trunk_product_si        => this%rvars(ir_trunk_product_si)%r81d, &
            rio_landuse_config_s        => this%rvars(ir_landuse_config_si)%int1d, &
            rio_ncohort_pa              => this%rvars(ir_ncohort_pa)%int1d, &
            rio_fcansno_pa              => this%rvars(ir_fcansno_pa)%r81d, &
@@ -3108,7 +3106,6 @@ contains
           rio_landuse_vector_gt_min_si               => this%rvars(ir_landuse_vector_gt_min_si)%int1d, &
           rio_area_bareground_si                  => this%rvars(ir_area_bareground_si)%r81d, &
           rio_snow_depth_si           => this%rvars(ir_snow_depth_si)%r81d, &
-          rio_trunk_product_si        => this%rvars(ir_trunk_product_si)%r81d, &
           rio_landuse_config_si       => this%rvars(ir_landuse_config_si)%int1d, &
           rio_ncohort_pa              => this%rvars(ir_ncohort_pa)%int1d, &
           rio_fcansno_pa              => this%rvars(ir_fcansno_pa)%r81d, &

--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -739,11 +739,6 @@ contains
          long_name='average snow depth', units='m', flushval = flushzero, &
          hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_snow_depth_si )
 
-    call this%set_restart_var(vname='fates_trunk_product_site', vtype=site_r8, &
-         long_name='Accumulate trunk product flux at site', &
-         units='kgC/m2', flushval = flushzero, &
-         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_trunk_product_si )
-
     call this%set_restart_var(vname='fates_landuse_config_site', vtype=site_int, &
          long_name='hlm_use_potentialveg status of run that created this restart file', &
          units='kgC/m2', flushval = flushzero, &
@@ -2743,9 +2738,6 @@ contains
           rio_fireweather_index_si(io_idx_si) = sites(s)%fireWeather%fire_weather_index
           rio_snow_depth_si(io_idx_si)   = sites(s)%snow_depth
 
-          ! Accumulated trunk product
-          rio_trunk_product_si(io_idx_si) = sites(s)%resources_management%trunk_product_site
-
           ! land use flag
           rio_landuse_config_si(io_idx_si) = hlm_use_potentialveg
 
@@ -3775,7 +3767,6 @@ contains
          
           sites(s)%fireWeather%fire_weather_index  = rio_fireweather_index_si(io_idx_si)
           sites(s)%snow_depth     = rio_snow_depth_si(io_idx_si)
-          sites(s)%resources_management%trunk_product_site = rio_trunk_product_si(io_idx_si)
 
           ! if needed, trigger the special procedure to initialize land use structure from a
           ! restart run that did not include land use.


### PR DESCRIPTION
This PR just removes a variable that we don't need.

### Description:
Currently there is a variable `currentSite%resources_management%trunk_product_site` that tracks the accumulated wood harvest product, which we output as the history variable `FATES_WOOD_PRODUCT`. We no longer need this variable, because we pass the harvest flux to the host model, which then tracks the 10- and 100-year product pools and their turnover rates. So it is just confusing to also have this variable in history. And since the only purpose of the `currentSite%resources_management%trunk_product_site` is to integrate this variable in time, we can just delete the whole thing and simplify the code.

### Collaborators:
n/a

### Expectation of Answer Changes:
Variable `FATES_WOOD_PRODUCT`will no longer exist. Otherwise should be bit for bit.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [x] The in-code documentation has been updated with descriptive comments
- [x] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [x] FATES PASS/FAIL regression tests were run
- [x] Evaluation of test results for answer changes was performed and results provided
- [x] FATES-CLM6 Code Freeze: satellite phenology regression tests are b4b

*If satellite phenology regressions are **not** b4b, please hold merge and notify the FATES development team.*

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

