### PR TITLE
fungal wood respiration

### DIFF
--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -3295,12 +3295,12 @@ contains
     
     do c = 1,ncwd
 
-       decomp_loss = SF_val_max_decomp(c) * years_per_day * fragmentation_scaler(soil_layer_index)
+       decomp_rate = SF_val_max_decomp(c) * years_per_day * fragmentation_scaler(soil_layer_index)
        litt%ag_cwd_frag(c)   = litt%ag_cwd(c) * decomp_rate * (1._r8-cwd_hr_frag_frac_eff)
        litt%ag_cwd_funghr(c) = litt%ag_cwd(c) * decomp_rate * cwd_hr_frag_frac_eff
        
        do ilyr = 1,nlev_eff_decomp
-          decomp_loss = SF_val_max_decomp(c) * years_per_day * fragmentation_scaler(ilyr)
+          decomp_rate = SF_val_max_decomp(c) * years_per_day * fragmentation_scaler(ilyr)
           litt%bg_cwd_frag(c,ilyr)   = litt%bg_cwd(c,ilyr) * decomp_rate * (1._r8-cwd_hr_frag_frac_eff)
           litt%bg_cwd_funghr(c,ilyr) = litt%bg_cwd(c,ilyr) * decomp_rate * cwd_hr_frag_frac_eff
        enddo

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -20,6 +20,7 @@ module EDPhysiologyMod
   use FatesInterfaceTypesMod, only    : hlm_use_nocomp
   use EDParamsMod           , only    : crop_lu_pft_vector
   use EDParamsMod           , only    : GetNVegLayers
+  use EDParamsMod           , only    : cwd_hr_frag_frac
   use FatesInterfaceTypesMod, only    : hlm_use_tree_damage
   use FatesInterfaceTypesMod, only : hlm_use_ed_prescribed_phys
   use FatesConstantsMod, only    : r8 => fates_r8
@@ -3273,6 +3274,9 @@ contains
     integer :: ilyr                    ! Soil layer index
     integer :: dcmpy                   ! Decomposibility pool indexer
     integer :: soil_layer_index = 1    ! Soil layer index associated with above ground litter
+    real(r8) :: decomp_rate            ! per-mass per-day loss rate due to fragmentation AND fungal HR
+    real(r8) :: cwd_hr_frag_frac_eff   ! Effective (element specific) proportion of
+                                       ! losses due to HR
     !----------------------------------------------------------------------
 
 
@@ -3280,18 +3284,25 @@ contains
     ! moisture scalars and fragmentation scalar associated with specified index value
     ! is used for ag_cwd_frag and root_fines_frag calculations.
 
+
+    ! Heterotrophic respiration can only be applied to the carbon pool!
+    if( litt%element_id.eq.carbon12_element) then
+       cwd_hr_frag_frac_eff = cwd_hr_frag_frac
+    else
+       cwd_hr_frag_frac_eff = 0._r8
+    end if
+    
+    
     do c = 1,ncwd
 
-       litt%ag_cwd_frag(c)   = litt%ag_cwd(c) * SF_val_max_decomp(c) * &
-             years_per_day * fragmentation_scaler(soil_layer_index)
-
-       litt%ag_cwd_funghr(c) = litt%ag_cwd(c) * fung_hetresp_baserate * years_per_day
+       decomp_loss = SF_val_max_decomp(c) * years_per_day * fragmentation_scaler(soil_layer_index)
+       litt%ag_cwd_frag(c)   = litt%ag_cwd(c) * decomp_rate * (1._r8-cwd_hr_frag_frac_eff)
+       litt%ag_cwd_funghr(c) = litt%ag_cwd(c) * decomp_rate * cwd_hr_frag_frac_eff
        
        do ilyr = 1,nlev_eff_decomp
-           litt%bg_cwd_frag(c,ilyr) = litt%bg_cwd(c,ilyr) * SF_val_max_decomp(c) * &
-                years_per_day * fragmentation_scaler(ilyr)
-
-           litt%bg_cwd_funghr(c,ilyr) = litt%bg_cwd(c,ilyr) * fung_hetresp_baserate * years_per_day
+          decomp_loss = SF_val_max_decomp(c) * years_per_day * fragmentation_scaler(ilyr)
+          litt%bg_cwd_frag(c,ilyr)   = litt%bg_cwd(c,ilyr) * decomp_rate * (1._r8-cwd_hr_frag_frac_eff)
+          litt%bg_cwd_funghr(c,ilyr) = litt%bg_cwd(c,ilyr) * decomp_rate * cwd_hr_frag_frac_eff
        enddo
     end do
 

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -490,6 +490,9 @@ contains
               sum(litt%leaf_fines_frag) + sum(litt%root_fines_frag) + &
               sum(litt%seed_decay) + sum(litt%seed_germ_decay))
 
+         site_mass%funghr_out = site_mass%funghr_out + currentPatch%area * &
+              (sum(litt%ag_cwd_funghr) + sum(litt%bg_cwd_funghr))
+
          ! Track total seed decay diagnostic in [kg/m2/day]
          diag%tot_seed_turnover = diag%tot_seed_turnover + &
               (sum(litt%seed_decay) + sum(litt%seed_germ_decay))*currentPatch%area*area_inv
@@ -562,11 +565,12 @@ contains
        ! -----------------------------------------------------------------------------------
        nlevsoil = size(litt%bg_cwd,dim=2)
        do c = 1,ncwd
-          litt%ag_cwd(c) = litt%ag_cwd(c)  + litt%ag_cwd_in(c) - litt%ag_cwd_frag(c)
+          litt%ag_cwd(c) = litt%ag_cwd(c)  + litt%ag_cwd_in(c) - litt%ag_cwd_frag(c) - litt%ag_cwd_funghr(c)
           do ilyr=1,nlevsoil
              litt%bg_cwd(c,ilyr) = litt%bg_cwd(c,ilyr) &
                   + litt%bg_cwd_in(c,ilyr) &
-                  - litt%bg_cwd_frag(c,ilyr)
+                  - litt%bg_cwd_frag(c,ilyr) &
+                  - litt%bg_cwd_funghr(c,ilyr)
           enddo
        end do
 
@@ -3281,9 +3285,13 @@ contains
        litt%ag_cwd_frag(c)   = litt%ag_cwd(c) * SF_val_max_decomp(c) * &
              years_per_day * fragmentation_scaler(soil_layer_index)
 
+       litt%ag_cwd_funghr(c) = litt%ag_cwd(c) * fung_hetresp_baserate * years_per_day
+       
        do ilyr = 1,nlev_eff_decomp
            litt%bg_cwd_frag(c,ilyr) = litt%bg_cwd(c,ilyr) * SF_val_max_decomp(c) * &
                 years_per_day * fragmentation_scaler(ilyr)
+
+           litt%bg_cwd_funghr(c,ilyr) = litt%bg_cwd(c,ilyr) * fung_hetresp_baserate * years_per_day
        enddo
     end do
 

--- a/biogeochem/FatesLitterMod.F90
+++ b/biogeochem/FatesLitterMod.F90
@@ -101,6 +101,9 @@ module FatesLitterMod
       real(r8),allocatable ::  leaf_fines_frag(:)   ! above ground fines fragmentation flux [kg/m2/day]
       real(r8),allocatable ::  root_fines_frag(:,:) ! kg/m2/day
 
+      real(r8),allocatable ::  ag_cwd_funghr(ncwd)  ! above ground Fungal respiration flux [kg/m2/day]
+      real(r8),allocatable ::  bg_cwd_funghr(:,:)   ! below ground fungal respiration flux [kg/m2/day]
+
       real(r8), allocatable :: seed_decay(:)      ! decay of viable seeds to litter     [kg/m2/day]
       real(r8), allocatable :: seed_germ_decay(:) ! decay of germinated seeds to litter [kg/m2/day]
       real(r8), allocatable :: seed_germ_in(:)    ! flux from viable to germinated seed [kg/m2/day]
@@ -164,6 +167,8 @@ contains
                              donor_litt%ag_cwd_in(c) * donor_weight
        this%ag_cwd_frag(c) = this%ag_cwd_frag(c) *self_weight + &
                              donor_litt%ag_cwd_frag(c) * donor_weight
+       this%ag_cwd_funghr(c)  = this%cwd_funghr(c) * self_weight + &
+                              donor_litt%cwd_funghr(c) * donor_weight
        do ilyr = 1,nlevsoil
           this%bg_cwd(c,ilyr)      = this%bg_cwd(c,ilyr) * self_weight + &
                                      donor_litt%bg_cwd(c,ilyr) * donor_weight
@@ -171,6 +176,8 @@ contains
                                      donor_litt%bg_cwd_in(c,ilyr) * donor_weight
           this%bg_cwd_frag(c,ilyr) = this%bg_cwd_frag(c,ilyr) * self_weight + &
                                      donor_litt%bg_cwd_frag(c,ilyr) * donor_weight
+          this%bg_cwd_funghr(c,ilyr) = this%bg_cwd_funghr(c,ilyr) * self_weight + &
+                                     donor_litt%bg_cwd_funghr(c,ilyr) * donor_weight
        end do
 
     end do
@@ -234,11 +241,13 @@ contains
     this%ag_cwd(:)      = donor_litt%ag_cwd(:)
     this%ag_cwd_in(:)   = donor_litt%ag_cwd_in(:)
     this%ag_cwd_frag(:) = donor_litt%ag_cwd_frag(:)
+    this%ag_cwd_funghr(:)  = donor_litt%ag_cwd_funghr(:)
     
     this%bg_cwd(:,:)      = donor_litt%bg_cwd(:,:)
     this%bg_cwd_in(:,:)   = donor_litt%bg_cwd_in(:,:)
     this%bg_cwd_frag(:,:) = donor_litt%bg_cwd_frag(:,:)
-
+    this%bg_cwd_funghr(:,:) = donor_litt%bg_cwd_funghr(:,:)
+    
     this%leaf_fines(:)    = donor_litt%leaf_fines(:)
     this%seed(:)          = donor_litt%seed(:)
     this%seed_germ(:)     = donor_litt%seed_germ(:)
@@ -272,7 +281,8 @@ contains
     allocate(this%bg_cwd_in(ncwd,numlevsoil))
     allocate(this%bg_cwd(ncwd,numlevsoil))
     allocate(this%bg_cwd_frag(ncwd,numlevsoil))
-
+    allocate(this%bg_cwd_funghr(ncwd,numlevsoil))
+    
     allocate(this%leaf_fines(ndcmpy))
     allocate(this%root_fines(ndcmpy,numlevsoil))
     allocate(this%leaf_fines_in(ndcmpy))
@@ -304,7 +314,9 @@ contains
     this%seed_in_extern(:)    = fates_unset_r8
 
     this%ag_cwd_frag(:)       = fates_unset_r8
+    this%ag_cwd_funghr(:)     = fates_unset_r8
     this%bg_cwd_frag(:,:)     = fates_unset_r8
+    this%bg_cwd_funghr(:,;)   = fates_unset_r8
     this%leaf_fines_frag(:)   = fates_unset_r8
     this%root_fines_frag(:,:) = fates_unset_r8
 
@@ -383,6 +395,7 @@ contains
     deallocate(this%seed_in_extern)
     
     deallocate(this%bg_cwd_frag)
+    deallocate(this%bg_cwd_funghr)
     deallocate(this%leaf_fines_frag)
     deallocate(this%root_fines_frag)
    
@@ -407,7 +420,9 @@ contains
     this%seed_in_extern(:)    = 0._r8
 
     this%ag_cwd_frag(:)       = 0._r8
+    this%ag_cwd_funghr(:)     = 0._r8
     this%bg_cwd_frag(:,:)     = 0._r8
+    this%bg_cwd_funghr(:,:)   = 0._r8
     this%leaf_fines_frag(:)   = 0._r8
     this%root_fines_frag(:,:) = 0._r8
     

--- a/biogeochem/FatesLitterMod.F90
+++ b/biogeochem/FatesLitterMod.F90
@@ -101,7 +101,7 @@ module FatesLitterMod
       real(r8),allocatable ::  leaf_fines_frag(:)   ! above ground fines fragmentation flux [kg/m2/day]
       real(r8),allocatable ::  root_fines_frag(:,:) ! kg/m2/day
 
-      real(r8),allocatable ::  ag_cwd_funghr(ncwd)  ! above ground Fungal respiration flux [kg/m2/day]
+      real(r8)             ::  ag_cwd_funghr(ncwd)  ! above ground Fungal respiration flux [kg/m2/day]
       real(r8),allocatable ::  bg_cwd_funghr(:,:)   ! below ground fungal respiration flux [kg/m2/day]
 
       real(r8), allocatable :: seed_decay(:)      ! decay of viable seeds to litter     [kg/m2/day]
@@ -167,8 +167,8 @@ contains
                              donor_litt%ag_cwd_in(c) * donor_weight
        this%ag_cwd_frag(c) = this%ag_cwd_frag(c) *self_weight + &
                              donor_litt%ag_cwd_frag(c) * donor_weight
-       this%ag_cwd_funghr(c)  = this%cwd_funghr(c) * self_weight + &
-                              donor_litt%cwd_funghr(c) * donor_weight
+       this%ag_cwd_funghr(c)  = this%ag_cwd_funghr(c) * self_weight + &
+                              donor_litt%ag_cwd_funghr(c) * donor_weight
        do ilyr = 1,nlevsoil
           this%bg_cwd(c,ilyr)      = this%bg_cwd(c,ilyr) * self_weight + &
                                      donor_litt%bg_cwd(c,ilyr) * donor_weight
@@ -316,7 +316,7 @@ contains
     this%ag_cwd_frag(:)       = fates_unset_r8
     this%ag_cwd_funghr(:)     = fates_unset_r8
     this%bg_cwd_frag(:,:)     = fates_unset_r8
-    this%bg_cwd_funghr(:,;)   = fates_unset_r8
+    this%bg_cwd_funghr(:,:)   = fates_unset_r8
     this%leaf_fines_frag(:)   = fates_unset_r8
     this%root_fines_frag(:,:) = fates_unset_r8
 

--- a/main/ChecksBalancesMod.F90
+++ b/main/ChecksBalancesMod.F90
@@ -325,13 +325,14 @@ contains
                  - ediag%tot_seed_turnover)
 
             ! Flux for litter: veg turnover + seed turnover - "these are tot_litter_input"
-            !                  fragmentation - 
+            !                  fragmentation - fungal respiration
             !                  burned litter
 
             ibal%iflux_litter = ibal%iflux_litter + &
                  tot_litter_input - &
                  (site_mass%frag_out*area_inv - ediag%tot_seed_turnover) - &
-                 (sum(site_mass%burn_flux_to_atm(:))*area_inv - ediag%burned_liveveg)
+                 (sum(site_mass%burn_flux_to_atm(:))*area_inv - ediag%burned_liveveg) - &
+                 site_mass%funghr_out*area_inv
 
 
             ediag%err_liveveg = ibal%iflux_liveveg - ibal%state_liveveg

--- a/main/EDMainMod.F90
+++ b/main/EDMainMod.F90
@@ -1015,6 +1015,7 @@ contains
                site_mass%seed_out + &
                site_mass%flux_generic_out + &
                site_mass%frag_out + &
+               site_mass%funghr_out + &
                site_mass%aresp_acc + &
                site_mass%herbivory_flux_out
        end if
@@ -1049,6 +1050,7 @@ contains
           write(fates_log(),*) 'seed_out: ',site_mass%seed_out
           write(fates_log(),*) 'flux_generic_out: ',site_mass%flux_generic_out
           write(fates_log(),*) 'frag_out: ',site_mass%frag_out
+          write(fates_log(),*) 'funghr_out: ',site_mass%funghr_out
           write(fates_log(),*) 'aresp_acc: ',site_mass%aresp_acc
           write(fates_log(),*) 'herbivory_flux_out: ',site_mass%herbivory_flux_out
           write(fates_log(),*) 'error=net_flux-dstock:', error

--- a/main/EDParamsMod.F90
+++ b/main/EDParamsMod.F90
@@ -44,6 +44,8 @@ module EDParamsMod
    real(r8),protected, public :: comp_excln_exp                       ! weighting factor (exponent) for canopy layer exclusion and promotion
    real(r8),protected, public :: ED_val_nignitions                    ! number of annual ignitions per square km
    real(r8),protected, public :: ED_val_understorey_death             ! fraction of plants in understorey cohort impacted by overstorey tree-fall
+   real(r8),protected, public :: cwd_hr_frag_frac                     ! fraction of losses from CWD pool that are due to
+                                                                      ! fungal heterotrophic respiration as opposed to fragmentation
    real(r8),protected, public :: ED_val_cwd_fcel                      ! Cellulose fraction for CWD
    real(r8),protected, public :: ED_val_cwd_flig                      ! Lignin fraction of coarse woody debris
    real(r8),protected, public :: maintresp_nonleaf_baserate           ! Base maintenance respiration rate for plant tissues

--- a/main/EDParamsMod.F90
+++ b/main/EDParamsMod.F90
@@ -229,6 +229,7 @@ module EDParamsMod
     comp_excln_exp                        = nan
     ED_val_nignitions                     = nan
     ED_val_understorey_death              = nan
+    cwd_hr_frag_frac                      = nan
     ED_val_cwd_fcel                       = nan
     ED_val_cwd_flig                       = nan
     maintresp_nonleaf_baserate            = nan
@@ -341,6 +342,9 @@ module EDParamsMod
     
     param_p => pstruct%GetParamFromName("fates_frag_cwd_flig")
     ED_val_cwd_flig = param_p%r_data_scalar
+
+    param_p => pstruct%GetParamFromName("fates_cwd_hrfrag_frac")
+    cwd_hr_frag_frac = param_p%r_data_scalar
     
     param_p => pstruct%GetParamFromName("fates_maintresp_nonleaf_baserate")
     maintresp_nonleaf_baserate = param_p%r_data_scalar
@@ -516,6 +520,7 @@ module EDParamsMod
         write(fates_log(),fmt0) 'comp_excln_exp = ',comp_excln_exp
         write(fates_log(),fmt0) 'ED_val_nignitions = ',ED_val_nignitions
         write(fates_log(),fmt0) 'ED_val_understorey_death = ',ED_val_understorey_death
+        write(fates_log(),fmt0) 'cwd_hr_frag_frac= ', cwd_hr_frag_frac
         write(fates_log(),fmt0) 'ED_val_cwd_fcel = ',ED_val_cwd_fcel
         write(fates_log(),fmt0) 'ED_val_cwd_flig = ',ED_val_cwd_flig
         write(fates_log(),fmt0) 'fates_maintresp_nonleaf_baserate = ', maintresp_nonleaf_baserate

--- a/main/EDTypesMod.F90
+++ b/main/EDTypesMod.F90
@@ -294,6 +294,8 @@ module EDTypesMod
 
      real(r8) :: frag_out         ! Litter and coarse woody debris fragmentation flux [kg/site/day]
 
+     real(r8) :: funghr_out       ! Losses to fungal respiration [kg/site/day]
+     
      real(r8) :: wood_product_harvest(maxpft)    ! Total mass exported as wood product from wood harvest [kg/site/day]
 
      real(r8) :: wood_product_landusechange(maxpft)    ! Total mass exported as wood product from land use change [kg/site/day]
@@ -715,6 +717,7 @@ contains
       this%seed_in           = 0._r8
       this%seed_out          = 0._r8
       this%frag_out          = 0._r8
+      this%funghr_out        = 0._r8
       this%wood_product_harvest(:)        = 0._r8
       this%wood_product_landusechange(:)  = 0._r8
       this%burn_flux_to_atm(:)            = 0._r8

--- a/main/FatesConstantsMod.F90
+++ b/main/FatesConstantsMod.F90
@@ -286,7 +286,6 @@ integer, parameter, public :: isemi_stress_decid = 4 ! Flag that indicates that 
 
   ! Conversion: megajoules per joule
   real(fates_r8), parameter, public :: megajoules_per_joule = 1.0E-6_fates_r8
- 
   
   ! Conversion: days per second
   real(fates_r8), parameter, public :: days_per_sec = 1.0_fates_r8/86400.0_fates_r8

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -402,6 +402,7 @@ module FatesHistoryInterfaceMod
   integer :: ih_tveg_si
   integer :: ih_nep_si
   integer :: ih_hr_si
+  integer :: ih_hr_cwdfung_si
 
   integer :: ih_c_stomata_si
   integer :: ih_c_lblayer_si
@@ -5179,6 +5180,7 @@ contains
     real(r8) :: dt_tstep_inv        ! inverse timestep (1/sec)
     real(r8) :: n_perm2             ! number of plants per square meter
     real(r8) :: sum_area_rad        ! sum of patch canopy areas
+    real(r8) :: cwd_funghr
     real(r8),allocatable :: age_area_rad(:)
 
     type(fates_patch_type),pointer  :: cpatch
@@ -5196,6 +5198,7 @@ contains
          hio_nir_rad_err_si           => this%hvars(ih_nir_rad_err_si)%r81d, &
          hio_nep_si                   => this%hvars(ih_nep_si)%r81d, &
          hio_hr_si                    => this%hvars(ih_hr_si)%r81d, &
+         hio_hr_cwdfung_si            => this%hvars(ih_hr_cwdfung_si)%r81d, &
          hio_gpp_canopy_si            => this%hvars(ih_gpp_canopy_si)%r81d, &
          hio_ar_canopy_si             => this%hvars(ih_ar_canopy_si)%r81d, &
          hio_gpp_understory_si        => this%hvars(ih_gpp_understory_si)%r81d, &
@@ -5246,6 +5249,16 @@ contains
                age_class = get_age_class_index(cpatch%age)
                age_area_rad(age_class) = age_area_rad(age_class) + cpatch%total_canopy_area
             end if
+
+            litt => cpatch%litter(element_pos(carbon12_element))
+
+            ! scale fungal resp to kg/m2/s (currently in kg/m2/day)
+            cwdfung_hr =  cpatch%area*(sum(litt%ag_cwd_funghr) + sum(litt%bg_cwd_funghr))*area_inv
+
+            hio_hr_si(io_si)  = hio_hr_si(io_si) + cwdfung_hr
+            hio_nep_si(io_si) = hio_nep_si(io_si) + cwdfung_hr
+            hio_hr_cwdfung_si(io_si) = hio_hr_cwdfung_si(io_si) + cwdfung_hr
+            
             cpatch => cpatch%younger
          end do
 
@@ -9108,6 +9121,11 @@ contains
             use_default='active', avgflag='A', vtype=site_r8, hlms='CLM:ALM',     &
             upfreq=group_hifr_simple, ivar=ivar, initialize=initialize_variables, index = ih_hr_si)
 
+       call this%set_history_var(vname='FATES_CWDFUNGAL_HET_RESP', units='kg m-2 s-1',  &
+            long='heterotrophic respiration strictly from fungal activity in CWD',      &
+            use_default='active', avgflag='A', vtype=site_r8, hlms='CLM:ALM',     &
+            upfreq=group_hifr_simple, ivar=ivar, initialize=initialize_variables, index = ih_hr_cwdfung_si)
+        
        hydro_active_if0: if(hlm_use_planthydro.eq.itrue) then
           call this%set_history_var(vname='FATES_SAPFLOW', units='kg m-2 s-1',    &
                long='areal sap flow rate in kg per m2 ground area per second',               &

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -5180,12 +5180,12 @@ contains
     real(r8) :: dt_tstep_inv        ! inverse timestep (1/sec)
     real(r8) :: n_perm2             ! number of plants per square meter
     real(r8) :: sum_area_rad        ! sum of patch canopy areas
-    real(r8) :: cwd_funghr
+    real(r8) :: cwdfung_hr
     real(r8),allocatable :: age_area_rad(:)
 
     type(fates_patch_type),pointer  :: cpatch
     type(fates_cohort_type),pointer :: ccohort
-
+    type(litter_type), pointer :: litt     ! Generic pointer to any litter pool
 
     associate( hio_gpp_si                   => this%hvars(ih_gpp_si)%r81d, &
          hio_npp_si                   => this%hvars(ih_npp_si)%r81d, &
@@ -5252,8 +5252,9 @@ contains
 
             litt => cpatch%litter(element_pos(carbon12_element))
 
-            ! scale fungal resp to kg/m2/s (currently in kg/m2/day)
-            cwdfung_hr =  cpatch%area*(sum(litt%ag_cwd_funghr) + sum(litt%bg_cwd_funghr))*area_inv
+            ! scale fungal resp to from /m2 patch to /m2 site (ie area weighted average)
+            ! convert time units from kg/m2/day to kg/m2/s
+            cwdfung_hr =  cpatch%area*(sum(litt%ag_cwd_funghr) + sum(litt%bg_cwd_funghr))*area_inv*days_per_sec
 
             hio_hr_si(io_si)  = hio_hr_si(io_si) + cwdfung_hr
             hio_nep_si(io_si) = hio_nep_si(io_si) + cwdfung_hr

--- a/parameter_files/fates_params_default.json
+++ b/parameter_files/fates_params_default.json
@@ -1685,10 +1685,11 @@
     },
     "fates_cwd_hrfrag_frac": {
 	"dtype": "float",
+	"dims": ["scalar"],
 	"long_name": "fraction of cwd losses due to fungal heterotrophic respiration and not fragmentation",
 	"units": "-",
 	"data": [0.5]
-    }
+    },
     "fates_cnp_eca_plant_escalar": {
       "dtype": "float",
       "dims": ["scalar"],

--- a/parameter_files/fates_params_default.json
+++ b/parameter_files/fates_params_default.json
@@ -1640,6 +1640,12 @@
       "units": "yr-1",
       "data": [0.52, 0.383, 0.383, 0.19, 1.0, 999.0]
     },
+      "fates_funghr_frac": {
+	  "dtype": "float",
+	  "long_name": "fraction of cwd losses due to fungal respiratoin and not fragmentation",
+	  "units": "-",
+	  "data": [0.5]
+      }
     "fates_frag_cwd_frac": {
       "dtype": "float",
       "dims": ["fates_NCWD"],

--- a/parameter_files/fates_params_default.json
+++ b/parameter_files/fates_params_default.json
@@ -1640,12 +1640,7 @@
       "units": "yr-1",
       "data": [0.52, 0.383, 0.383, 0.19, 1.0, 999.0]
     },
-      "fates_funghr_frac": {
-	  "dtype": "float",
-	  "long_name": "fraction of cwd losses due to fungal respiratoin and not fragmentation",
-	  "units": "-",
-	  "data": [0.5]
-      }
+   
     "fates_frag_cwd_frac": {
       "dtype": "float",
       "dims": ["fates_NCWD"],
@@ -1688,6 +1683,12 @@
       "units": "unitless",
       "data": [0.8]
     },
+    "fates_cwd_hrfrag_frac": {
+	"dtype": "float",
+	"long_name": "fraction of cwd losses due to fungal heterotrophic respiration and not fragmentation",
+	"units": "-",
+	"data": [0.5]
+    }
     "fates_cnp_eca_plant_escalar": {
       "dtype": "float",
       "dims": ["scalar"],


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

This set of changes introduces a new heterotrophic respiration loss applied to coarse woody debris.  This loss pathway is designed to mimic fungal wood decomposition, prior to entering the decomposition cascades in the host model.  This is applied to the fragmented loss fluxes.  A portion of the fragmented carbon loss from wood is sent to the hosts for further decomposition, and a portion is lost to the atmosphere now as this fungal respiration term.  

This change was motivate through discussions and brainstorming by the NGEET nutrient: including Anthony Walker, Charlie Koven, Xiaojuan Yang, Matthew Craig, Daniela Yaffar, Mingjie Shi, myself and others.

New FATES parameter: [fates_cwd_hrfrag_frac](https://github.com/rgknox/fates/blob/fungal-wood-respiration/parameter_files/fates_params_default.json#L1686-L1692)

This sets the fraction of carbon that is lost to fragmentation that ends up as fungal respiration flux.  Note that the higher the value of this term, the lower the C/N and C/P ratio (i.e. higher nutrient concentration) of the fragmentation flux into the host.

Control of total fragmentation rate remains unchanged, and is still based on a maximum rate set by the parameters:  [fates_frag_maxdecomp](https://github.com/rgknox/fates/blob/fungal-wood-respiration/parameter_files/fates_params_default.json#L1636C1-L1642C7)

This parameter is most useful in nutrient limited simulations. Moreover, we have found that this parameter is important to keeping C/N ratios of the total litter pool at lower and reasonable levels. 

<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

### Collaborators:

Conceptual design: 
@walkeranthonyp, @ckoven, Xiaojuan Yang, @rgknox 

<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

These changes should not impact C-only runs, aside from specific output variables related to litter composition. C-only dynamics should not be affected by this change.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [ ] The in-code documentation has been updated with descriptive comments
- [ ] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided
- [ ] FATES-CLM6 Code Freeze: satellite phenology regression tests are b4b

*If satellite phenology regressions are **not** b4b, please hold merge and notify the FATES development team.*

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

