### PR TITLE
Split initial density into to parameters with a switch on HLM side

### DIFF
--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -66,6 +66,7 @@ module EDInitMod
   use FatesInterfaceTypesMod         , only : nlevcoage
   use FatesInterfaceTypesMod         , only : nlevdamage
   use FatesInterfaceTypesMod         , only : hlm_use_nocomp
+  use FatesInterfaceTypesMod         , only : hlm_use_dbh_init
   use FatesInterfaceTypesMod         , only : nlevage
   use FatesAllometryMod         , only : h2d_allom
   use FatesAllometryMod         , only : h_allom
@@ -1204,7 +1205,7 @@ contains
       ! if any pfts are starting with a non-recruitment size then the whole site
       ! needs the inventory type of spread 
       do pft = 1, numpft
-         if (EDPftvarcon_inst%initd(pft) < 0.0_r8) then   
+         if (hlm_use_dbh_init .eq. itrue) then   
             site_in%spread = init_spread_inventory
          end if
       end do
@@ -1295,13 +1296,6 @@ contains
                end select phen_select
             end if if_spmode 
 
-            ! If EDPftvarcon_inst%initd is positive, then it is interpreted as
-            ! initial recruit density (stems/m2)
-            ! If EDPftvarcon_inss%initd is negative, then it is interpreted as
-            ! the initial DBH of the plant, and that the canopy is closed
-            ! at one layer. However, this is only possible in nocomp since
-            ! each PFT has its own patch area, and we don't have to assume
-            ! the differences in coverage.
 
             if_fullfates: if (hlm_use_nocomp .eq. ifalse) then
 
@@ -1315,8 +1309,8 @@ contains
                
             else ! We are in a nocomp simulation 
 
-               ! interpret as initial density and calculate diameter
-               if_init_dens: if (EDPftvarcon_inst%initd(pft) > nearzero) then  
+               ! Use initial density and calculate diameter
+               if_init_dens: if (hlm_use_dbh_init .eq. ifalse) then  
 
                   cohort_n = EDPftvarcon_inst%initd(pft)*patch_in%area
                   ! in nocomp mode we only have one PFT per patch
@@ -1333,9 +1327,9 @@ contains
                   ! calculate the plant diameter from height
                   call h2d_allom(height, pft, dbh)
 
-               else ! interpret as initial diameter and calculate density 
+               else ! Use initial diameter and calculate density 
 
-                  dbh = abs(EDPftvarcon_inst%initd(pft))
+                  dbh = EDPftvarcon_inst%initdbh(pft)
 
                   ! calculate crown area of a single plant
                   call carea_allom(dbh, 1.0_r8, site_in%spread, pft, crown_damage,  &

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -1260,19 +1260,6 @@ contains
         ! Check that in initial density is not equal to zero in a cold-start run
         !-----------------------------------------------------------------------------------
         
-        if ( hlm_use_inventory_init == ifalse .and. & 
-             abs( EDPftvarcon_inst%initd(ipft) ) < nearzero ) then
-          
-           write(fates_log(),*) ' In a cold start run initial density cannot be zero.'
-           write(fates_log(),*) ' For a bare ground run set to initial recruit density.'
-           write(fates_log(),*) ' If no-comp is on it is possible to initialize with larger  '
-           write(fates_log(),*) ' plants by setting use_fates_dbh_init to true'
-           write(fates_log(),*) ' so that initial dbh parameter is used instead of density. '
-           write(fates_log(),*) ' Aborting'
-           call endrun(msg=errMsg(sourcefile, __LINE__))
-           
-        end if
-        
         if ( EDPftvarcon_inst%initd(ipft) < -nearzero ) then
            write(fates_log(),*) ' Option to use negative values for initial density'
            write(fates_log(),*) ' has been depricated. Set use_fates_dbh_init to true'
@@ -1281,6 +1268,21 @@ contains
            write(fates_log(),*) ' Aborting'
            call endrun(msg=errMsg(sourcefile, __LINE__))
         end if
+
+        if ( hlm_use_inventory_init == ifalse .and. & 
+            EDPftvarcon_inst%initd(ipft) < nearzero ) then
+          
+           write(fates_log(),*) ' In a cold start run initial density cannot be zero'
+           write(fates_log(),*) ' without inventory initialization.'
+           write(fates_log(),*) ' If no-comp is on it is possible to initialize with larger  '
+           write(fates_log(),*) ' plants by setting use_fates_dbh_init to true'
+           write(fates_log(),*) ' so that initial dbh parameter is used instead of density. '
+           write(fates_log(),*) ' Aborting'
+           call endrun(msg=errMsg(sourcefile, __LINE__))
+           
+        end if
+        
+
 
 
         if (hlm_use_dbh_init .eq. itrue) then

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -60,8 +60,10 @@ module EDPftvarcon
      real(r8), allocatable :: displar(:)             ! ratio of displacement height to canopy top height
      real(r8), allocatable :: bark_scaler(:)         ! scaler from dbh to bark thickness. For fire model.
      real(r8), allocatable :: crown_kill(:)          ! scaler on fire death. For fire model.
-     real(r8), allocatable :: initd(:)               ! initial seedling density [/m2] (positive values)
-                                                     ! or -dbh [cm] (negative values)
+     real(r8), allocatable :: initd(:)               ! initial seedling density [/m2] 
+     real(r8), allocatable :: initdbh(:)             ! initial seedling dbh [cm]
+                                                     ! alternative to initd for nocomp
+                                                     ! used only when use_dbh_init and use_nocomp are both true
      real(r8), allocatable :: init_seed(:)           ! Initial seed bank [kg/m2]
                                                      ! For SP: this is unused
                                                      ! For Nocomp: This only applies the seed from the
@@ -345,6 +347,10 @@ contains
     param_p => pstruct%GetParamFromName('fates_recruit_init_density')
     allocate(EDPftvarcon_inst%initd(numpft))
     EDPftvarcon_inst%initd(:) = param_p%r_data_1d(:)
+
+    param_p => pstruct%GetParamFromName('fates_recruit_init_dbh')
+    allocate(EDPftvarcon_inst%initdbh(numpft))
+    EDPftvarcon_inst%initdbh(:) = param_p%r_data_1d(:)
 
     param_p => pstruct%GetParamFromName('fates_recruit_init_seed')
     allocate(EDPftvarcon_inst%init_seed(numpft))
@@ -844,6 +850,7 @@ contains
         write(fates_log(),fmt0) 'bark_scaler = ',EDPftvarcon_inst%bark_scaler
         write(fates_log(),fmt0) 'crown_kill = ',EDPftvarcon_inst%crown_kill
         write(fates_log(),fmt0) 'initd = ',EDPftvarcon_inst%initd
+        write(fates_log(),fmt0) 'initdbh = ',EDPftvarcon_inst%initdbh
         write(fates_log(),fmt0) 'init_seed = ',EDPftvarcon_inst%init_seed
         write(fates_log(),fmt0) 'seed_suppl = ',EDPftvarcon_inst%seed_suppl
         write(fates_log(),fmt0) 'lf_flab = ',EDPftvarcon_inst%lf_flab
@@ -950,6 +957,7 @@ contains
     use FatesInterfaceTypesMod, only : hlm_use_fixed_biogeog,hlm_use_sp, hlm_name
     use FatesInterfaceTypesMod, only : hlm_use_inventory_init
     use FatesInterfaceTypesMod, only : hlm_use_nocomp
+    use FatesInterfaceTypesMod, only : hlm_use_dbh_init
     use EDParamsMod        , only : max_nocomp_pfts_by_landuse, maxpatches_by_landuse
     use FatesConstantsMod  , only : n_landuse_cats
 
@@ -1258,24 +1266,31 @@ contains
            write(fates_log(),*) ' In a cold start run initial density cannot be zero.'
            write(fates_log(),*) ' For a bare ground run set to initial recruit density.'
            write(fates_log(),*) ' If no-comp is on it is possible to initialize with larger  '
-           write(fates_log(),*) ' plants by setting fates_recruit_init_density to a negative number'
-           write(fates_log(),*) ' which will be interpreted as (absolute) initial dbh. '
+           write(fates_log(),*) ' plants by setting use_fates_dbh_init to true'
+           write(fates_log(),*) ' so that initial dbh parameter is used instead of density. '
            write(fates_log(),*) ' Aborting'
            call endrun(msg=errMsg(sourcefile, __LINE__))
            
         end if
         
-        if ( hlm_use_nocomp .eq. ifalse .and. EDPftvarcon_inst%initd(ipft) < -nearzero ) then
-           write(fates_log(),*) ' When not in a noncomp configuration, FATES does not'
-           write(fates_log(),*) ' know how to interpret a negative %initd (number density)'
-           write(fates_log(),*) ' on a cold-start. In nocomp with a negative, we assume the absolute'
-           write(fates_log(),*) ' value of the %inidt parameter is the initial plant size.'
-           write(fates_log(),*) ' And since the fractional area of each PFT is known from'
-           write(fates_log(),*) ' the surface file, we can derive a number density from this'
-           write(fates_log(),*) ' However, we do not have a hypothesis to do this in full FATES.'
+        if ( EDPftvarcon_inst%initd(ipft) < -nearzero ) then
+           write(fates_log(),*) ' Option to use negative values for initial density'
+           write(fates_log(),*) ' has been depricated. Set use_fates_dbh_init to true'
+           write(fates_log(),*) ' to initialize with dbh in nocomp mode. The corresponding'
+           write(fates_log(),*) ' is called fates_recruit_init_dbh'
            write(fates_log(),*) ' Aborting'
            call endrun(msg=errMsg(sourcefile, __LINE__))
         end if
+
+
+        if (hlm_use_dbh_init .eq. itrue) then
+           if (EDPftvarcon_inst%initdbh(ipft) < nearzero) then
+              write(fates_log(),*) ' You are running in nocomp mode using initial dbh instead of density.'
+              write(fates_log(),*) ' In a cold start run initial dbh cannot be less or equal zero.'
+              write(fates_log(),*) ' Aborting'
+              call endrun(msg=errMsg(sourcefile, __LINE__))
+           endif
+        endif
 
         if ( EDPftvarcon_inst%init_seed(ipft) < 0._r8) then
            write(fates_log(),*) ' Initial seed pool fates_init_seed can not be negative.'

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -1290,6 +1290,13 @@ contains
               write(fates_log(),*) ' Aborting'
               call endrun(msg=errMsg(sourcefile, __LINE__))
            endif
+           if (EDPftvarcon_inst%init_seed(ipft) < nearzero) then
+              write(fates_log(),*) ' You are running in nocomp mode using initial dbh instead of density.'
+              write(fates_log(),*) ' In a cold start run initial seed cannot equal zero '
+              write(fates_log(),*) ' Otherwize mass-balance will not be conserved.'
+              write(fates_log(),*) ' Aborting'
+              call endrun(msg=errMsg(sourcefile, __LINE__))
+           endif
         endif
 
         if ( EDPftvarcon_inst%init_seed(ipft) < 0._r8) then

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -1683,7 +1683,7 @@ contains
             call endrun(msg=errMsg(sourcefile, __LINE__))
          end if
 
-         if (  .not.((hlm_use_dbh_init.eq.1).or.(hlm_use_dbh_init.eq.0))    ) then
+         if (  .not.((hlm_use_dbh_init.eq.itrue).or.(hlm_use_dbh_init.eq.ifalse))    ) then
             write(fates_log(), *) 'The Fates dbh init flag must be 0 or 1, exiting'
             call endrun(msg=errMsg(sourcefile, __LINE__))
          elseif ((hlm_use_dbh_init .eq. itrue) .and. (hlm_use_nocomp .eq. ifalse)) then

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -1574,6 +1574,7 @@ contains
          hlm_use_nocomp = unset_int   
          hlm_use_sp = unset_int
          hlm_use_inventory_init = unset_int
+         hlm_use_dbh_init = unset_int
          hlm_inventory_ctrl_file = 'unset'
          hlm_hist_level_dynam = unset_int
          hlm_hist_level_hifrq = unset_int
@@ -1679,6 +1680,14 @@ contains
          
          if(trim(hlm_inventory_ctrl_file) .eq. 'unset') then
             write(fates_log(),*) 'namelist entry for fates inventory control file is unset, exiting'
+            call endrun(msg=errMsg(sourcefile, __LINE__))
+         end if
+
+         if (  .not.((hlm_use_dbh_init.eq.1).or.(hlm_use_dbh_init.eq.0))    ) then
+            write(fates_log(), *) 'The Fates dbh init flag must be 0 or 1, exiting'
+            call endrun(msg=errMsg(sourcefile, __LINE__))
+         elseif ((hlm_use_dbh_init .eq. itrue) .and. (hlm_use_nocomp .eq. ifalse)) then
+            write(fates_log(), *) 'The Fates dbh init can only be ON in NOCOMP mode, exiting'
             call endrun(msg=errMsg(sourcefile, __LINE__))
          end if
 
@@ -2182,6 +2191,12 @@ contains
                hlm_use_inventory_init = ival
                if (fates_global_verbose()) then
                   write(fates_log(),*) 'Transfering hlm_use_inventory_init= ',ival,' to FATES'
+               end if
+
+            case('use_dbh_init')
+               hlm_use_dbh_init = ival
+               if (fates_global_verbose()) then
+                  write(fates_log(),*) 'Transfering hlm_use_dbh_init= ',ival,' to FATES'
                end if
 
             case('hist_hifrq_dimlevel')

--- a/main/FatesInterfaceTypesMod.F90
+++ b/main/FatesInterfaceTypesMod.F90
@@ -207,6 +207,11 @@ module FatesInterfaceTypesMod
                                                                     ! This need only be defined when
                                                                     ! hlm_use_inventory_init = 1
 
+   integer, public :: hlm_use_dbh_init                              ! Flag to use fates_recruit_init_dbh
+                                                                    ! instead of fates_recruit_init_density
+                                                                    ! only works in nocomp mode
+                                                                    !  1 = TRUE, 0 = FALSE 
+
   integer, public ::  hlm_use_fixed_biogeog                         !  Flag to use FATES fixed biogeography mode
                                                                     !  1 = TRUE, 0 = FALSE 
 

--- a/parameter_files/fates_params_default.json
+++ b/parameter_files/fates_params_default.json
@@ -1281,7 +1281,7 @@
       "dims": ["fates_pft"],
       "long_name": "initial seed pool - per m2 of associated pft-patch for no-comp, per m2 of whole site for non no-comp",
       "units": "kg/m2",
-      "data": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      "data": [0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
     },
     "fates_recruit_prescribed_rate": {
       "dtype": "float",

--- a/parameter_files/fates_params_default.json
+++ b/parameter_files/fates_params_default.json
@@ -1281,7 +1281,7 @@
       "dims": ["fates_pft"],
       "long_name": "initial seed pool - per m2 of associated pft-patch for no-comp, per m2 of whole site for non no-comp",
       "units": "kg/m2",
-      "data": [0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
+      "data": [0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00]
     },
     "fates_recruit_prescribed_rate": {
       "dtype": "float",

--- a/parameter_files/fates_params_default.json
+++ b/parameter_files/fates_params_default.json
@@ -1265,9 +1265,16 @@
     "fates_recruit_init_density": {
       "dtype": "float",
       "dims": ["fates_pft"],
-      "long_name": "initial seedling density for a cold-start near-bare-ground simulation. If negative sets initial tree dbh - only to be used in nocomp mode",
+      "long_name": "initial seedling density for a cold-start near-bare-ground simulation.",
       "units": "stems/m2",
       "data": [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.16, 0.2, 0.2, 0.2, 0.2]
+    },
+    "fates_recruit_init_dbh": {
+      "dtype": "float",
+      "dims": ["fates_pft"],
+      "long_name": "initial seedling dbh for a cold-start near-bare-ground simulation. Can only to be used in nocomp mode. To use it set use_dbh_init to true",
+      "units": "cm",
+      "data": [ 1, 1, 1, 1, 1, 1, 0.5, 0.5, 0.5, 0.5, 0.5, 0.1, 0.1, 0.1]
     },
     "fates_recruit_init_seed": {
       "dtype": "float",

--- a/parameter_files/fates_params_default.json
+++ b/parameter_files/fates_params_default.json
@@ -1281,7 +1281,7 @@
       "dims": ["fates_pft"],
       "long_name": "initial seed pool - per m2 of associated pft-patch for no-comp, per m2 of whole site for non no-comp",
       "units": "kg/m2",
-      "data": [0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00]
+      "data": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     },
     "fates_recruit_prescribed_rate": {
       "dtype": "float",

--- a/parameter_files/fates_params_default.json
+++ b/parameter_files/fates_params_default.json
@@ -1262,19 +1262,19 @@
       "units": "m",
       "data": [1.3, 1.3, 1.3, 1.3, 1.3, 1.3, 0.2, 0.2, 0.2, 0.8, 0.8, 0.11, 0.2, 0.2]
     },
-    "fates_recruit_init_density": {
-      "dtype": "float",
-      "dims": ["fates_pft"],
-      "long_name": "initial seedling density for a cold-start near-bare-ground simulation.",
-      "units": "stems/m2",
-      "data": [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.16, 0.2, 0.2, 0.2, 0.2]
-    },
     "fates_recruit_init_dbh": {
       "dtype": "float",
       "dims": ["fates_pft"],
       "long_name": "initial seedling dbh for a cold-start near-bare-ground simulation. Can only to be used in nocomp mode. To use it set use_dbh_init to true",
       "units": "cm",
       "data": [ 1, 1, 1, 1, 1, 1, 0.5, 0.5, 0.5, 0.5, 0.5, 0.1, 0.1, 0.1]
+    },
+    "fates_recruit_init_density": {
+      "dtype": "float",
+      "dims": ["fates_pft"],
+      "long_name": "initial seedling density for a cold-start near-bare-ground simulation.",
+      "units": "stems/m2",
+      "data": [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.16, 0.2, 0.2, 0.2, 0.2]
     },
     "fates_recruit_init_seed": {
       "dtype": "float",


### PR DESCRIPTION

### Description:
Instead of using negative numbers in `fates_recruit_init_density` for an option to coldstart nocomp with dbh instead of density. Add `fates_recruit_init_dbh` parameter that can only be used when a new switch `use_dbh_init` is on. That one has to be set on the hlm side.
This is needed to have NorESM calibrated parameters to work and be default while NOT braking any full-fates configurations. 

### Collaborators:


### Expectation of Answer Changes:
None, since switch is off by default.
If the switch is on, the model will break anyway with the current values for `init_seed`.

### Checklist


All checklist items must be checked to enable merging this pull request:

*Contributor*
- [x] The in-code documentation has been updated with descriptive comments
- [x] The documentation has been assessed to determine if updates are necessary

*Integrator*
- [x] FATES PASS/FAIL regression tests were run
- [x] Evaluation of test results for answer changes was performed and results provided
- [x] FATES-CLM6 Code Freeze: satellite phenology regression tests are b4b

*If satellite phenology regressions are **not** b4b, please hold merge and notify the FATES development team.*

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

