### PR TITLE
Bound treelai if leafc_per_unitarea is tiny.

### DIFF
--- a/biogeochem/FatesAllometryMod.F90
+++ b/biogeochem/FatesAllometryMod.F90
@@ -748,7 +748,8 @@ contains
           tree_lai = (log(exp(-1.0_r8 * kn * canopy_lai_above) - &
                kn * slat * leafc_per_unitarea) + &
                (kn * canopy_lai_above)) / (-1.0_r8 * kn)
-
+          ! precision errors in the above when leafc_per_unit_area is tiny can make treelai negative
+          tree_lai = max(0.0_r8,tree_lai)
           ! If leafc_per_unitarea becomes too large, tree_lai becomes an imaginary number 
           ! (because the tree_lai equation requires us to take the natural log of something >0)
           ! Thus, we include the following error message in case leafc_per_unitarea becomes too large.
@@ -774,7 +775,8 @@ contains
                kn * slat * leafc_slamax) + &
                (kn * canopy_lai_above)) / (-1.0_r8 * kn)) + &
                (leafc_per_unitarea - leafc_slamax) * sla_max
-
+          ! precision errors in the above when leafc_per_unit_area is tiny can make treelai negative
+          tree_lai = max(0.0_r8,tree_lai)
           ! if leafc_slamax becomes too large, tree_lai_exp becomes an imaginary number 
           ! (because the tree_lai equation requires us to take the natural log of something >0)
           ! Thus, we include the following error message in case leafc_slamax becomes too large.


### PR DESCRIPTION
### Description:
Fixes #1487 

Bound treelai to non-negative due to `log(exp(-X))+X` having precision ~1e-16 for 64-bit floats.

This should prevent endrun here:

https://github.com/NGEET/fates/blob/75a465c0b650fad9e40059204903f6017f22a1ee/biogeophys/FatesPlantRespPhotosynthMod.F90#L1091-L1097

### Collaborators:
@JessicaNeedham @rosiealice @glemieux 

### Expectation of Answer Changes:
Should be bfb, mb roundoff.

### Checklist


All checklist items must be checked to enable merging this pull request:

*Contributor*
- [X] The in-code documentation has been updated with descriptive comments
- [x] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [x] FATES PASS/FAIL regression tests were run
- [x] Evaluation of test results for answer changes was performed and results provided
- [x] FATES-CLM6 Code Freeze: satellite phenology regression tests are b4b

*If satellite phenology regressions are **not** b4b, please hold merge and notify the FATES development team.*

### Documentation

No update needed.

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

