### PR TITLE
Update secondary young frac calculation

### DIFF
--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -848,7 +848,7 @@ contains
      currentPatch => this%oldest_patch
      do while (associated(currentPatch))
         if (currentPatch%land_use_label .eq. secondaryland) then
-           if ( currentPatch%age .ge. secondary_age_threshold ) then
+           if ( currentPatch%age_since_anthro_disturbance .ge. secondary_age_threshold ) then
               secondary_old_area = secondary_old_area + currentPatch%area
            else
               secondary_young_area = secondary_young_area + currentPatch%area


### PR DESCRIPTION
### Description:
This change fixes #1478 .  Since get_harvest_rate_area is using patch age_since_anthro_disturbance to determine if patches are over the threshold to count as secondary old, the function get_secondary_young_frac also needs to use age_since_anthro_disturbance and not patch age, otherwise the secondary young frac can be 1, but some patches are over the threshold to count as secondary old, triggering 100% harvest. 

### Collaborators:
@kjetilaas @rosiealice @ckoven @sshu88 

### Expectation of Answer Changes:
This will be answer changing if land use is on. It will reduce large spikes in harvest. 

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [x] The in-code documentation has been updated with descriptive comments
- [x] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [x] FATES PASS/FAIL regression tests were run
- [x] Evaluation of test results for answer changes was performed and results provided
- [x] FATES-CLM6 Code Freeze: satellite phenology regression tests are b4b

*If satellite phenology regressions are **not** b4b, please hold merge and notify the FATES development team.*

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
Tested on the NorESM-FATES side and prevents the case where secondary young frac = 1, but the patch is over the age threshold. 
