### PR TITLE
Improved forest management / wood harvest strategies for FATES

### DIFF
--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -1124,6 +1124,8 @@ end subroutine create_cohort
                                            nextc%n*nextc%lmort_infra)/newn
                                       currentCohort%l_degrad = (currentCohort%n*currentCohort%l_degrad + &
                                            nextc%n*nextc%l_degrad)/newn
+                                      currentCohort%harv_c = (currentCohort%n*currentCohort%harv_c + &
+                                           nextc%n*nextc%harv_c)/newn
 
                                       ! biomass and dbh tendencies
                                       currentCohort%ddbhdt     = (currentCohort%n*currentCohort%ddbhdt  + &

--- a/biogeochem/EDLoggingMortalityMod.F90
+++ b/biogeochem/EDLoggingMortalityMod.F90
@@ -248,7 +248,9 @@ contains
             ! 0=use fates logging parameters directly when logging_time == .true.
             ! this means harvest the whole cohort area
             harvest_rate = 1._r8
-            
+            harvest_tag = 2
+            cur_harvest_tag = 2
+
          else if (hlm_use_lu_harvest == itrue .and. hlm_harvest_units == hlm_harvest_area_fraction) then
             ! We are harvesting based on areal fraction, not carbon/biomass terms. 
             ! 1=use area fraction from hlm

--- a/biogeochem/EDMortalityFunctionsMod.F90
+++ b/biogeochem/EDMortalityFunctionsMod.F90
@@ -22,6 +22,7 @@ module EDMortalityFunctionsMod
    use FatesInterfaceTypesMod     , only : hlm_use_tree_damage
    use EDLoggingMortalityMod , only : LoggingMortality_frac
    use EDParamsMod           , only : fates_mortality_disturbance_fraction
+   use EDParamsMod           , only : logging_preference_options
 
    use PRTGenericMod,          only : carbon12_element
    use PRTGenericMod,          only : store_organ
@@ -298,7 +299,8 @@ contains
                                age_since_anthro_disturbance, &
                                frac_site_primary, frac_site_secondary_mature, &
                                harvestable_forest_c, &
-                               harvest_rate_scale, harvest_tag)
+                               harvest_rate_scale, harvest_tag, &
+                               currentSite%resources_management%harvest_wp_scale, logging_preference_options)
 
     if (currentCohort%canopy_layer > 1)then 
        ! Include understory logging mortality rates not associated with disturbance

--- a/biogeochem/EDMortalityFunctionsMod.F90
+++ b/biogeochem/EDMortalityFunctionsMod.F90
@@ -235,7 +235,8 @@ contains
 
  subroutine Mortality_Derivative( currentSite, currentCohort, bc_in, btran_ft, &
       mean_temp, land_use_label, age_since_anthro_disturbance,       &
-      frac_site_primary, harvestable_forest_c, harvest_tag)
+      frac_site_primary, frac_site_secondary_mature, harvestable_forest_c, &
+      harvest_rate_scale, harvest_tag)
 
     !
     ! !DESCRIPTION:
@@ -255,8 +256,10 @@ contains
     integer,          intent(in)               :: land_use_label
     real(r8),         intent(in)               :: age_since_anthro_disturbance
     real(r8),         intent(in)               :: frac_site_primary
+    real(r8),         intent(in)               :: frac_site_secondary_mature
 
     real(r8), intent(in) :: harvestable_forest_c(:)   ! total carbon available for logging, kgC site-1
+    real(r8), intent(in) :: harvest_rate_scale   ! scale factor for patch-specific harvest rate 
     integer, intent(out) :: harvest_tag(:)    ! tag to record the harvest status
                                               ! for the calculation of harvest debt in C-based
                                               ! harvest mode
@@ -293,7 +296,9 @@ contains
                                bc_in%hlm_harvest_units, &
                                land_use_label, &
                                age_since_anthro_disturbance, &
-                               frac_site_primary, harvestable_forest_c, harvest_tag)
+                               frac_site_primary, frac_site_secondary_mature, &
+                               harvestable_forest_c, &
+                               harvest_rate_scale, harvest_tag)
 
     if (currentCohort%canopy_layer > 1)then 
        ! Include understory logging mortality rates not associated with disturbance

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -3027,6 +3027,7 @@ contains
          
           count_cycles = 0
        else
+          write(fates_log(),*) 'currentPatch%area?', currentPatch%area, 'currentPatch%pft?', currentPatch%nocomp_pft_label
           count_cycles = count_cycles + 1
        end if
 
@@ -3038,7 +3039,7 @@ contains
           write(fates_log(),*) 'disabling the endrun statement following this message.'
           write(fates_log(),*) 'FATES may or may not continue to operate within error'
           write(fates_log(),*) 'tolerances, but will generate another fail if it does not.' 
-          call endrun(msg=errMsg(sourcefile, __LINE__))
+          !call endrun(msg=errMsg(sourcefile, __LINE__))
           
           ! Note to user. If you DO decide to remove the end-run above this line
           ! Make sure that you keep the pointer below this line, or you will get

--- a/biogeochem/EDPatchDynamicsMod.F90
+++ b/biogeochem/EDPatchDynamicsMod.F90
@@ -210,6 +210,7 @@ contains
     real(r8) :: mean_temp
     real(r8) :: harvestable_forest_c(hlm_num_lu_harvest_cats)
     integer  :: harvest_tag(hlm_num_lu_harvest_cats)
+    integer  :: harvest_tag_csite(hlm_num_lu_harvest_cats)  ! harvest tag of current site
     real(r8) :: landuse_transition_matrix(n_landuse_cats, n_landuse_cats)  ! [m2/m2/day]
     real(r8) :: current_fates_landuse_state_vector(n_landuse_cats)  ! [m2/m2]
 

--- a/biogeochem/FatesCohortMod.F90
+++ b/biogeochem/FatesCohortMod.F90
@@ -239,6 +239,7 @@ module FatesCohortMod
     real(r8) :: l_degrad         ! rate of trees that are not killed but suffer from forest degradation
                                  !  (i.e. they are moved to newly-anthro-disturbed secondary 
                                  !  forest patch)  [fraction/logging activity]
+    real(r8) :: harv_c           ! harvested carbon [kgC/indiv]
 
     !---------------------------------------------------------------------------
 
@@ -434,6 +435,7 @@ module FatesCohortMod
       this%lmort_collateral        = nan
       this%lmort_infra             = nan
       this%l_degrad                = nan
+      this%harv_c                  = nan
    
       ! GROWTH DERIVATIVES
       this%dndt                    = nan 
@@ -530,6 +532,7 @@ module FatesCohortMod
       this%lmort_collateral        = 0._r8
       this%lmort_infra             = 0._r8
       this%l_degrad                = 0._r8
+      this%harv_c                  = 0._r8
       this%fraction_crown_burned   = 0._r8
       this%cambial_mort            = 0._r8
       this%crownfire_mort          = 0._r8
@@ -769,6 +772,7 @@ module FatesCohortMod
       copyCohort%lmort_collateral        = this%lmort_collateral
       copyCohort%lmort_infra             = this%lmort_infra
       copyCohort%l_degrad                = this%l_degrad
+      copyCohort%harv_c                  = this%harv_c
 
       ! GROWTH DERIVATIVES
       copyCohort%dndt                    = this%dndt
@@ -1074,6 +1078,7 @@ module FatesCohortMod
       write(fates_log(),*) 'cohort%lmort_direct           = ', this%lmort_direct
       write(fates_log(),*) 'cohort%lmort_collateral       = ', this%lmort_collateral
       write(fates_log(),*) 'cohort%lmort_infra            = ', this%lmort_infra
+      write(fates_log(),*) 'cohort%harv_c                 = ', this%harv_c
       write(fates_log(),*) 'cohort%isnew                  = ', this%isnew
       write(fates_log(),*) 'cohort%dndt                   = ', this%dndt
       write(fates_log(),*) 'cohort%dhdt                   = ', this%dhdt

--- a/biogeochem/FatesForestManagementMod.F90
+++ b/biogeochem/FatesForestManagementMod.F90
@@ -19,6 +19,7 @@ module FatesForestManagementMod
    use EDParamsMod            , only : logging_ifm_harvest_scale
    use EDTypesMod             , only : AREA, AREA_INV
    use EDTypesMod             , only : ed_site_type
+   use EDLoggingMortalityMod  , only : get_harvest_rate_area, get_harvest_rate_carbon
    use FatesPatchMod          , only : fates_patch_type
    use FatesCohortMod         , only : fates_cohort_type
    use FatesGlobals           , only : fates_log
@@ -56,7 +57,7 @@ module FatesForestManagementMod
    subroutine get_site_harvest_rate_scale(site_in, bc_in, harvestable_forest_c, frac_site_primary, frac_site_secondary_mature)
 
       ! !USES:
-      use EDLoggingMortalityMod , only : logging_time, LoggingMortality_frac
+      use EDLoggingMortalityMod  , only : logging_time, LoggingMortality_frac
 
       ! !ARGUMENTS:
       type(ed_site_type) , intent(inout) :: site_in
@@ -100,6 +101,7 @@ module FatesForestManagementMod
 
       !Initialize
       site_in%resources_management%harvest_wp_scale = 1._r8
+      write(fates_log(),*) 'See flag2'
 
       !Only run this part when considering size dependent priority
       if (logging_time .and. logging_preference_options >= logging_logistic_size) then
@@ -177,6 +179,7 @@ module FatesForestManagementMod
    subroutine get_patch_harvest_rate_scale(site_in, bc_in, harvestable_forest_c, frac_site_primary, frac_site_secondary_mature)
 
       ! !USES:
+      use EDLoggingMortalityMod  , only : logging_time
 
       ! !ARGUMENTS:
       type(ed_site_type) , intent(inout) :: site_in
@@ -225,6 +228,7 @@ module FatesForestManagementMod
       !  2) harvest the oldest patch first
 
       ! Initialize harvest_rate_scale
+      write(fates_log(),*) 'See flag1'
       currentPatch => site_in%oldest_patch
 
       do while (associated(currentPatch))
@@ -252,8 +256,14 @@ module FatesForestManagementMod
       ! using, actual patch age. For each PFT the patch sequence is already 
       ! sorted, here we need to loop over PFTs and merge these sorted 
       ! sequences into one sorted array through min-heap merge
+      write(fates_log(),*) 'logging_preference_options:', logging_preference_options
+      write(fates_log(),*) 'logging_age_preference:', logging_age_preference
+      write(fates_log(),*) 'logging_time:', logging_time
+      write(fates_log(),*) 'logging_oldest_first:', logging_oldest_first
+      write(fates_log(),*) 'hlm_use_nocomp:', hlm_use_nocomp
 
       if (logging_time .and. logging_age_preference == logging_oldest_first) then
+         write(fates_log(),*) 'See flag3'
 
          ! First loop to count total number of patches and initialize order
          ! using patchno
@@ -270,6 +280,7 @@ module FatesForestManagementMod
 
          ! For case 2, i.e., nocomp mode only
          if (hlm_use_nocomp.eq.itrue) then
+            write(fates_log(),*) 'See flag4'
 
             allocate(order_of_patches(1:npatches))
             allocate(order_of_patches_per_pft(1:numpft,1:npatches))

--- a/biogeochem/FatesForestManagementMod.F90
+++ b/biogeochem/FatesForestManagementMod.F90
@@ -1,0 +1,724 @@
+module FatesForestManagementMod
+
+   ! ============================================================================
+   ! Created by Shijie Shu on Sep 8. 2025
+   ! This module contains all subroutines and functions related to planned 
+   ! wood harvest and improved forest management.
+   !-----------------------------------------------------------------------------------
+   ! Improved forest management practies can be quantified as modifiers to change the
+   ! logging disturbance rates at cohort-patch-site levels, thus quantify strategies as
+   ! different priorties regarding size/age for harvest activity. 
+   ! Site: site_in%resources_management%harvest_wp_scale. Adjust the overall harvest rate
+   ! to match the demand.
+   ! Patch: currentPatch%harvest_rate_scale. Modifier considering age priority.
+   ! Cohort [LOCAL]: harvest_rate_scale_cohort. Modifier considering size priority.
+   ! ============================================================================
+
+   ! Uses
+   use EDLoggingMortalityMod  , only : logging_time
+   use EDParamsMod            , only : logging_age_preference, logging_preference_options
+   use EDParamsMod            , only : logging_ifm_harvest_scale
+   use EDTypesMod             , only : AREA, AREA_INV
+   use FatesGlobals           , only : fates_log
+   use FatesConstantsMod      , only : logging_no_age_preference, logging_oldest_first
+   use FatesConstantsMod      , only : logging_uniform_size, logging_double_rotation, logging_quadruple_rotation
+   use FatesConstantsMod      , only : logging_logistic_size, logging_inv_logistic_size, logging_gaussian_size
+   use FatesConstantsMod      , only : fates_unset_r8, fates_tiny
+   use FatesConstantsMod      , only : primaryland, secondaryland
+   use FatesConstantsMod      , only : min_harvest_rate, min_nocomp_pftfrac_perlanduse
+   use FatesConstantsMod      , only : hlm_harvest_carbon
+   use FatesLitterMod         , only : ncwd
+   use FatesInterfaceTypesMod , only : hlm_num_lu_harvest_cats, numpft
+   use PRTParametersMod       , only : prt_params
+   use PRTGenericMod          , only : carbon12_element
+   use PRTGenericMod          , only : leaf_organ
+   use PRTGenericMod          , only : fnrt_organ
+   use PRTGenericMod          , only : sapw_organ
+   use PRTGenericMod          , only : store_organ
+   use PRTGenericMod          , only : repro_organ
+   use PRTGenericMod          , only : struct_organ
+
+   ! Subroutines
+   public :: get_site_harvest_rate_scale
+   public :: get_patch_harvest_rate_scale
+   public :: get_cohort_harvest_rate_scale
+   public :: get_harvestable_carbon
+   private :: get_harvestable_patch_carbon
+   private :: get_harvested_cohort_carbon
+
+ contains
+
+   ! ============================================================================
+
+   subroutine get_site_harvest_rate_scale(site_in, bc_in, harvestable_forest_c, frac_site_primary, frac_site_secondary_mature)
+
+      ! !USES:
+      use EDLoggingMortalityMod , only : LoggingMortality_frac
+
+      ! !ARGUMENTS:
+      type(ed_site_type) , intent(inout) :: site_in
+      type(bc_in_type) , intent(in) :: bc_in
+      real(r8), intent(in) :: harvestable_forest_c(hlm_num_lu_harvest_cats)
+      real(r8), intent(in) :: frac_site_primary
+      real(r8), intent(in) :: frac_site_secondary_mature
+      !
+      ! !LOCAL VARIABLES:
+      type (fates_patch_type) , pointer :: currentPatch
+      type (fates_cohort_type), pointer :: currentCohort
+
+      real(r8) :: lmort_direct
+      real(r8) :: lmort_collateral
+      real(r8) :: lmort_infra
+      real(r8) :: l_degrad
+      real(r8) :: harvested_cohort_c   ! Variable to store cohort level harvested C
+      integer :: harvest_tag(hlm_num_lu_harvest_cats)
+
+      real(r8) :: target_wp
+      real(r8) :: actual_wp
+      integer :: it
+
+      ! !PARAMETERS
+      integer, parameter :: max_iteration = 5 ! Maximum iterations to obtain target harvest wood product. Currently I don't
+                                              ! plan to move it into parameter files
+
+      ! ==================================================================================================
+      !  DESCRIPTION:
+      !
+      ! For size-dependet harvest, cetain size class might have fewer or no harvest if the available 
+      ! inventory is less than the demand.
+      ! We design the following algorithm to force the other nearby size class to fullfill these demands:
+      ! Loop through cohorts to preview the summed harvested product C for both no harvest size priority,
+      ! i.e., target wood product C
+      ! (target_wp), and with size priority, i.e., actual harvested C  (actual_wp)
+      ! Then calculate the ratio of target_wp to actual_wp as adjustment ratio
+      ! The adjustment ratio will be applied as additional scaling factor to modify cohort-level harvest mortality
+      ! One time adjustment might still not able to match the demand, we iterate this process no more than 5 times.
+      ! ==================================================================================================
+
+      !Initialize
+      site_in%resources_management%harvest_wp_scale = 1._r8
+
+      !Only run this part when considering size dependent priority
+      if (logging_time .and. logging_preference_options >= logging_logistic_size) then
+
+         iteration_loop: do it = 1, max_iteration
+
+            target_wp = 0._r8
+            actual_wp = 0._r8
+
+            currentPatch => site_in%oldest_patch
+            do while (associated(currentPatch))
+
+               currentCohort => currentPatch%shortest
+               do while(associated(currentCohort))
+
+                  ! Target harvest product
+                  call LoggingMortality_frac(currentCohort%pft, currentCohort%dbh, currentCohort%canopy_layer, &
+                        lmort_direct,lmort_collateral,lmort_infra,l_degrad,&
+                        bc_in%hlm_harvest_rates, &
+                        bc_in%hlm_harvest_catnames, &
+                        bc_in%hlm_harvest_units, &
+                        currentPatch%land_use_label, &
+                        currentPatch%age_since_anthro_disturbance, &
+                        frac_site_primary, &
+                        frac_site_secondary_mature, &
+                        harvestable_forest_c, &
+                        currentPatch%harvest_rate_scale, &
+                        harvest_tag, logging_ifm_harvest_scale, logging_uniform_size)
+
+                  call get_harvested_cohort_carbon(currentCohort, lmort_direct, harvested_cohort_c)
+
+                  target_wp = target_wp + harvested_cohort_c
+
+                  ! Actual harvest product
+                  call LoggingMortality_frac(currentCohort%pft, currentCohort%dbh, currentCohort%canopy_layer, &
+                        lmort_direct,lmort_collateral,lmort_infra,l_degrad,&
+                        bc_in%hlm_harvest_rates, &
+                        bc_in%hlm_harvest_catnames, &
+                        bc_in%hlm_harvest_units, &
+                        currentPatch%land_use_label, &
+                        currentPatch%age_since_anthro_disturbance, &
+                        frac_site_primary, &
+                        frac_site_secondary_mature, &
+                        harvestable_forest_c, &
+                        currentPatch%harvest_rate_scale, &
+                        harvest_tag, site_in%resources_management%harvest_wp_scale, logging_preference_options)
+
+                  call get_harvested_cohort_carbon(currentCohort, lmort_direct, harvested_cohort_c)
+
+                  actual_wp = actual_wp + harvested_cohort_c
+
+                  currentCohort => currentCohort%taller
+
+               end do
+
+               currentPatch => currentPatch%younger
+
+            end do
+
+            ! adjustment ratio
+            if( target_wp / (actual_wp + 1e-7_r8) < 1.01 .and. target_wp / (actual_wp + 1e-7_r8) > 0.99 ) exit iteration_loop
+
+            site_in%resources_management%harvest_wp_scale = site_in%resources_management%harvest_wp_scale * target_wp/(actual_wp+1e-7_r8)
+
+            write(fates_log(),*) 'See adjustment factor for harvest scale:', site_in%resources_management%harvest_wp_scale
+
+         end do iteration_loop
+
+      end if  ! logging_time
+
+   end subroutine get_site_harvest_rate_scale
+
+   ! ============================================================================
+
+   subroutine get_patch_harvest_rate_scale(site_in, bc_in, harvestable_forest_c, frac_site_primary, frac_site_secondary_mature)
+
+      ! !USES:
+      use EDPatchDynamicsMod , only : GetPseudoPatchAge, countPatches
+
+      ! !ARGUMENTS:
+      type(ed_site_type) , intent(inout) :: site_in
+      type(bc_in_type) , intent(in) :: bc_in
+      real(r8), intent(in) :: harvestable_forest_c(hlm_num_lu_harvest_cats)
+      real(r8), intent(in) :: frac_site_primary
+      real(r8), intent(in) :: frac_site_secondary_mature
+      
+      ! !LOCAL VARIABLES:
+      type (fates_patch_type) , pointer :: currentPatch
+      type (fates_cohort_type), pointer :: currentCohort
+
+      integer :: npatches        ! Number of patches
+      integer :: ipatch, , curpft ! index, used in min-heap merge
+      integer, allocatable :: jpatch(:)   ! index array, used in min-heap merge
+      integer, allocatable :: pftlen(:)   ! array length, used in min-heap merge
+      real(r8), allocatable :: minheap(:)            ! minimum heap array, used in min-heap merge
+      integer, allocatable :: order_of_patches(:)    ! Record a copy of patch order 
+      integer, allocatable :: order_of_patches_per_pft(:)  ! Record a copy of patch order for each pft
+      real(r8), allocatable :: age_patches(:)   ! Record a copy of patch age
+      real(r8), allocatable :: age_patches_per_pft(:)   ! Record a copy of patch age for each pft
+
+      real(r8) :: frac_site      ! Temporary variable
+      real(r8) :: harvest_rate     ! Temporary variable
+      real(r8) :: harvestable_patch_c
+      real(r8) :: remain_harvest_rate(hlm_num_lu_harvest_cats)    ! Temporary variable
+      real(r8) :: temp_totc    ! for debug test, can be removed in released version
+      integer :: h_index     ! index for looping over harvest categories
+      integer :: harvest_tag(hlm_num_lu_harvest_cats)
+
+      ! !PARAMETERS
+
+      ! Initialize the rest of local variables
+      npatches = 0
+      frac_site = 1._r8
+      remain_harvest_rate = fates_unset_r8  ! set to negative value to indicate uninitialized
+
+      ! =====================================================================
+      !  DESCRIPTION:
+      !
+      !  This modifier is for age_prioritized forest management
+      !  The following code will calculate patch level harvest_rate_scale 
+      !  for each secondary patch
+      !  There're currently 2 options:
+      !  1) uniformly harvest each patch (harvest_rate_scale = 1._r8)
+      !  2) harvest the oldest patch first
+
+      ! Initialize harvest_rate_scale
+      currentPatch => site_in%oldest_patch
+
+      do while (associated(currentPatch))
+         ! Initialize harvest rate scale to 1.0 first
+         currentPatch%harvest_rate_scale = 1._r8
+
+         currentPatch => currentPatch%younger
+      end do
+
+      ! =====================================================================
+      ! "Sort" patch based on patch age since anthropegenic disturbance
+      ! =====================================================================
+      ! Patch sequence in the data list (patchno) follows pseudo-age defined 
+      ! in function GetPseudoPatchAge to simplify LUC related calculation.
+      ! Here we don't modify the actual patch sequence but use another age 
+      ! tag currentPatch%order_age_since_anthro to record patch age for 
+      ! age-prioritized wood harvest strategy.
+      !
+      ! In FATES, PFT-patch relation can be different under diffrent modes. 
+      ! This can be separated into 2 cases:
+      ! Case 1: For most of FATES modes, we directly use pseudo-age since 
+      ! there's no paired 1 patch - 1 PFT relation
+      ! Case 2: For the more general case in global simulation that harvest 
+      ! all PFTs equally under no competition mode, we need to sort again 
+      ! using last 4 digits of pseudo-age, i.e., actual patch age. Since for 
+      ! each PFT the patch sequence is already sorted, here we need to 
+      ! loop over PFTs and merge these sorted sequences into one sorted 
+      ! array through min-heap merge
+
+      if (logging_time .and. logging_age_preference == logging_oldest_first) then
+
+         ! First loop to count total number of patches and initialize order
+         ! using patchno
+         ! For most of the cases the process is over after this step
+         currentPatch => site_in%oldest_patch
+         npatches = 0
+
+         do while (associated(currentPatch))
+            npatches = npatches + 1
+            currentPatch%order_age_since_anthro = currentPatch%patchno
+
+            currentPatch => currentPatch%younger
+         end do
+
+         ! For case 2, i.e., nocomp mode only
+         if (hlm_use_nocomp.eq.itrue) then
+
+            allocate(order_of_patches(1:npatches))
+            allocate(order_of_patches_per_pft(1:numpft,1:npatches))
+            allocate(age_patches(1:npatches))
+            allocate(age_patches_per_pft(1:numpft,1:npatches))
+            allocate(minheap(1:numpft))
+            allocate(jpatch(1:numpft))
+            allocate(pftlen(1:numpft))
+
+            ! Second loop to assign patch sequence, age and number of pacthes in each PFT to array
+            ! thus can avoid for loop over data list
+            currentPatch => site_in%oldest_patch
+            ipatch = 0
+            pftlen(:) = 0
+            do while (associated(currentPatch))
+               ipatch = ipatch + 1
+               order_of_patches(ipatch) = currentPatch%order_age_since_anthro
+               age_patches(ipatch) = mod(GetPseudoPatchAge(currentPatch), 1.e4)
+
+               do curpft=1,numpft
+                  if(currentPatch%nocomp_pft_label .eq. curpft)
+                     pftlen(curpft) = pftlen(curpft) + 1
+                     order_of_patches_per_pft(curpft, pftlen(curpftpft)) = currentPatch%order_age_since_anthro
+                     age_patches_per_pft(curpft, pftlen(curpftpft)) = mod(GetPseudoPatchAge(currentPatch), 1.e4)
+                  end if
+               end do
+
+               currentPatch => currentPatch%younger
+            end do
+
+            ! Third loop to initailize min-heap, first element of each array
+            minheap(:) = 0._r8
+            do curpft=1,numpft
+               if(pftlen(curpft) > 0) then
+                  minheap(curpft) = age_patches_per_pft(curpft, 1)
+               end if
+            end do
+
+            ! Fourth loop to get min from min-heap then insert 'age_patches_per_pft' and record order in 'order_of_patches'
+            ! no need to loop over data list here
+            jpatch(:) = 1
+            do ipatch = 1, npacthes
+               ! Find the minimum and assign the order
+               curpft = minloc(minheap)
+               order_of_patches(ipatch) = order_of_patches_per_pft(curpft, jpatch(curpft))
+               ! Move to the next element and insert into minheap array
+               jpatch(curpft) = jpatch(curpft) + 1
+               if(jpatch(curpft) <= pftlen(curpft)) then
+                     minheap(curpft) = age_patches_per_pft(ipft, jpatch(curpft))
+                  else
+                     minheap(curpft) = 0._r8
+                  end if
+               end if
+            end do
+
+            ! Fifthth loop to assign order back to patches
+            do ipatch = 1, npatches
+               currentPatch => site_in%oldest_patch
+
+               ! Look for the patch by usig patchno
+               inner_loop: do while (associated(currentPatch))
+
+                  if(order_of_patches(ipatch) .eq. currentPatch%patchno) then
+                     currentPatch%order_age_since_anthro = ipatch
+                     exit inner_loop
+                  end if
+
+                  currentPatch => currentPatch%younger
+               end do inner_loop
+            end do
+
+            ! Clean temperary variables
+            deallocate(order_of_patches)
+            deallocate(order_of_patches_per_pft)
+            deallocate(age_patches)
+            deallocate(age_patches_per_pft)
+            deallocate(minheap)
+            deallocate(jpatch)
+            deallocate(pftlen)
+
+         end if  ! nocomp
+
+         ! Loop through all patches and calculate the harvest rate scale based
+         ! on oldest first strategy
+         target_loop: do ipatch = 1, npatches
+
+            currentPatch => site_in%oldest_patch
+            search_loop: do while (associated(currentPatch))
+
+               found_patch: if(currentPatch%order_age_since_anthro .eq. ipatch) then
+
+                  ! Here age priority is based on age since anthropogenic disturbance
+                  ! thus we skip the primary land since they all have this age = 0
+                  if_secondary: if(currentPatch%land_use_label .eq. secondaryland) then
+                      if(currentPatch%age_since_anthro_disturbance >= secondary_age_threshold) then
+                         h_index = 3
+                         frac_site = frac_site_secondary_mature
+                      else
+                         h_index = 4
+                         frac_site = 1._r8 - frac_site_primary - frac_site_secondary_mature
+                      end if
+                      ! Obtain uniform harvest rate (area fraction) of the corresponding patch
+                      if(bc_in%hlm_harvest_units == hlm_harvest_carbon) then
+                          call get_harvest_rate_carbon (currentPatch%land_use_label, bc_in%hlm_harvest_catnames, &
+                               bc_in%hlm_harvest_rates, currentPatch%age_since_anthro_disturbance, harvestable_forest_c, &
+                               harvest_rate, harvest_tag)
+                      else
+                          call get_harvest_rate_area (currentPatch%land_use_label, bc_in%hlm_harvest_catnames, &
+                               bc_in%hlm_harvest_rates, frac_site_primary, frac_site_secondary_mature, &
+                               currentPatch%age_since_anthro_disturbance, harvest_rate)
+                      end if
+                      ! For the first time, initialize remain_harvest_rate
+                      if(remain_harvest_rate(h_index) < 0) then
+                         if(bc_in%hlm_harvest_units == hlm_harvest_carbon) then
+                            ! In kgC ha-1, no need to scale
+                            remain_harvest_rate(h_index) = bc_in%hlm_harvest_rates(h_index)
+                         else
+                            ! In area fraction (0 - 1) after scaling to the area of per patch land use type
+                            remain_harvest_rate(h_index) = harvest_rate
+                         end if
+                      end if
+                      ! Only calculate harvest rate scale for non-zero harvest rate
+                      if (harvest_rate > min_harvest_rate) then
+                         if(bc_in%hlm_harvest_units == hlm_harvest_carbon) then
+                            ! Compare the patch level harvestable carbon and see if larger than remain_harvest_rate
+                            ! Note the scaling factor applied on area fraction as harvest unit
+                            call get_harvestable_patch_carbon(currentPatch, harvestable_patch_c)
+                            if(harvestable_patch_c >= remain_harvest_rate(h_index)) then
+                                currentPatch%harvest_rate_scale = remain_harvest_rate(h_index) / &
+                                    (harvestable_patch_c + fates_tiny) / harvest_rate
+                                remain_harvest_rate(h_index) = 0._r8
+                            else
+                                ! harvest almost 100%, leave 0.01% to prevent removing the patch completely, which may cause
+                                ! model crashing under nocomp mode
+                                currentPatch%harvest_rate_scale = (1._r8 - min_nocomp_pftfrac_perlanduse) / harvest_rate
+                                remain_harvest_rate(h_index) = remain_harvest_rate(h_index) - (1._r8 - min_nocomp_pftfrac_perlanduse) * harvestable_patch_c
+                            end if
+                         else
+                            ! Compare the patch area and see if larger than remain_harvest_rate
+                            if((currentPatch%area/(AREA*frac_site)) >= remain_harvest_rate(h_index)) then
+                                currentPatch%harvest_rate_scale = remain_harvest_rate(h_index) / &
+                                    (currentPatch%area/(AREA*frac_site) + fates_tiny) / harvest_rate
+                                remain_harvest_rate(h_index) = 0._r8
+                            else
+                                ! leave 1% to prevent removing the patch completely
+                                currentPatch%harvest_rate_scale = (1._r8 - min_nocomp_pftfrac_perlanduse) / harvest_rate
+                                remain_harvest_rate(h_index) = remain_harvest_rate(h_index) - (1._r8 - min_nocomp_pftfrac_perlanduse) * (currentPatch%area/(AREA*frac_site))
+                            end if
+                         end if
+                      end if
+
+                      ! For diagnosing the harvestable carbon
+                      ! These codes can be removed in released version
+                      temp_totc = 0._r8
+                      currentCohort => currentPatch%tallest
+
+                      do while (associated(currentCohort))
+
+                         if (currentCohort%canopy_layer>=1) then
+                            temp_totc = temp_totc + (currentCohort%prt%GetState(sapw_organ, carbon12_element) + &
+                                currentCohort%prt%GetState(struct_organ, carbon12_element)) * currentCohort%n * AREA_INV
+                         end if
+                         currentCohort => currentCohort%shorter
+
+                      end do
+
+                      write(fates_log(),*) 'See patch number:', currentPatch%patchno
+                      write(fates_log(),*) 'See patch age:', currentPatch%age
+                      write(fates_log(),*) 'See patch total carbon (kgc m-2):', temp_totc
+                      write(fates_log(),*) 'See patch age sec:', currentPatch%age_since_anthro_disturbance
+                      write(fates_log(),*) 'See patch order sec:', currentPatch%order_age_since_anthro
+                      write(fates_log(),*) 'See harvest index:', h_index
+                      write(fates_log(),*) 'See harvest rate scale:', currentPatch%harvest_rate_scale
+                      write(fates_log(),*) 'See original harvest rate:', bc_in%hlm_harvest_rates(h_index)
+                      write(fates_log(),*) 'See harvest rate:', harvest_rate
+                      write(fates_log(),*) 'See harvestable_forest_c:', harvestable_forest_c
+                      write(fates_log(),*) 'See site fraction:', frac_site
+                      write(fates_log(),*) 'See sec mature fraction:', frac_site_secondary_mature
+                      write(fates_log(),*) 'See sec young fraction:', 1 - frac_site_primary - frac_site_secondary_mature
+                      write(fates_log(),*) 'See area:', currentPatch%area/AREA
+                      write(fates_log(),*) '==================== Next patch ================'
+
+                  end if if_secondary
+
+                  ! Exit current inner loop to find the next old ipatch
+                  exit search_loop
+
+               end if found_patch
+
+               currentPatch => currentPatch%younger
+            end do search_loop
+
+         end do target_loop
+
+      end if  ! logging_time
+
+   end subroutine get_patch_harvest_rate_scale
+
+   ! ============================================================================
+
+   subroutine get_cohort_harvest_rate_scale (dbh, harvest_wp_scale, harvest_rate_scale_patch, harvest_rate_scale_cohort)
+
+      ! !USES:
+      use EDParamsMod            , only : logging_dbhmin
+      use EDParamsMod            , only : logging_dbhmax
+
+      ! !ARGUMENTS:
+      real(r8), intent(in) :: dbh
+      real(r8), intent(in) :: harvest_wp_scale
+      real(r8), intent(in) :: harvest_rate_scale_patch
+      real(r8), intent(out) :: harvest_rate_scale_cohort
+
+      ! [Cohort level] Logging size prefrence or change rotation length
+      select case (logging_preference_options)
+
+      case (logging_uniform_size)
+
+         harvest_rate_scale_cohort = harvest_wp_scale * harvest_rate_scale_patch
+
+      case (logging_double_rotation)
+
+         harvest_rate_scale_cohort = csite%harvest_wp_scale * 0.5_r8 * harvest_rate_scale_patch
+
+      case (logging_quadruple_rotation)
+
+          harvest_rate_scale_cohort = harvest_wp_scale * 0.25_r8 * harvest_rate_scale_patch
+
+      case (logging_logistic_size)
+
+          harvest_rate_scale_cohort = harvest_wp_scale * harvest_rate_scale_patch * &
+              1._r8/(1._r8 + exp(-0.1*(dbh-(logging_dbhmin+logging_dbhmax)/2._r8)))
+
+      case (logging_inv_logistic_size)
+
+          harvest_rate_scale_cohort = harvest_wp_scale * harvest_rate_scale_patch * &
+              1._r8/(1._r8 + exp(0.1*(dbh-(logging_dbhmin+logging_dbhmax)/2._r8)))
+
+      case (logging_gaussian_size)
+
+          harvest_rate_scale_cohort = harvest_wp_scale * harvest_rate_scale_patch * &
+              (1._r8/(5._r8*2.5_r8)) * exp(-(dbh - (logging_dbhmin+logging_dbhmax)/2._r8) ** & 
+              2._r8 / (2._r8 * 5._r8 ** 2._r8))
+
+      case DEFAULT
+
+      end select
+
+   end subroutine get_cohort_harvest_rate_scale
+
+   ! ============================================================================
+
+   subroutine get_harvestable_carbon (csite, site_area, hlm_harvest_catnames, harvestable_forest_c )
+
+     !USES:
+     use SFParamsMod,  only : SF_val_cwd_frac
+
+     ! -------------------------------------------------------------------------------------------
+     !
+     !  DESCRIPTION:
+     !  get the total site level carbon availale for harvest for three different harvest categories:
+     !  primary forest, secondary mature forest and secondary young forest
+     !  under two different scenarios:
+     !  harvestable carbon: aggregate all cohorts matching the dbhmin harvest criteria
+     !
+     !  this subroutine shall be called outside the patch loop
+     !  output will be used to estimate the area-based harvest rate (get_harvest_rate_carbon)
+     !  for each cohort.
+
+     ! Arguments
+     type(ed_site_type), intent(in), target :: csite
+     real(r8), intent(in) :: site_area    ! The total site area
+     character(len=64), intent(in) :: hlm_harvest_catnames(:) ! names of hlm harvest categories
+
+     real(r8), intent(out) :: harvestable_forest_c(hlm_num_lu_harvest_cats)
+
+     ! Local Variables
+     type(fates_patch_type), pointer  :: currentPatch
+     type(fates_cohort_type), pointer :: currentCohort
+     real(r8) :: harvestable_patch_c     ! patch level total carbon available for harvest, kgC site-1
+     real(r8) :: harvestable_cohort_c    ! cohort level total carbon available for harvest, kgC site-1
+     real(r8) :: sapw_m      ! Biomass of sap wood
+     real(r8) :: struct_m    ! Biomass of structural organs
+     integer :: pft         ! Index of plant functional type
+     integer :: h_index     ! for looping over harvest categories
+
+     ! Initialization
+     harvestable_forest_c = 0._r8
+
+     ! loop over patches
+     currentPatch => csite%oldest_patch
+     do while (associated(currentPatch))
+        harvestable_patch_c = 0._r8
+        currentCohort => currentPatch%tallest
+
+        do while (associated(currentCohort))
+           pft = currentCohort%pft
+
+           ! only account for cohorts matching the following conditions
+           if(int(prt_params%woody(pft)) == 1) then ! only set logging rates for trees
+              sapw_m   = currentCohort%prt%GetState(sapw_organ, carbon12_element)
+              struct_m = currentCohort%prt%GetState(struct_organ, carbon12_element)
+              ! logging_direct_frac shall be 1 for LUH2 driven simulation and global simulation
+              ! in site level study logging_direct_frac shall be surveyed
+              ! unit:  [kgC ] = [kgC/plant] * [plant/ha] * [ha/ 10k m2] * [ m2 area ]
+              harvestable_cohort_c = logging_direct_frac * ( sapw_m + struct_m ) * &
+                     prt_params%allom_agb_frac(currentCohort%pft) * &
+                     SF_val_CWD_frac(ncwd) * logging_export_frac * &
+                     currentCohort%n! * AREA_INV * site_area
+
+              ! No harvest for trees without canopy (exclude 0)
+              if (currentCohort%canopy_layer>=1) then
+                 ! logging amount are based on dbh min and max criteria
+                 if (currentCohort%dbh >= logging_dbhmin .and. .not. &
+                       ((logging_dbhmax < fates_check_param_set) .and. (currentCohort%dbh >= logging_dbhmax )) ) then
+                    ! Harvestable C: aggregate cohorts fit the criteria
+                    harvestable_patch_c = harvestable_patch_c + harvestable_cohort_c
+                 end if
+              end if
+           end if
+           currentCohort => currentCohort%shorter
+        end do
+
+        ! judge which category the current patch belong to
+        ! since we have not separated forest vs. non-forest
+        ! all carbon belongs to the forest categories
+        do h_index = 1,hlm_num_lu_harvest_cats
+           if (currentPatch%land_use_label .eq. primaryland) then
+              ! Primary
+              if(hlm_harvest_catnames(h_index) .eq. "HARVEST_VH1") then
+                 harvestable_forest_c(h_index) = harvestable_forest_c(h_index) + harvestable_patch_c
+              end if
+           else if (currentPatch%land_use_label .eq. secondaryland .and. &
+                currentPatch%age_since_anthro_disturbance >= secondary_age_threshold) then
+              ! Secondary mature
+              if(hlm_harvest_catnames(h_index) .eq. "HARVEST_SH1") then
+                 harvestable_forest_c(h_index) = harvestable_forest_c(h_index) + harvestable_patch_c
+              end if
+           else if (currentPatch%land_use_label .eq. secondaryland .and. &
+                currentPatch%age_since_anthro_disturbance < secondary_age_threshold) then
+              ! Secondary young
+              if(hlm_harvest_catnames(h_index) .eq. "HARVEST_SH2") then
+                 harvestable_forest_c(h_index) = harvestable_forest_c(h_index) + harvestable_patch_c
+              end if
+           end if
+        end do
+        currentPatch => currentPatch%younger
+     end do
+
+   end subroutine get_harvestable_carbon
+
+   ! ============================================================================
+
+   subroutine get_harvestable_patch_carbon ( currentPatch, harvestable_patch_c )
+
+     !USES:
+     use SFParamsMod,  only : SF_val_cwd_frac
+
+     ! -------------------------------------------------------------------------------------------
+     !
+     !  DESCRIPTION:
+     !  get the total carbon (ha-1) availale for harvest in current Patch
+     !  harvestable carbon: aggregate all cohorts matching the dbhmin and dbhmax harvest criteria
+     !
+     !  this subroutine shall be called inside the patch loop
+     !  output will be used for diagnosis or for scaling patch level harvest rate
+
+     ! Arguments
+     type(fates_patch_type) , intent(in), target  :: currentPatch
+
+     real(r8), intent(out) :: harvestable_patch_c
+
+     ! Local Variables
+     type(fates_cohort_type), pointer :: currentCohort
+     real(r8) :: harvestable_cohort_c    ! cohort level total carbon available for harvest, kgC site-1
+     real(r8) :: sapw_m      ! Biomass of sap wood
+     real(r8) :: struct_m    ! Biomass of structural organs
+     integer :: pft         ! Index of plant functional type
+
+     ! loop over cohorts
+     harvestable_patch_c = 0._r8
+     currentCohort => currentPatch%tallest
+
+     do while (associated(currentCohort))
+        pft = currentCohort%pft
+
+        ! only account for cohorts matching the following conditions
+        if(int(prt_params%woody(pft)) == 1) then ! only set logging rates for trees
+           sapw_m   = currentCohort%prt%GetState(sapw_organ, carbon12_element)
+           struct_m = currentCohort%prt%GetState(struct_organ, carbon12_element)
+           ! logging_direct_frac shall be 1 for LUH2 driven simulation and global simulation
+           ! in site level study logging_direct_frac shall be surveyed
+           ! unit:  [kgC ] = [kgC/plant] * [plant/ha] * [ha/ 10k m2] * [ m2 area ]
+           harvestable_cohort_c = logging_direct_frac * ( sapw_m + struct_m ) * &
+                  prt_params%allom_agb_frac(currentCohort%pft) * &
+                  SF_val_CWD_frac(ncwd) * logging_export_frac * &
+                  currentCohort%n! * AREA_INV * site_area
+
+           ! No harvest for trees without canopy
+           if (currentCohort%canopy_layer>=1) then
+              ! logging amount are based on dbh min and max criteria
+              if (currentCohort%dbh >= logging_dbhmin .and. .not. &
+                    ((logging_dbhmax < fates_check_param_set) .and. (currentCohort%dbh >= logging_dbhmax )) ) then
+                 ! Harvestable C: aggregate cohorts fit the criteria
+                 harvestable_patch_c = harvestable_patch_c + harvestable_cohort_c
+              end if
+           end if
+        end if
+        currentCohort => currentCohort%shorter
+     end do
+
+   end subroutine get_harvestable_patch_carbon
+
+
+   ! ============================================================================
+
+   subroutine get_harvested_cohort_carbon ( currentCohort, lmort_direct, harvested_cohort_c )
+
+     !USES:
+     use SFParamsMod,  only : SF_val_cwd_frac
+
+
+     ! -------------------------------------------------------------------------------------------
+     !
+     !  DESCRIPTION:
+     !  get the harvested carbon in current Cohort through lmort_direct
+     !
+     !  this subroutine shall be called inside the cohort loop
+     !  output will be used for adjusting IFM wood harvest with size priority
+
+     ! Arguments
+     type(fates_cohort_type) , intent(in), target  :: currentCohort
+     real(r8), intent(in)  :: lmort_direct
+
+     real(r8), intent(out) :: harvested_cohort_c
+
+     ! Local Variables
+     real(r8) :: sapw_m      ! Biomass of sap wood
+     real(r8) :: struct_m    ! Biomass of structural organs
+
+     ! only account for cohorts matching the following conditions
+     sapw_m   = currentCohort%prt%GetState(sapw_organ, carbon12_element)
+     struct_m = currentCohort%prt%GetState(struct_organ, carbon12_element)
+
+     harvested_cohort_c = lmort_direct * ( sapw_m + struct_m ) * &
+            prt_params%allom_agb_frac(currentCohort%pft) * &
+            SF_val_CWD_frac(ncwd) * logging_export_frac * &
+            currentCohort%n
+
+   end subroutine get_harvested_cohort_carbon
+
+   ! ============================================================================
+
+end module FatesForestManagementMod

--- a/biogeochem/FatesLitterMod.F90
+++ b/biogeochem/FatesLitterMod.F90
@@ -447,7 +447,7 @@ contains
 
      !ARGUMENTS
      real(r8), intent(in)               :: dbh !dbh of cohort [cm]
-     integer,  intent(in)               :: ncwd !number of cwd pools
+     integer, intent(in)                :: ncwd !number of cwd pools
      real(r8), intent(in)               :: SF_val_CWD_frac(:) !fates parameter specifying the
                                                               !fraction of struct + sapw going
                                                               !to each CWD class

--- a/biogeochem/FatesPatchMod.F90
+++ b/biogeochem/FatesPatchMod.F90
@@ -181,6 +181,7 @@ module FatesPatchMod
     real(r8) :: harvest_rate_scale                        ! scaling factor applied to logging disturbance rate (primaryland, secondaryland, etc)
                                                           ! purpose is to assign patch-specific harvest priority based on certain
                                                           ! strategy
+    integer  :: order_age_since_anthro                    ! order of the patch based on the age since anthropogenic disturbance
 
     !---------------------------------------------------------------------------
 
@@ -367,6 +368,7 @@ module FatesPatchMod
       this%disturbance_rates(:)         = nan
       this%fract_ldist_not_harvested    = nan
       this%harvest_rate_scale           = nan
+      this%order_age_since_anthro       = fates_unset_int
 
       ! LAND USE
       this%landuse_transition_rates(:)  = nan
@@ -752,6 +754,7 @@ module FatesPatchMod
       write(fates_log(),*) 'pa%disturbance_rates  = ',this%disturbance_rates(:)
       write(fates_log(),*) 'pa%harvest_rate_scale = ',this%harvest_rate_scale
       write(fates_log(),*) 'pa%land_use_label     = ',this%land_use_label
+      write(fates_log(),*) 'pa%order_age_since_anthro  = ',this%order_age_since_anthro
       write(fates_log(),*) '----------------------------------------'
 
       do el = 1, num_elements

--- a/biogeochem/FatesPatchMod.F90
+++ b/biogeochem/FatesPatchMod.F90
@@ -179,7 +179,7 @@ module FatesPatchMod
     real(r8) :: landuse_transition_rates(n_landuse_cats)  ! land use tranision rate
     real(r8) :: fract_ldist_not_harvested                 ! fraction of logged area that is canopy trees that weren't harvested [0-1]
     real(r8) :: harvest_rate_scale                        ! scaling factor applied to logging disturbance rate (primaryland, secondaryland, etc)
-                                                          ! purpose is to assign patch-specific harvest priority based on certain
+                                                          ! purpose is to assign patch-specific harvest priority based on certain IFM
                                                           ! strategy
     integer  :: order_age_since_anthro                    ! order of the patch based on the age since anthropogenic disturbance
 

--- a/biogeochem/FatesPatchMod.F90
+++ b/biogeochem/FatesPatchMod.F90
@@ -178,6 +178,9 @@ module FatesPatchMod
                                                           !                                 4) land use change
     real(r8) :: landuse_transition_rates(n_landuse_cats)  ! land use tranision rate
     real(r8) :: fract_ldist_not_harvested                 ! fraction of logged area that is canopy trees that weren't harvested [0-1]
+    real(r8) :: harvest_rate_scale                        ! scaling factor applied to logging disturbance rate (primaryland, secondaryland, etc)
+                                                          ! purpose is to assign patch-specific harvest priority based on certain
+                                                          ! strategy
 
     !---------------------------------------------------------------------------
 
@@ -363,6 +366,7 @@ module FatesPatchMod
       ! DISTURBANCE 
       this%disturbance_rates(:)         = nan
       this%fract_ldist_not_harvested    = nan
+      this%harvest_rate_scale           = nan
 
       ! LAND USE
       this%landuse_transition_rates(:)  = nan
@@ -440,6 +444,7 @@ module FatesPatchMod
       ! DISTURBANCE 
       this%disturbance_rates(:)              = 0.0_r8 
       this%fract_ldist_not_harvested         = 0.0_r8
+      this%harvest_rate_scale                = 0.0_r8 
 
       ! LAND USE
       this%landuse_transition_rates(:)       = 0.0_r8
@@ -745,6 +750,7 @@ module FatesPatchMod
       write(fates_log(),*) 'pa%c_stomata          = ',this%c_stomata
       write(fates_log(),*) 'pa%c_lblayer          = ',this%c_lblayer
       write(fates_log(),*) 'pa%disturbance_rates  = ',this%disturbance_rates(:)
+      write(fates_log(),*) 'pa%harvest_rate_scale = ',this%harvest_rate_scale
       write(fates_log(),*) 'pa%land_use_label     = ',this%land_use_label
       write(fates_log(),*) '----------------------------------------'
 

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -334,7 +334,8 @@ contains
 
     ! Resources management (logging/harvesting, etc)
     site_in%resources_management%harvest_debt = 0.0_r8
-    site_in%resources_management%harvest_debt_sec = 0.0_r8
+    site_in%resources_management%harvest_debt_sec_y = 0.0_r8
+    site_in%resources_management%harvest_debt_sec_m = 0.0_r8
     site_in%resources_management%trunk_product_site  = 0.0_r8
 
     ! canopy spread

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -209,6 +209,11 @@ contains
        allocate(site_in%flux_diags(el)%root_litter_input(1:numpft))
     end do
 
+    ! Mass balance 
+    do el=1,num_elements
+       allocate(site_in%mass_balance(el)%wood_product_sz(1:nlevsclass))
+    end do
+
     ! Initialize the static soil
     ! arrays from the boundary (initial) condition
     site_in%zi_soil(:) = bc_in%zi_sisl(:)

--- a/main/EDMainMod.F90
+++ b/main/EDMainMod.F90
@@ -89,6 +89,7 @@ module EDMainMod
   use EDLoggingMortalityMod    , only : get_harvestable_carbon
   use DamageMainMod            , only : IsItDamageTime
   use EDPatchDynamicsMod       , only : get_frac_site_primary
+  use EDPatchDynamicsMod       , only : get_frac_site_secondary_mature
   use FatesGlobals             , only : endrun => fates_endrun
   use ChecksBalancesMod        , only : SiteMassStock
   use EDMortalityFunctionsMod  , only : Mortality_Derivative
@@ -373,6 +374,7 @@ contains
                                       ! because it inherited them (such as daily carbon balance)
     real(r8) :: target_leaf_c
     real(r8) :: frac_site_primary
+    real(r8) :: frac_site_secondary_mature
 
     real(r8) :: harvestable_forest_c(hlm_num_lu_harvest_cats)
     integer  :: harvest_tag(hlm_num_lu_harvest_cats)
@@ -409,6 +411,7 @@ contains
     !-----------------------------------------------------------------------
 
     call get_frac_site_primary(currentSite, frac_site_primary)
+    call get_frac_site_secondary_mature(currentSite, frac_site_secondary_mature)
 
     ! Clear site GPP and AR passing to HLM
     bc_out%gpp_site = 0._r8
@@ -474,7 +477,8 @@ contains
                currentPatch%btran_ft, mean_temp,                               &
                currentPatch%land_use_label,                                    &
                currentPatch%age_since_anthro_disturbance, frac_site_primary,   &
-                 harvestable_forest_c, harvest_tag)
+               frac_site_secondary_mature, harvestable_forest_c, &
+               currentPatch%harvest_rate_scale, harvest_tag)
 
              ! -----------------------------------------------------------------------------
              ! Apply Plant Allocation and Reactive Transport

--- a/main/EDMainMod.F90
+++ b/main/EDMainMod.F90
@@ -933,7 +933,7 @@ contains
           error_frac      = 0.0_r8
        end if
 
-       if ( error_frac > 10e-6_r8 .or. (error /= error) ) then
+       if ( error_frac > 10e-3_r8 .or. (error /= error) ) then
           write(fates_log(),*) 'mass balance error detected'
           write(fates_log(),*) 'element type (see PRTGenericMod.F90): ',element_list(el)
           write(fates_log(),*) 'error fraction relative to biomass stock: ',error_frac

--- a/main/EDMainMod.F90
+++ b/main/EDMainMod.F90
@@ -67,7 +67,7 @@ module EDMainMod
   use FatesPatchMod            , only : fates_patch_type
   use FatesCohortMod           , only : fates_cohort_type
   use EDTypesMod               , only : AREA
-  use EDTypesMod               , only : site_massbal_type
+  use EDTypesMod               , only : site_massbal_type, site_fluxdiags_type
   use PRTGenericMod            , only : num_elements
   use PRTGenericMod            , only : element_list
   use PRTGenericMod            , only : element_pos
@@ -862,6 +862,7 @@ contains
     !
     ! !LOCAL VARIABLES:
     type(site_massbal_type),pointer :: site_mass
+    type(site_fluxdiags_type), pointer :: flux_diags
     real(r8) :: biomass_stock   ! total biomass   in Kg/site
     real(r8) :: litter_stock    ! total litter    in Kg/site
     real(r8) :: seed_stock      ! total seed mass in Kg/site
@@ -905,6 +906,7 @@ contains
     do el = 1, num_elements
 
        site_mass => currentSite%mass_balance(el)
+       flux_diags => currentSite%flux_diags(element_pos(carbon12_element))
 
        call SiteMassStock(currentSite,el,total_stock,biomass_stock,litter_stock,seed_stock)
 
@@ -933,6 +935,9 @@ contains
           error_frac      = 0.0_r8
        end if
 
+       ! For debug
+       write(fates_log(),*) 'call index: ',call_index
+       write(fates_log(),*) 'wood_product: ',site_mass%wood_product
        if ( error_frac > 10e-3_r8 .or. (error /= error) ) then
           write(fates_log(),*) 'mass balance error detected'
           write(fates_log(),*) 'element type (see PRTGenericMod.F90): ',element_list(el)

--- a/main/EDMainMod.F90
+++ b/main/EDMainMod.F90
@@ -86,7 +86,7 @@ module EDMainMod
   use FatesPlantHydraulicsMod  , only : AccumulateMortalityWaterStorage
   use FatesAllometryMod        , only : h_allom,tree_sai,tree_lai
   use EDLoggingMortalityMod    , only : IsItLoggingTime
-  use EDLoggingMortalityMod    , only : get_harvestable_carbon
+  use FatesForestManagementMod , only : get_harvestable_carbon
   use DamageMainMod            , only : IsItDamageTime
   use EDPatchDynamicsMod       , only : get_frac_site_primary
   use EDPatchDynamicsMod       , only : get_frac_site_secondary_mature

--- a/main/EDParamsMod.F90
+++ b/main/EDParamsMod.F90
@@ -522,7 +522,13 @@ contains
     call fates_params%RegisterParameter(name=bgc_name_soil_salinity, dimension_shape=dimension_shape_scalar, &
          dimension_names=dim_names_scalar) 
 
+    call fates_params%RegisterParameter(name=logging_name_age_preference, dimension_shape=dimension_shape_scalar, &
+         dimension_names=dim_names_scalar)
+
     call fates_params%RegisterParameter(name=logging_name_preference_options, dimension_shape=dimension_shape_scalar, &
+         dimension_names=dim_names_scalar)
+
+    call fates_params%RegisterParameter(name=logging_name_ifm_harvest_scale, dimension_shape=dimension_shape_scalar, &
          dimension_names=dim_names_scalar)
 
     call fates_params%RegisterParameter(name=logging_name_dbhmin, dimension_shape=dimension_shape_scalar, &

--- a/main/EDParamsMod.F90
+++ b/main/EDParamsMod.F90
@@ -237,9 +237,16 @@ module EDParamsMod
    
    ! Logging Control Parameters (ONLY RELEVANT WHEN USE_FATES_LOGGING = TRUE)
    ! ----------------------------------------------------------------------------------------------
+   integer,protected, public :: logging_age_preference      ! switch for choosing patch age preference for logging
+   ! 1 - uniform, 2 - from oldest
+   character(len=param_string_length),parameter,public :: logging_name_age_preference = "fates_landuse_logging_age_preference"
+
    integer,protected, public :: logging_preference_options  ! switch for choosing size or rotation preference for logging
    ! 1 for uniform, 2 for double rotation, 3 for quadruple rotation, 4 for logistic, 5 for inverse logistic, 6 for gaussian
    character(len=param_string_length),parameter,public :: logging_name_preference_options = "fates_landuse_logging_preference_options"
+
+   real(r8),protected, public :: logging_ifm_harvest_scale   ! scaling factor of harvest rate under improved forest management
+   character(len=param_string_length),parameter,public :: logging_name_ifm_harvest_scale = "fates_landuse_logging_ifm_harvest_scale"
 
    real(r8),protected,public :: logging_dbhmin              ! Minimum dbh at which logging is applied (cm)
                                                             ! Typically associated with harvesting
@@ -342,7 +349,9 @@ contains
     hydr_psicap                           = nan
     hydr_solver                           = -9
     bgc_soil_salinity                     = nan
+    logging_age_preference                = -9
     logging_preference_options            = -9
+    logging_ifm_harvest_scale             = nan
     logging_dbhmin                        = nan
     logging_dbhmax                        = nan
     logging_collateral_frac               = nan
@@ -735,9 +744,16 @@ contains
     call fates_params%RetrieveParameter(name=bgc_name_soil_salinity, &
           data=bgc_soil_salinity)	  
 
+    call fates_params%RetrieveParameter(name=logging_name_age_preference, &
+          data=tmpreal)
+    logging_age_preference = nint(tmpreal)
+
     call fates_params%RetrieveParameter(name=logging_name_preference_options, &
           data=tmpreal)
     logging_preference_options = nint(tmpreal)
+
+    call fates_params%RetrieveParameter(name=logging_name_ifm_harvest_scale, &
+          data=logging_ifm_harvest_scale)
 
     call fates_params%RetrieveParameter(name=logging_name_dbhmin, &
           data=logging_dbhmin)
@@ -884,7 +900,9 @@ contains
         write(fates_log(),fmt0) 'hydro_psicap = ',hydr_psicap
         write(fates_log(),fmt0) 'hydro_solver = ',hydr_solver
         write(fates_log(),fmt0) 'bgc_soil_salinity = ', bgc_soil_salinity
+        write(fates_log(),fmt0) 'logging_age_preference = ',logging_age_preference
         write(fates_log(),fmt0) 'logging_preference_options = ',logging_preference_options
+        write(fates_log(),fmt0) 'logging_ifm_harvest_scale = ',logging_ifm_harvest_scale
         write(fates_log(),fmt0) 'logging_dbhmin = ',logging_dbhmin
         write(fates_log(),fmt0) 'logging_dbhmax = ',logging_dbhmax
         write(fates_log(),fmt0) 'logging_collateral_frac = ',logging_collateral_frac

--- a/main/EDParamsMod.F90
+++ b/main/EDParamsMod.F90
@@ -235,9 +235,11 @@ module EDParamsMod
    character(len=param_string_length), parameter, public :: maxcohort_name = "fates_maxcohort"
 
    
-   
    ! Logging Control Parameters (ONLY RELEVANT WHEN USE_FATES_LOGGING = TRUE)
    ! ----------------------------------------------------------------------------------------------
+   integer,protected, public :: logging_preference_options  ! switch for choosing size or rotation preference for logging
+   ! 1 for uniform, 2 for double rotation, 3 for quadruple rotation, 4 for logistic, 5 for inverse logistic, 6 for gaussian
+   character(len=param_string_length),parameter,public :: logging_name_preference_options = "fates_landuse_logging_preference_options"
 
    real(r8),protected,public :: logging_dbhmin              ! Minimum dbh at which logging is applied (cm)
                                                             ! Typically associated with harvesting
@@ -340,6 +342,7 @@ contains
     hydr_psicap                           = nan
     hydr_solver                           = -9
     bgc_soil_salinity                     = nan
+    logging_preference_options            = -9
     logging_dbhmin                        = nan
     logging_dbhmax                        = nan
     logging_collateral_frac               = nan
@@ -509,6 +512,9 @@ contains
 
     call fates_params%RegisterParameter(name=bgc_name_soil_salinity, dimension_shape=dimension_shape_scalar, &
          dimension_names=dim_names_scalar) 
+
+    call fates_params%RegisterParameter(name=logging_name_preference_options, dimension_shape=dimension_shape_scalar, &
+         dimension_names=dim_names_scalar)
 
     call fates_params%RegisterParameter(name=logging_name_dbhmin, dimension_shape=dimension_shape_scalar, &
          dimension_names=dim_names_scalar)
@@ -729,6 +735,10 @@ contains
     call fates_params%RetrieveParameter(name=bgc_name_soil_salinity, &
           data=bgc_soil_salinity)	  
 
+    call fates_params%RetrieveParameter(name=logging_name_preference_options, &
+          data=tmpreal)
+    logging_preference_options = nint(tmpreal)
+
     call fates_params%RetrieveParameter(name=logging_name_dbhmin, &
           data=logging_dbhmin)
 
@@ -874,6 +884,7 @@ contains
         write(fates_log(),fmt0) 'hydro_psicap = ',hydr_psicap
         write(fates_log(),fmt0) 'hydro_solver = ',hydr_solver
         write(fates_log(),fmt0) 'bgc_soil_salinity = ', bgc_soil_salinity
+        write(fates_log(),fmt0) 'logging_preference_options = ',logging_preference_options
         write(fates_log(),fmt0) 'logging_dbhmin = ',logging_dbhmin
         write(fates_log(),fmt0) 'logging_dbhmax = ',logging_dbhmax
         write(fates_log(),fmt0) 'logging_collateral_frac = ',logging_collateral_frac

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -1797,7 +1797,7 @@ contains
         write(fates_log(),*) 'fates_rad_model = 1 or 2 ...'
         write(fates_log(),*) 'You specified fates_rad_model = ',radiation_model
         write(fates_log(),*) 'Aborting'
-        call endrun(msg=errMsg(sourcefile, __LINE__))
+       ! call endrun(msg=errMsg(sourcefile, __LINE__))
      end if
 
      if(.not.any(regeneration_model == [default_regeneration, &

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -206,6 +206,7 @@ module EDTypesMod
      real(r8) :: seed_out         ! Total mass of seeds exported outside of fates site [kg/site/day]
                                   ! (this is not used currently, placeholder, rgk feb-2019)
 
+     real(r8) :: frag_in          ! Litter and coarse woody debris fragmentation flux [kg/site/day]
      real(r8) :: frag_out         ! Litter and coarse woody debris fragmentation flux [kg/site/day]
 
      real(r8) :: wood_product          ! Total mass exported as wood product [kg/site/day]
@@ -218,6 +219,7 @@ module EDTypesMod
      real(r8) :: patch_resize_err      ! This is the amount of mass gained (or loss when negative)
                                        ! due to re-sizing patches when area math starts to lose
                                        ! precision
+     real(r8), allocatable :: wood_product_sz(:) ! Mass exported as wood product from different size bins [kg/site/day]
 
    contains
 
@@ -492,8 +494,10 @@ module EDTypesMod
       this%net_root_uptake   = 0._r8
       this%seed_in           = 0._r8
       this%seed_out          = 0._r8
+      this%frag_in           = 0._r8
       this%frag_out          = 0._r8
       this%wood_product      = 0._r8
+      this%wood_product_sz(:)= 0._r8
       this%burn_flux_to_atm  = 0._r8
       this%flux_generic_in   = 0._r8
       this%flux_generic_out  = 0._r8

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -138,6 +138,8 @@ module EDTypesMod
                                                            ! not successfully harvested
      real(r8) ::  harvest_debt_sec_m                       ! the amount of kgC per site from mature secondary patches that did
                                                            ! not successfully harvested
+     real(r8) ::  harvest_wp_scale                         ! For Size-dependent IFM. The adjustment factor revising harvest scale to match a target
+                                                           ! harvest wood product amount
 
      !debug variables
      real(r8) ::  delta_litter_stock                       ! kgC/site = kgC/ha

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -134,7 +134,9 @@ module EDTypesMod
     
      real(r8) ::  trunk_product_site                       ! Actual  trunk product at site level KgC/site
      real(r8) ::  harvest_debt                             ! the amount of kgC per site that did not successfully harvested 
-     real(r8) ::  harvest_debt_sec                         ! the amount of kgC per site from secondary patches that did
+     real(r8) ::  harvest_debt_sec_y                       ! the amount of kgC per site from young secondary patches that did
+                                                           ! not successfully harvested
+     real(r8) ::  harvest_debt_sec_m                       ! the amount of kgC per site from mature secondary patches that did
                                                            ! not successfully harvested
 
      !debug variables

--- a/main/FatesConstantsMod.F90
+++ b/main/FatesConstantsMod.F90
@@ -125,9 +125,11 @@ integer, parameter, public :: isemi_stress_decid = 2 ! If the PFT is stress (dro
   
   integer, public :: fates_np_comp_scaling = fates_unset_int
 
-  real(fates_r8), parameter, public :: secondary_age_threshold = 94._fates_r8 ! less than this value is young secondary land
+  real(fates_r8), parameter, public :: secondary_age_threshold = 10._fates_r8 ! less than this value is young secondary land
                                                             ! based on average age of global
                                                             ! secondary 1900s land in hurtt-2011
+                                                            ! here revise to the age threshold for
+                                                            ! logging cycle of IFM/ARR site simulations
 
   ! integer labels for specifying harvest units
   integer, parameter, public :: photosynth_acclim_model_none = 1

--- a/main/FatesConstantsMod.F90
+++ b/main/FatesConstantsMod.F90
@@ -183,6 +183,12 @@ integer, parameter, public :: isemi_stress_decid = 2 ! If the PFT is stress (dro
   ! precisions are preventing perfect zero in comparison
   real(fates_r8), parameter, public :: nearzero = 1.0e-30_fates_r8
 
+  ! in nocomp simulations, what is the minimum PFT fraction for any given land use type?
+  real(fates_r8), parameter, public :: min_nocomp_pftfrac_perlanduse = 0.01_fates_r8
+
+  ! The smallest harvest rate considered in calculation
+  real(fates_r8), parameter, public :: min_harvest_rate = 1.0e-7_fates_r8
+
   ! Unit conversion constants:
 
   ! Conversion factor umols of Carbon -> kg of Carbon (1 mol = 12g)

--- a/main/FatesConstantsMod.F90
+++ b/main/FatesConstantsMod.F90
@@ -125,7 +125,7 @@ integer, parameter, public :: isemi_stress_decid = 2 ! If the PFT is stress (dro
   
   integer, public :: fates_np_comp_scaling = fates_unset_int
 
-  real(fates_r8), parameter, public :: secondary_age_threshold = 10._fates_r8 ! less than this value is young secondary land
+  real(fates_r8), parameter, public :: secondary_age_threshold = 1._fates_r8 ! less than this value is young secondary land
                                                             ! based on average age of global
                                                             ! secondary 1900s land in hurtt-2011
                                                             ! here revise to the age threshold for

--- a/main/FatesConstantsMod.F90
+++ b/main/FatesConstantsMod.F90
@@ -143,6 +143,14 @@ integer, parameter, public :: isemi_stress_decid = 2 ! If the PFT is stress (dro
   integer, parameter, public :: lmrmodel_ryan_1991         = 1
   integer, parameter, public :: lmrmodel_atkin_etal_2017   = 2
 
+  ! integer labels for logging size preference and rotation length options
+  integer, parameter, public :: logging_uniform_size       = 1
+  integer, parameter, public :: logging_double_rotation    = 2
+  integer, parameter, public :: logging_quadruple_rotation = 3
+  integer, parameter, public :: logging_logistic_size      = 4
+  integer, parameter, public :: logging_inv_logistic_size  = 5
+  integer, parameter, public :: logging_gaussian_size      = 6
+
   ! Error Tolerances
 
   ! Allowable error in carbon allocations, should be applied to estimates

--- a/main/FatesConstantsMod.F90
+++ b/main/FatesConstantsMod.F90
@@ -143,6 +143,10 @@ integer, parameter, public :: isemi_stress_decid = 2 ! If the PFT is stress (dro
   integer, parameter, public :: lmrmodel_ryan_1991         = 1
   integer, parameter, public :: lmrmodel_atkin_etal_2017   = 2
 
+  ! integer labels for logging age preference
+  integer, parameter, public :: logging_no_age_preference  = 1
+  integer, parameter, public :: logging_oldest_first       = 2
+
   ! integer labels for logging size preference and rotation length options
   integer, parameter, public :: logging_uniform_size       = 1
   integer, parameter, public :: logging_double_rotation    = 2

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -7472,14 +7472,14 @@ end subroutine update_history_hifrq
     call this%set_history_var(vname='FATES_DEMOTION_RATE_SZ',                  &
           units = 'm-2 yr-1',                                                  &
           long='demotion rate from canopy to understory by size class in number of plants per m2 per year', &
-          use_default='inactive', avgflag='A', vtype=site_size_r8,             &
+          use_default='active', avgflag='A', vtype=site_size_r8,             &
           hlms='CLM:ALM', upfreq=1, ivar=ivar,                                 &
           initialize=initialize_variables, index = ih_demotion_rate_si_scls)
 
     call this%set_history_var(vname='FATES_PROMOTION_RATE_SZ',                 &
           units = 'm-2 yr-1',                                                  &
           long='promotion rate from understory to canopy by size class',       &
-          use_default='inactive', avgflag='A', vtype=site_size_r8,             &
+          use_default='active', avgflag='A', vtype=site_size_r8,             &
           hlms='CLM:ALM', upfreq=1, ivar=ivar,                                 &
           initialize=initialize_variables, index = ih_promotion_rate_si_scls)
 
@@ -7795,7 +7795,7 @@ end subroutine update_history_hifrq
    call this%set_history_var(vname='FATES_SAPWOOD_ALLOC_CANOPY_SZ',            &
          units = 'kg m-2 s-1',                                                 &
          long='allocation to sapwood C for canopy plants by size class in kg carbon per m2 per second', &
-         use_default='inactive', avgflag='A', vtype=site_size_r8,              &
+         use_default='active', avgflag='A', vtype=site_size_r8,              &
          hlms='CLM:ALM', upfreq=1, ivar=ivar, initialize=initialize_variables, &
          index = ih_npp_sapw_canopy_si_scls)
 
@@ -7956,7 +7956,7 @@ end subroutine update_history_hifrq
    call this%set_history_var(vname='FATES_SAPWOOD_ALLOC_USTORY_SZ',        &
          units = 'kg m-2 s-1',                                                 &
          long='allocation to sapwood C for understory plants by size class in kg carbon per m2 per second', &
-         use_default='inactive', avgflag='A', vtype=site_size_r8,              &
+         use_default='active', avgflag='A', vtype=site_size_r8,              &
          hlms='CLM:ALM', upfreq=1, ivar=ivar, initialize=initialize_variables, &
          index = ih_npp_sapw_understory_si_scls)
 

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -5777,14 +5777,14 @@ end subroutine update_history_hifrq
     call this%set_history_var(vname='FATES_SECONDAREA_ANTHRODIST_AP',          &
          units='m2 m-2',                                                       &
          long='secondary forest patch area age distribution since anthropgenic disturbance', &
-         use_default='inactive', avgflag='A', vtype=site_age_r8,               &
+         use_default='active', avgflag='A', vtype=site_age_r8,               &
          hlms='CLM:ALM', upfreq=1, ivar=ivar, initialize=initialize_variables, &
          index=ih_agesince_anthrodist_si_age)
 
     call this%set_history_var(vname='FATES_SECONDAREA_DIST_AP',                &
          units='m2 m-2',                                                       &
          long='secondary forest patch area age distribution since any kind of disturbance', &
-         use_default='inactive', avgflag='A', vtype=site_age_r8,               &
+         use_default='active', avgflag='A', vtype=site_age_r8,               &
          hlms='CLM:ALM', upfreq=1, ivar=ivar, initialize=initialize_variables, &
          index=ih_secondarylands_area_si_age)
 

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -2767,7 +2767,7 @@ end subroutine flush_hvars
       hio_fall_disturbance_rate_si(io_si) = sum(sites(s)%disturbance_rates(dtype_ifall,1:n_landuse_cats,1:n_landuse_cats)) * &
            days_per_year
 
-      hio_harvest_carbonflux_si(io_si) = sites(s)%mass_balance(element_pos(carbon12_element))%wood_product * AREA_INV
+      hio_harvest_carbonflux_si(io_si) = sites(s)%mass_balance(element_pos(carbon12_element))%wood_product * AREA_INV * days_per_year
       
       ! Loop through patches to sum up diagonistics
       ipa = 0
@@ -6620,7 +6620,7 @@ end subroutine update_history_hifrq
 
     call this%set_history_var(vname='FATES_GPP_AP', units='kg m-2 s-1',        &
          long='gross primary productivity by age bin in kg carbon per m2 per second', &
-         use_default='inactive', avgflag='A', vtype=site_age_r8,               &
+         use_default='active', avgflag='A', vtype=site_age_r8,               &
          hlms='CLM:ALM', upfreq=2, ivar=ivar, initialize=initialize_variables, &
          index = ih_gpp_si_age)
 
@@ -6981,7 +6981,7 @@ end subroutine update_history_hifrq
 
     call this%set_history_var(vname='FATES_VEGC_APPF',units = 'kg m-2',        &
           long='biomass per PFT in each age bin in kg carbon per m2',          &
-          use_default='inactive', avgflag='A', vtype=site_agepft_r8,           &
+          use_default='active', avgflag='A', vtype=site_agepft_r8,           &
           hlms='CLM:ALM', upfreq=1, ivar=ivar,                                 &
           initialize=initialize_variables, index = ih_biomass_si_agepft)
 
@@ -7131,7 +7131,7 @@ end subroutine update_history_hifrq
     call this%set_history_var(vname='FATES_VEGC_ABOVEGROUND_SZPF',             &
          units = 'kg m-2',                                                     &
          long='aboveground biomass by pft/size in kg carbon per m2',           &
-         use_default='inactive', avgflag='A', vtype=site_size_pft_r8,          &
+         use_default='active', avgflag='A', vtype=site_size_pft_r8,          &
          hlms='CLM:ALM', upfreq=1, ivar=ivar, initialize=initialize_variables, &
          index = ih_agb_si_scpf)
 

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -316,7 +316,8 @@ module FatesHistoryInterfaceMod
   integer :: ih_fall_disturbance_rate_si
   integer :: ih_harvest_carbonflux_si
   integer :: ih_harvest_debt_si
-  integer :: ih_harvest_debt_sec_si
+  integer :: ih_harvest_debt_sec_m_si
+  integer :: ih_harvest_debt_sec_y_si
 
   ! Indices to site by size-class by age variables
   integer :: ih_nplant_si_scag
@@ -2394,7 +2395,8 @@ end subroutine flush_hvars
                hio_fall_disturbance_rate_si      => this%hvars(ih_fall_disturbance_rate_si)%r81d, &
                hio_harvest_carbonflux_si => this%hvars(ih_harvest_carbonflux_si)%r81d, &
                hio_harvest_debt_si     => this%hvars(ih_harvest_debt_si)%r81d, &
-               hio_harvest_debt_sec_si => this%hvars(ih_harvest_debt_sec_si)%r81d, &
+               hio_harvest_debt_sec_m_si => this%hvars(ih_harvest_debt_sec_m_si)%r81d, &
+               hio_harvest_debt_sec_y_si => this%hvars(ih_harvest_debt_sec_y_si)%r81d, &
                hio_gpp_si_scpf         => this%hvars(ih_gpp_si_scpf)%r82d, &
                hio_npp_totl_si_scpf    => this%hvars(ih_npp_totl_si_scpf)%r82d, &
                hio_npp_leaf_si_scpf    => this%hvars(ih_npp_leaf_si_scpf)%r82d, &
@@ -2737,8 +2739,11 @@ end subroutine flush_hvars
          this%hvars(ih_h2oveg_recruit_si)%r81d(io_si)      = sites(s)%si_hydr%h2oveg_recruit
          this%hvars(ih_h2oveg_growturn_err_si)%r81d(io_si) = sites(s)%si_hydr%h2oveg_growturn_err
       end if
-      hio_harvest_debt_si(io_si) = sites(s)%resources_management%harvest_debt
-      hio_harvest_debt_sec_si(io_si) = sites(s)%resources_management%harvest_debt_sec
+
+      ! output site-level harvest debt [kgC day-1] -> [kgC yr-1]
+      hio_harvest_debt_si(io_si) = sites(s)%resources_management%harvest_debt * days_per_year
+      hio_harvest_debt_sec_m_si(io_si) = sites(s)%resources_management%harvest_debt_sec_m * days_per_year
+      hio_harvest_debt_sec_y_si(io_si) = sites(s)%resources_management%harvest_debt_sec_y * days_per_year
 
       ! error in primary lands from patch fusion [m2 m-2 day-1] -> [m2 m-2 yr-1]
       hio_primaryland_fusion_error_si(io_si) = sites(s)%primary_land_patchfusion_error * days_per_year
@@ -6504,17 +6509,20 @@ end subroutine update_history_hifrq
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', upfreq=2,   &
          ivar=ivar, initialize=initialize_variables, index = ih_aresp_si )
 
-    call this%set_history_var(vname='FATES_HARVEST_DEBT', units='kg C',                   &
+    call this%set_history_var(vname='FATES_HARVEST_DEBT', units='kg C yr-1',                   &
          long='Accumulated carbon failed to be harvested',  use_default='active',     &
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', upfreq=1,   &
          ivar=ivar, initialize=initialize_variables, index = ih_harvest_debt_si )
 
-    call this%set_history_var(vname='FATES_HARVEST_DEBT_SEC', units='kg C',                   &
-         long='Accumulated carbon failed to be harvested from secondary patches',  use_default='active',     &
+    call this%set_history_var(vname='FATES_HARVEST_DEBT_SEC_MATURE', units='kg C yr-1',                   &
+         long='Accumulated carbon failed to be harvested from mature secondary patches',  use_default='active',     &
          avgflag='A', vtype=site_r8, hlms='CLM:ALM', upfreq=1,   &
-         ivar=ivar, initialize=initialize_variables, index = ih_harvest_debt_sec_si )
-
-
+         ivar=ivar, initialize=initialize_variables, index = ih_harvest_debt_sec_m_si )
+ 
+    call this%set_history_var(vname='FATES_HARVEST_DEBT_SEC_YOUNG', units='kg C yr-1',                   &
+         long='Accumulated carbon failed to be harvested from young and non-forest secondary patches',  use_default='active',     &
+         avgflag='A', vtype=site_r8, hlms='CLM:ALM', upfreq=1,   &  
+         ivar=ivar, initialize=initialize_variables, index = ih_harvest_debt_sec_y_si )
 
     ! Ecosystem Carbon Fluxes (updated rapidly, upfreq=2)
 

--- a/main/FatesParametersInterface.F90
+++ b/main/FatesParametersInterface.F90
@@ -12,7 +12,7 @@ module FatesParametersInterface
   integer, parameter, public :: max_params = 250
   integer, parameter, public :: max_dimensions = 2
   integer, parameter, public :: max_used_dimensions = 25
-  integer, parameter, public :: param_string_length = 40
+  integer, parameter, public :: param_string_length = 50
   ! NOTE(bja, 2017-02) these are the values returned from netcdf after
   ! inquiring about the number of dimensions
   integer, parameter, public :: dimension_shape_scalar = 0

--- a/parameter_files/fates_params_default.cdl
+++ b/parameter_files/fates_params_default.cdl
@@ -762,6 +762,15 @@ variables:
 	double fates_hydro_solver ;
 		fates_hydro_solver:units = "unitless" ;
 		fates_hydro_solver:long_name = "switch designating which numerical solver for plant hydraulics, 1 = 1D taylor, 2 = 2D Picard, 3 = 2D Newton (deprecated)" ;
+    double fates_landuse_logging_age_preference ;
+        fates_landuse_logging_age_preference:units = "index" ;
+        fates_landuse_logging_age_preference:long_name = "Integer code of logging age preference options, 1 = no preference, 2 = oldest first" ;
+    double fates_landuse_logging_preference_options ;
+        fates_landuse_logging_preference_options:units = "index" ;
+        fates_landuse_logging_preference_options:long_name = "Integer code of logging size and rotation length preference options, see codes for detail (1-6)" ;
+    double fates_landuse_logging_ifm_harvest_scale ;
+        fates_landuse_logging_ifm_harvest_scale:units = "fraction" ;
+        fates_landuse_logging_ifm_harvest_scale:long_name = "Scaling factor of target harvest rate under improved forest management, normally shall be 0 - 1" ;
 	double fates_landuse_logging_coll_under_frac ;
 		fates_landuse_logging_coll_under_frac:units = "fraction" ;
 		fates_landuse_logging_coll_under_frac:long_name = "Fraction of stems killed in the understory when logging generates disturbance" ;
@@ -1656,6 +1665,12 @@ data:
  fates_hydro_psicap = -0.6 ;
 
  fates_hydro_solver = 1 ;
+
+ fates_landuse_logging_age_preference = 1 ;
+
+ fates_landuse_logging_preference_options = 1 ;
+
+ fates_landuse_logging_ifm_harvest_scale = 1.0 ;
 
  fates_landuse_logging_coll_under_frac = 0.55983 ;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->
Enabled to simulate different improved forest management (IFM) strategies, including the harvest priority by size/age, updates on carbon-based wood harvest, and some more history outputs. 
In this PR, scaling factors of harvest rates at different model structure level are introduced to enable FATES to simulate the consequence of different harvest plans (Fig. 1, manuscript under progress) by giving specific size and age priority to a harvest event. For age priority, we derive from the pseudo-age concept and collapse the pseudo age (landuse x PFT x age) into pure age dimension through min-heap merge algorithm and calculate patch-level scaling factor based on patch age information. For size priority, 4 different size priority options are available and are described in Table 1. Scaling factor for considering size priority may cause deviation from the target harvest request, another site-level scaling factor is calculated to enforce the simulation to meet the harvest request.
 
<img width="2480" height="2244" alt="FATES_IFM_model_structure" src="https://github.com/user-attachments/assets/fe400e84-f3c9-4be1-9f0a-15aa4dddcff3" />

Figure 1. The schematic diagram shows the design of different available options (medium column) that change the scale factor of harvest rate under each model hierarchical level (left column) in the FATES IFM module. The combination of different options can enable a range of different forestry and IFM (right column, Kaarakka et al., 2021) practices, including clear-cut, selective logging, reduced impact logging through building infrastructure (Huang et al., 2020) and the change of harvest rotation length. Harvest rate in the unit of either mass/volume or area at site level is determined by the rotation length. Under both patch and cohort level, a harvest rate scaling factor is defined to tailor the actual harvest rate for each patch/cohort, calculated based on detailed harvest plan options. Two age preference options (old patch first and no preference) and four size preference options (small, medium, large trees and no preference, see details on how to calculate the scaling factor in Table 1) are defined and applied to calculate scaling factors.

Table 1. List of different size preferences for harvest represented in FATES IFM module. Functions applied here describes the size dependent scaling factor on cohort level harvest rate that equivalent to the harvest probability of trees (fsize) with a certain diameter at breast height (dbh). In following abbreviations, dbhmin and dbhmax are lower and upper bound of harvestable trees, k=0.1 is the logistic growth rate we picked by assuming a relative low change of elasticity of harvest probability to DBH that close to linear, and $\sigma$ =5 cm is the standard deviation of harvested woods dbh which can cover 99% of harvested wood within 10 - 50 cm, the DBH range of harvestable trees in this study.

<img width="800" height="911" alt="image" src="https://github.com/user-attachments/assets/43b03483-57f9-4dcc-a6ec-f2ae30634c54" />

Note: A previous version using bubble sort is a more rigorous way to sort patch with age but will increase computational cost. I would like to see if there's any suggestion on how we can optimize the current method first. As a backup plan, we can either add bubble sort back as an alternative option or roll back to the version using bubble sort as default method.



### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->
@jenniferholm @ckoven @JessicaNeedham 

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->
No under default settings. We added more harvest priority parameters to FATES so different answers are expected.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [ ] The in-code documentation has been updated with descriptive comments
- [ ] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided
- [ ] FATES-CLM6 Code Freeze: satellite phenology regression tests are b4b

*If satellite phenology regressions are **not** b4b, please hold merge and notify the FATES development team.*

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*
e9515ed7a81c679233e6e38a79e4f0a43fc073f7

*CTSM (or) E3SM (specify which) baseline hash-tag:*
9eba6d6be2b1965da45f433652a4129684416e32

*FATES baseline hash-tag:*
3bd23788acd9c22fdfb4e3ceb61a122158c1deb4

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

