### PR TITLE
Enable DBH initialization to "full FATES" on coldstarts

### DIFF
--- a/biogeochem/FatesSoilBGCFluxMod.F90
+++ b/biogeochem/FatesSoilBGCFluxMod.F90
@@ -218,7 +218,7 @@ contains
                 pft = ccohort%pft
                 fnrt_c = ccohort%prt%GetState(fnrt_organ, carbon12_element)
                 ccohort%daily_p_demand = fnrt_c * EDPftvarcon_inst%vmax_p(pft) * sec_per_day
-                ccohort%daily_p_gain   = fnrt_c * EDPftvarcon_inst%vmax_p(pft) * sec_per_day * EDPftvarcon_inst%prescribed_nuptake(pft)
+                ccohort%daily_p_gain   = fnrt_c * EDPftvarcon_inst%vmax_p(pft) * sec_per_day * EDPftvarcon_inst%prescribed_puptake(pft)
                 ccohort => ccohort%shorter
              end do
              cpatch => cpatch%younger

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -66,6 +66,7 @@ module EDInitMod
   use FatesInterfaceTypesMod         , only : nlevcoage
   use FatesInterfaceTypesMod         , only : nlevdamage
   use FatesInterfaceTypesMod         , only : hlm_use_nocomp
+  use FatesInterfaceTypesMod         , only : hlm_use_dbh_init
   use FatesInterfaceTypesMod         , only : nlevage
   use FatesAllometryMod         , only : h2d_allom
   use FatesAllometryMod         , only : h_allom
@@ -1204,7 +1205,7 @@ contains
       ! if any pfts are starting with a non-recruitment size then the whole site
       ! needs the inventory type of spread 
       do pft = 1, numpft
-         if (EDPftvarcon_inst%initd(pft) < 0.0_r8) then   
+         if (hlm_use_dbh_init .eq. itrue) then   
             site_in%spread = init_spread_inventory
          end if
       end do
@@ -1295,13 +1296,6 @@ contains
                end select phen_select
             end if if_spmode 
 
-            ! If EDPftvarcon_inst%initd is positive, then it is interpreted as
-            ! initial recruit density (stems/m2)
-            ! If EDPftvarcon_inss%initd is negative, then it is interpreted as
-            ! the initial DBH of the plant, and that the canopy is closed
-            ! at one layer. However, this is only possible in nocomp since
-            ! each PFT has its own patch area, and we don't have to assume
-            ! the differences in coverage.
 
             if_fullfates: if (hlm_use_nocomp .eq. ifalse) then
 
@@ -1315,8 +1309,8 @@ contains
                
             else ! We are in a nocomp simulation 
 
-               ! interpret as initial density and calculate diameter
-               if_init_dens: if (EDPftvarcon_inst%initd(pft) > nearzero) then  
+               ! Use initial density and calculate diameter
+               if_init_dens: if (hlm_use_dbh_init .eq. ifalse) then  
 
                   cohort_n = EDPftvarcon_inst%initd(pft)*patch_in%area
                   ! in nocomp mode we only have one PFT per patch
@@ -1333,9 +1327,9 @@ contains
                   ! calculate the plant diameter from height
                   call h2d_allom(height, pft, dbh)
 
-               else ! interpret as initial diameter and calculate density 
+               else ! Use initial diameter and calculate density 
 
-                  dbh = abs(EDPftvarcon_inst%initd(pft))
+                  dbh = EDPftvarcon_inst%initdbh(pft)
 
                   ! calculate crown area of a single plant
                   call carea_allom(dbh, 1.0_r8, site_in%spread, pft, crown_damage,  &

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -111,6 +111,11 @@ module EDInitMod
 
   logical   ::  debug = .false.
   integer :: istat           ! return status code
+
+  real(r8),parameter :: undamaged_crown = 1.0_r8   ! Assume on initialization the plants
+                                                   ! are not damaged
+  real(r8),parameter :: untrimmed = 1.0_r8         ! Initialize plants as untrimmed
+  
   character(len=255) :: smsg ! Message string for deallocation errors
   character(len=*), parameter, private :: sourcefile = &
        __FILE__
@@ -1169,7 +1174,6 @@ contains
       integer                          :: use_pft_local(numpft) ! determine whether this PFT is used for this patch and site
       integer                          :: crown_damage          ! crown damage class of the cohort [1 = undamaged, >1 = damaged] 
       real(r8)                         :: l2fr                  ! leaf to fineroot biomass ratio [kg kg-1]
-      real(r8)                         :: canopy_trim           ! fraction of the maximum leaf biomass that we are targeting [0-1]
       real(r8)                         :: cohort_n              ! cohort density
       real(r8)                         :: dbh                   ! cohort dbh [cm]
       real(r8)                         :: height                ! cohort height [m]
@@ -1243,7 +1247,6 @@ contains
       pft_loop: do pft =  1, numpft
          if_use_this_pft: if (use_pft_local(pft) .eq. itrue) then
             l2fr         = prt_params%allom_l2fr(pft)
-            canopy_trim  = 1.0_r8
             c_area       = fates_unset_r8
             
             ! retrieve drop fraction of non-leaf tissues for phenology initialization
@@ -1299,34 +1302,35 @@ contains
                end select phen_select
             end if if_spmode 
 
-            ! Initialize cohort abundance and size
+            ! Initialize cohort abundance, size and leaf mass
+            ! (we also include leaf mass because this is an output
+            !  from the SP init algorithm)
             call ColdInitDBHAndNumDense(patch_in%area, &              ! in
                                         sum(site_in%use_this_pft), &  ! in
                                         sum(use_pft_local), &         ! in
                                         pft, &                        ! in
+                                        efleaf_coh, &                 ! in
                                         dbh, &                        ! out
                                         height, &                     ! out
                                         n_plant, &                    ! out
                                         c_leaf)                       ! out
             
-           
-            
             ! calculate total above-ground biomass from allometry
-            call bagw_allom(dbh, pft, crown_damage, efstem_coh, c_agw)
+            call bagw_allom(dbh, pft, undamaged_crown, efstem_coh, c_agw)
 
             ! calculate coarse root biomass from allometry
             call bbgw_allom(dbh, pft, efstem_coh, c_bgw)
 
             ! Calculate fine root biomass from allometry
             ! (calculates a maximum and then trimming value)
-            call bfineroot(dbh, pft, canopy_trim, l2fr, effnrt_coh, c_fnrt)
+            call bfineroot(dbh, pft, untrimmed, l2fr, effnrt_coh, c_fnrt)
 
             ! Calculate sapwood biomass
-            call bsap_allom(dbh, pft, crown_damage, canopy_trim, efstem_coh,   &
+            call bsap_allom(dbh, pft, undamaged_crown, untrimmed, efstem_coh,   &
                a_sapw, c_sapw)
 
             call bdead_allom(c_agw, c_bgw, c_sapw, pft, c_struct)
-            call bstore_allom(dbh, pft, crown_damage, canopy_trim, c_store)
+            call bstore_allom(dbh, pft, undamaged_crown, untrimmed, c_store)
 
             ! --------------------------------------------------------------------------------
             ! Initialize the mass of every element in every organ of the organ
@@ -1390,7 +1394,7 @@ contains
             call create_cohort(site_in, patch_in, pft, cohort_n,               &
                height, zero_co_age, dbh, prt, efleaf_coh,                      &
                effnrt_coh, efstem_coh, leaf_status, recruitstatus,             &
-               canopy_trim, c_area, 1, crown_damage, site_in%spread, bc_in)
+               untrimmed, c_area, 1, undamaged_crown, site_in%spread, bc_in)
 
          endif if_use_this_pft
       enddo pft_loop
@@ -1408,7 +1412,8 @@ contains
    ! =================================================================================
    
    
-   subroutine ColdInitDBHAndNumDense(patch_area, spread, num_pft_in_site, num_pft_in_patch, pft, dbh, height, n_plant, c_leaf)
+   subroutine ColdInitDBHAndNumDense(patch_area, spread, num_pft_in_site, &
+                                     num_pft_in_patch, pft, dbh, height, n_plant, c_leaf)
 
      ! This routine returns the plant density and size
      ! for a cold-started plant.
@@ -1426,6 +1431,7 @@ contains
      integer,  intent(in) :: num_pft_in_site  ! number of pfts that exist at this site
      integer,  intent(in) :: num_pft_in_patch ! number of pfts coexisting in this patch
      integer,  intent(in) :: pft              ! pft index of this cohort
+     real(r8), intent(in) :: efleaf           ! amount of leaf flushing (0-1)
      real(r8), intent(out) :: dbh             ! diameter (cm)
      real(r8), intent(out) :: n_plant         ! number of plants (plants/patch)
      real(r8), intent(out) :: c_leaf          ! leaf biomass, SP seems to have
@@ -1436,8 +1442,7 @@ contains
      real(r8) :: c_area_plant                 ! crown area per plant (m2)
      real(r8) :: c_area_co                    ! crown area of cohort (m2)
      
-     real(r8),parameter :: undamaged_crown = 1.0_r8   ! Assume on initialization the plants
-                                                      ! are not damaged
+  
      real(r8),parameter :: nominal_sp_height = 0.5_r8 ! nominal height (dummy) for SP
      real(r8),parameter :: nominal_sp_tlai   = 0.2_r8 ! nominal TLAI for SP
      real(r8),parameter :: nominal_sp_tsai   = 0.1_r8 ! nominal TSAI for SP
@@ -1508,7 +1513,7 @@ contains
 
         ! Calculate the leaf biomass from allometry
         ! (calculates a maximum first, then applies canopy trim)
-        call bleaf(dbh, pft, crown_damage, canopy_trim, efleaf_coh, c_leaf)
+        call bleaf(dbh, pft, undamaged_crown, untrimmed, efleaf, c_leaf)
         
      end if if_sp
 

--- a/main/EDInitMod.F90
+++ b/main/EDInitMod.F90
@@ -1196,7 +1196,8 @@ contains
       real(r8)                         :: fnrt_drop_fraction    ! fraction of fine roots to absciss when leaves absciss
       integer, parameter               :: recruitstatus = 0     ! whether the newly created cohorts are recruited or initialized
       real(r8),parameter               :: zero_co_age = 0._r8   ! The age of a newly recruited cohort is zero
-      !-------------------------------------------------------------------------------------
+
+     !-------------------------------------------------------------------------------------
 
       patch_in%tallest  => null()
       patch_in%shortest => null()
@@ -1217,6 +1218,7 @@ contains
       ! 3. biogeog = false. nocomp = true : patch level filter
       ! 4. biogeog = true.  nocomp = true : patch and site level filter
       ! in principle this could be a patch level variable.
+      
       do pft = 1, numpft
          ! first turn every PFT ON, unless we are in a special case
          use_pft_local(pft) = itrue ! Case 1
@@ -1235,11 +1237,13 @@ contains
          endif
       end do
 
+      
+
+      
       pft_loop: do pft =  1, numpft
          if_use_this_pft: if (use_pft_local(pft) .eq. itrue) then
             l2fr         = prt_params%allom_l2fr(pft)
             canopy_trim  = 1.0_r8
-            crown_damage = 1  ! Assume no damage to begin with
             c_area       = fates_unset_r8
             
             ! retrieve drop fraction of non-leaf tissues for phenology initialization
@@ -1295,80 +1299,18 @@ contains
                end select phen_select
             end if if_spmode 
 
-            ! If EDPftvarcon_inst%initd is positive, then it is interpreted as
-            ! initial recruit density (stems/m2)
-            ! If EDPftvarcon_inss%initd is negative, then it is interpreted as
-            ! the initial DBH of the plant, and that the canopy is closed
-            ! at one layer. However, this is only possible in nocomp since
-            ! each PFT has its own patch area, and we don't have to assume
-            ! the differences in coverage.
-
-            if_fullfates: if (hlm_use_nocomp .eq. ifalse) then
-
-               cohort_n = EDPftvarcon_inst%initd(pft)*patch_in%area
-               height = EDPftvarcon_inst%hgt_min(pft)
-
-               ! calculate the plant diameter from height
-               call h2d_allom(height, pft, dbh)
-
-               call bleaf(dbh, pft, crown_damage, canopy_trim, efleaf_coh, c_leaf)
-               
-            else ! We are in a nocomp simulation 
-
-               ! interpret as initial density and calculate diameter
-               if_init_dens: if (EDPftvarcon_inst%initd(pft) > nearzero) then  
-
-                  cohort_n = EDPftvarcon_inst%initd(pft)*patch_in%area
-                  ! in nocomp mode we only have one PFT per patch
-
-                  ! as opposed to numpft's. So we should up the initial density
-                  ! to compensate (otherwise runs are very hard to compare)
-                  ! this multiplies it by the number of PFTs there would have been in
-                  ! the single shared patch in competition mode.
-                  ! n.b. that this is the same as currentcohort%n = initd(pft) &AREA
-                  cohort_n = cohort_n*sum(site_in%use_this_pft)
-
-                  height = EDPftvarcon_inst%hgt_min(pft)
-
-                  ! calculate the plant diameter from height
-                  call h2d_allom(height, pft, dbh)
-
-               else ! interpret as initial diameter and calculate density 
-
-                  dbh = abs(EDPftvarcon_inst%initd(pft))
-
-                  ! calculate crown area of a single plant
-                  call carea_allom(dbh, 1.0_r8, site_in%spread, pft, crown_damage,  &
-                       c_area)
-
-                  ! calculate initial density required to close canopy 
-                  cohort_n = patch_in%area/c_area
-
-                  ! calculate height from diameter
-                  call h_allom(dbh, pft, height)
-
-               endif if_init_dens
-               
-               ! Calculate the leaf biomass from allometry
-               ! (calculates a maximum first, then applies canopy trim)
-               call bleaf(dbh, pft, crown_damage, canopy_trim, efleaf_coh, c_leaf)
-               
-               ! If we are in SP mode we ignore the initial values and read in height,
-               ! which is used to calcualte n.
-               ! h, dbh, leafc, n from SP values or from small initial size
-               if (hlm_use_sp .eq. itrue) then
-                  ! At this point, we do not know the bc_in values of tlai tsai and htop,
-                  ! so this is initializing to an arbitrary value for the very first timestep.
-                  ! Not sure if there's a way around this or not.
-                  height = 0.5_r8
-                  call calculate_SP_properties(height, 0.2_r8, 0.1_r8,         &
-                       patch_in%area, pft, crown_damage, 1,                      &
-                       EDPftvarcon_inst%vcmax25top(pft, 1), c_leaf, dbh,         &
-                       cohort_n, c_area)
-               endif  ! sp mode
-
-            endif if_fullfates
-
+            ! Initialize cohort abundance and size
+            call ColdInitDBHAndNumDense(patch_in%area, &              ! in
+                                        sum(site_in%use_this_pft), &  ! in
+                                        sum(use_pft_local), &         ! in
+                                        pft, &                        ! in
+                                        dbh, &                        ! out
+                                        height, &                     ! out
+                                        n_plant, &                    ! out
+                                        c_leaf)                       ! out
+            
+           
+            
             ! calculate total above-ground biomass from allometry
             call bagw_allom(dbh, pft, crown_damage, efstem_coh, c_agw)
 
@@ -1385,8 +1327,6 @@ contains
 
             call bdead_allom(c_agw, c_bgw, c_sapw, pft, c_struct)
             call bstore_allom(dbh, pft, crown_damage, canopy_trim, c_store)
-
-            if (debug) write(fates_log(),*) 'EDInitMod.F90 call create_cohort '
 
             ! --------------------------------------------------------------------------------
             ! Initialize the mass of every element in every organ of the organ
@@ -1464,6 +1404,118 @@ contains
 
    end subroutine init_cohorts
 
+
+   ! =================================================================================
+   
+   
+   subroutine ColdInitDBHAndNumDense(patch_area, spread, num_pft_in_site, num_pft_in_patch, pft, dbh, height, n_plant, c_leaf)
+
+     ! This routine returns the plant density and size
+     ! for a cold-started plant.
+     ! If EDPftvarcon_inst%initd is positive, then it is interpreted as
+     ! initial recruit density (stems/m2)
+     ! If EDPftvarcon_inss%initd is negative, then it is interpreted as
+     ! the initial DBH of the plant, and that the canopy is closed
+     ! at one layer. However, this is only possible in nocomp since
+     ! each PFT has its own patch area, and we don't have to assume
+     ! the differences in coverage.
+     
+     ! Arguments
+     real(r8), intent(in) :: patch_area       ! The area of this patch (m2)
+     real(r8), intent(in) :: spread           ! Crown spread, currently init_spread
+     integer,  intent(in) :: num_pft_in_site  ! number of pfts that exist at this site
+     integer,  intent(in) :: num_pft_in_patch ! number of pfts coexisting in this patch
+     integer,  intent(in) :: pft              ! pft index of this cohort
+     real(r8), intent(out) :: dbh             ! diameter (cm)
+     real(r8), intent(out) :: n_plant         ! number of plants (plants/patch)
+     real(r8), intent(out) :: c_leaf          ! leaf biomass, SP seems to have
+                                              ! its own algorithm here, so we
+                                              ! don't necessarily rely on the allometry equations
+     
+     real(r8) :: height
+     real(r8) :: c_area_plant                 ! crown area per plant (m2)
+     real(r8) :: c_area_co                    ! crown area of cohort (m2)
+     
+     real(r8),parameter :: undamaged_crown = 1.0_r8   ! Assume on initialization the plants
+                                                      ! are not damaged
+     real(r8),parameter :: nominal_sp_height = 0.5_r8 ! nominal height (dummy) for SP
+     real(r8),parameter :: nominal_sp_tlai   = 0.2_r8 ! nominal TLAI for SP
+     real(r8),parameter :: nominal_sp_tsai   = 0.1_r8 ! nominal TSAI for SP
+     integer, parameter :: upper_canopy      = 1      ! initializing a single canopy layer
+     real(r8),parameter :: unit_plant_dense  = 1.0    ! used to get crown-area per plant (1. plant/m2)
+
+     
+     if_sp: if (hlm_use_sp .eq. itrue) then
+        
+        ! If we are in SP mode we ignore the initial values and read in height,
+        ! which is used to calculate plant density.
+        ! h, dbh, leafc, n from SP values or from small initial size
+        ! At this point, we do not know the bc_in values of tlai tsai and htop,
+        ! so this is initializing to an arbitrary value for the very first timestep.
+        ! Not sure if there's a way around this or not.
+
+        height = nominal_sp_height
+        
+        call calculate_SP_properties(height, &  ! in
+                                     nominal_sp_tlai,   &  ! in
+                                     nominal_sp_tsai,   &  ! in
+                                     patch_area,        &  ! in
+                                     pft,               &  ! in
+                                     undamaged_crown,   &  ! in
+                                     upper_canopy,      &  ! in
+                                     EDPftvarcon_inst%vcmax25top(pft, 1), & !in
+                                     c_leaf,            &  ! out
+                                     dbh,               &  ! out
+                                     cohort_n,          &  ! out
+                                     c_area_co)            ! out
+     else
+        
+        ! interpret as initial density and calculate diameter
+        if_init_dens: if (EDPftvarcon_inst%initd(pft) > nearzero) then  
+           
+           n_plant = EDPftvarcon_inst%initd(pft)*patch_area
+           
+           ! For no-comp, we should up the initial density
+           ! to compensate (otherwise runs are very hard to compare)
+           ! this multiplies it by the number of PFTs there would have been in
+           ! the single shared patch in competition mode.
+           ! n.b. that this is the same as currentcohort%n = initd(pft) &AREA
+           if(hlm_use_nocomp.eq.itrue)then
+              n_plant = n_plant*real(num_pft_in_site,r8)
+           end if
+           
+           height = EDPftvarcon_inst%hgt_min(pft)
+           
+           ! calculate the plant diameter from height
+           call h2d_allom(height, pft, dbh)
+                  
+        else ! interpret as initial diameter and calculate density 
+           
+           dbh = abs(EDPftvarcon_inst%initd(pft))
+
+           ! calculate crown area of a single plant
+           call carea_allom(dbh, unit_plant_dense, spread, pft, undamaged_crown, c_area_plant)
+           
+           ! calculate initial density required to close canopy
+           ! If we are in "full-fates/non-nocomp" mode, then we
+           ! simply assume equal canopy area for each cohort
+           plant_n = (patch_area/real(num_pft_in_patch),r8)/c_area_plant
+           
+           ! calculate height from diameter
+           call h_allom(dbh, pft, height)
+           
+        endif if_init_dens
+
+        ! Calculate the leaf biomass from allometry
+        ! (calculates a maximum first, then applies canopy trim)
+        call bleaf(dbh, pft, crown_damage, canopy_trim, efleaf_coh, c_leaf)
+        
+     end if if_sp
+
+   end subroutine ColdInitDBHAndNumDense
+
+
+   
   ! ======================================================================================
 
 end module EDInitMod

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -1260,19 +1260,6 @@ contains
         ! Check that in initial density is not equal to zero in a cold-start run
         !-----------------------------------------------------------------------------------
         
-        if ( hlm_use_inventory_init == ifalse .and. & 
-             abs( EDPftvarcon_inst%initd(ipft) ) < nearzero ) then
-          
-           write(fates_log(),*) ' In a cold start run initial density cannot be zero.'
-           write(fates_log(),*) ' For a bare ground run set to initial recruit density.'
-           write(fates_log(),*) ' If no-comp is on it is possible to initialize with larger  '
-           write(fates_log(),*) ' plants by setting use_fates_dbh_init to true'
-           write(fates_log(),*) ' so that initial dbh parameter is used instead of density. '
-           write(fates_log(),*) ' Aborting'
-           call endrun(msg=errMsg(sourcefile, __LINE__))
-           
-        end if
-        
         if ( EDPftvarcon_inst%initd(ipft) < -nearzero ) then
            write(fates_log(),*) ' Option to use negative values for initial density'
            write(fates_log(),*) ' has been depricated. Set use_fates_dbh_init to true'
@@ -1281,6 +1268,21 @@ contains
            write(fates_log(),*) ' Aborting'
            call endrun(msg=errMsg(sourcefile, __LINE__))
         end if
+
+        if ( hlm_use_inventory_init == ifalse .and. & 
+            EDPftvarcon_inst%initd(ipft) < nearzero ) then
+          
+           write(fates_log(),*) ' In a cold start run initial density cannot be zero'
+           write(fates_log(),*) ' without inventory initialization.'
+           write(fates_log(),*) ' If no-comp is on it is possible to initialize with larger  '
+           write(fates_log(),*) ' plants by setting use_fates_dbh_init to true'
+           write(fates_log(),*) ' so that initial dbh parameter is used instead of density. '
+           write(fates_log(),*) ' Aborting'
+           call endrun(msg=errMsg(sourcefile, __LINE__))
+           
+        end if
+        
+
 
 
         if (hlm_use_dbh_init .eq. itrue) then

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -60,8 +60,10 @@ module EDPftvarcon
      real(r8), allocatable :: displar(:)             ! ratio of displacement height to canopy top height
      real(r8), allocatable :: bark_scaler(:)         ! scaler from dbh to bark thickness. For fire model.
      real(r8), allocatable :: crown_kill(:)          ! scaler on fire death. For fire model.
-     real(r8), allocatable :: initd(:)               ! initial seedling density [/m2] (positive values)
-                                                     ! or -dbh [cm] (negative values)
+     real(r8), allocatable :: initd(:)               ! initial seedling density [/m2] 
+     real(r8), allocatable :: initdbh(:)             ! initial seedling dbh [cm]
+                                                     ! alternative to initd for nocomp
+                                                     ! used only when use_dbh_init and use_nocomp are both true
      real(r8), allocatable :: init_seed(:)           ! Initial seed bank [kg/m2]
                                                      ! For SP: this is unused
                                                      ! For Nocomp: This only applies the seed from the
@@ -345,6 +347,10 @@ contains
     param_p => pstruct%GetParamFromName('fates_recruit_init_density')
     allocate(EDPftvarcon_inst%initd(numpft))
     EDPftvarcon_inst%initd(:) = param_p%r_data_1d(:)
+
+    param_p => pstruct%GetParamFromName('fates_recruit_init_dbh')
+    allocate(EDPftvarcon_inst%initdbh(numpft))
+    EDPftvarcon_inst%initdbh(:) = param_p%r_data_1d(:)
 
     param_p => pstruct%GetParamFromName('fates_recruit_init_seed')
     allocate(EDPftvarcon_inst%init_seed(numpft))
@@ -844,6 +850,7 @@ contains
         write(fates_log(),fmt0) 'bark_scaler = ',EDPftvarcon_inst%bark_scaler
         write(fates_log(),fmt0) 'crown_kill = ',EDPftvarcon_inst%crown_kill
         write(fates_log(),fmt0) 'initd = ',EDPftvarcon_inst%initd
+        write(fates_log(),fmt0) 'initdbh = ',EDPftvarcon_inst%initdbh
         write(fates_log(),fmt0) 'init_seed = ',EDPftvarcon_inst%init_seed
         write(fates_log(),fmt0) 'seed_suppl = ',EDPftvarcon_inst%seed_suppl
         write(fates_log(),fmt0) 'lf_flab = ',EDPftvarcon_inst%lf_flab
@@ -950,6 +957,7 @@ contains
     use FatesInterfaceTypesMod, only : hlm_use_fixed_biogeog,hlm_use_sp, hlm_name
     use FatesInterfaceTypesMod, only : hlm_use_inventory_init
     use FatesInterfaceTypesMod, only : hlm_use_nocomp
+    use FatesInterfaceTypesMod, only : hlm_use_dbh_init
     use EDParamsMod        , only : max_nocomp_pfts_by_landuse, maxpatches_by_landuse
     use FatesConstantsMod  , only : n_landuse_cats
 
@@ -1258,24 +1266,31 @@ contains
            write(fates_log(),*) ' In a cold start run initial density cannot be zero.'
            write(fates_log(),*) ' For a bare ground run set to initial recruit density.'
            write(fates_log(),*) ' If no-comp is on it is possible to initialize with larger  '
-           write(fates_log(),*) ' plants by setting fates_recruit_init_density to a negative number'
-           write(fates_log(),*) ' which will be interpreted as (absolute) initial dbh. '
+           write(fates_log(),*) ' plants by setting use_fates_dbh_init to true'
+           write(fates_log(),*) ' so that initial dbh parameter is used instead of density. '
            write(fates_log(),*) ' Aborting'
            call endrun(msg=errMsg(sourcefile, __LINE__))
            
         end if
         
-        if ( hlm_use_nocomp .eq. ifalse .and. EDPftvarcon_inst%initd(ipft) < -nearzero ) then
-           write(fates_log(),*) ' When not in a noncomp configuration, FATES does not'
-           write(fates_log(),*) ' know how to interpret a negative %initd (number density)'
-           write(fates_log(),*) ' on a cold-start. In nocomp with a negative, we assume the absolute'
-           write(fates_log(),*) ' value of the %inidt parameter is the initial plant size.'
-           write(fates_log(),*) ' And since the fractional area of each PFT is known from'
-           write(fates_log(),*) ' the surface file, we can derive a number density from this'
-           write(fates_log(),*) ' However, we do not have a hypothesis to do this in full FATES.'
+        if ( EDPftvarcon_inst%initd(ipft) < -nearzero ) then
+           write(fates_log(),*) ' Option to use negative values for initial density'
+           write(fates_log(),*) ' has been depricated. Set use_fates_dbh_init to true'
+           write(fates_log(),*) ' to initialize with dbh in nocomp mode. The corresponding'
+           write(fates_log(),*) ' is called fates_recruit_init_dbh'
            write(fates_log(),*) ' Aborting'
            call endrun(msg=errMsg(sourcefile, __LINE__))
         end if
+
+
+        if (hlm_use_dbh_init .eq. itrue) then
+           if (EDPftvarcon_inst%initdbh(ipft) < nearzero) then
+              write(fates_log(),*) ' You are running in nocomp mode using initial dbh instead of density.'
+              write(fates_log(),*) ' In a cold start run initial dbh cannot be less or equal zero.'
+              write(fates_log(),*) ' Aborting'
+              call endrun(msg=errMsg(sourcefile, __LINE__))
+           endif
+        endif
 
         if ( EDPftvarcon_inst%init_seed(ipft) < 0._r8) then
            write(fates_log(),*) ' Initial seed pool fates_init_seed can not be negative.'

--- a/main/EDPftvarcon.F90
+++ b/main/EDPftvarcon.F90
@@ -1290,6 +1290,13 @@ contains
               write(fates_log(),*) ' Aborting'
               call endrun(msg=errMsg(sourcefile, __LINE__))
            endif
+           if (EDPftvarcon_inst%init_seed(ipft) < nearzero) then
+              write(fates_log(),*) ' You are running in nocomp mode using initial dbh instead of density.'
+              write(fates_log(),*) ' In a cold start run initial seed cannot equal zero '
+              write(fates_log(),*) ' Otherwize mass-balance will not be conserved.'
+              write(fates_log(),*) ' Aborting'
+              call endrun(msg=errMsg(sourcefile, __LINE__))
+           endif
         endif
 
         if ( EDPftvarcon_inst%init_seed(ipft) < 0._r8) then

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -1683,7 +1683,7 @@ contains
             call endrun(msg=errMsg(sourcefile, __LINE__))
          end if
 
-         if (  .not.((hlm_use_dbh_init.eq.1).or.(hlm_use_dbh_init.eq.0))    ) then
+         if (  .not.((hlm_use_dbh_init.eq.itrue).or.(hlm_use_dbh_init.eq.ifalse))    ) then
             write(fates_log(), *) 'The Fates dbh init flag must be 0 or 1, exiting'
             call endrun(msg=errMsg(sourcefile, __LINE__))
          elseif ((hlm_use_dbh_init .eq. itrue) .and. (hlm_use_nocomp .eq. ifalse)) then

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -1574,6 +1574,7 @@ contains
          hlm_use_nocomp = unset_int   
          hlm_use_sp = unset_int
          hlm_use_inventory_init = unset_int
+         hlm_use_dbh_init = unset_int
          hlm_inventory_ctrl_file = 'unset'
          hlm_hist_level_dynam = unset_int
          hlm_hist_level_hifrq = unset_int
@@ -1679,6 +1680,14 @@ contains
          
          if(trim(hlm_inventory_ctrl_file) .eq. 'unset') then
             write(fates_log(),*) 'namelist entry for fates inventory control file is unset, exiting'
+            call endrun(msg=errMsg(sourcefile, __LINE__))
+         end if
+
+         if (  .not.((hlm_use_dbh_init.eq.1).or.(hlm_use_dbh_init.eq.0))    ) then
+            write(fates_log(), *) 'The Fates dbh init flag must be 0 or 1, exiting'
+            call endrun(msg=errMsg(sourcefile, __LINE__))
+         elseif ((hlm_use_dbh_init .eq. itrue) .and. (hlm_use_nocomp .eq. ifalse)) then
+            write(fates_log(), *) 'The Fates dbh init can only be ON in NOCOMP mode, exiting'
             call endrun(msg=errMsg(sourcefile, __LINE__))
          end if
 
@@ -2182,6 +2191,12 @@ contains
                hlm_use_inventory_init = ival
                if (fates_global_verbose()) then
                   write(fates_log(),*) 'Transfering hlm_use_inventory_init= ',ival,' to FATES'
+               end if
+
+            case('use_dbh_init')
+               hlm_use_dbh_init = ival
+               if (fates_global_verbose()) then
+                  write(fates_log(),*) 'Transfering hlm_use_dbh_init= ',ival,' to FATES'
                end if
 
             case('hist_hifrq_dimlevel')

--- a/main/FatesInterfaceTypesMod.F90
+++ b/main/FatesInterfaceTypesMod.F90
@@ -207,6 +207,11 @@ module FatesInterfaceTypesMod
                                                                     ! This need only be defined when
                                                                     ! hlm_use_inventory_init = 1
 
+   integer, public :: hlm_use_dbh_init                              ! Flag to use fates_recruit_init_dbh
+                                                                    ! instead of fates_recruit_init_density
+                                                                    ! only works in nocomp mode
+                                                                    !  1 = TRUE, 0 = FALSE 
+
   integer, public ::  hlm_use_fixed_biogeog                         !  Flag to use FATES fixed biogeography mode
                                                                     !  1 = TRUE, 0 = FALSE 
 

--- a/parameter_files/fates_params_default.json
+++ b/parameter_files/fates_params_default.json
@@ -1281,7 +1281,7 @@
       "dims": ["fates_pft"],
       "long_name": "initial seed pool - per m2 of associated pft-patch for no-comp, per m2 of whole site for non no-comp",
       "units": "kg/m2",
-      "data": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+      "data": [0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
     },
     "fates_recruit_prescribed_rate": {
       "dtype": "float",

--- a/parameter_files/fates_params_default.json
+++ b/parameter_files/fates_params_default.json
@@ -1281,7 +1281,7 @@
       "dims": ["fates_pft"],
       "long_name": "initial seed pool - per m2 of associated pft-patch for no-comp, per m2 of whole site for non no-comp",
       "units": "kg/m2",
-      "data": [0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
+      "data": [0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00]
     },
     "fates_recruit_prescribed_rate": {
       "dtype": "float",

--- a/parameter_files/fates_params_default.json
+++ b/parameter_files/fates_params_default.json
@@ -1265,9 +1265,16 @@
     "fates_recruit_init_density": {
       "dtype": "float",
       "dims": ["fates_pft"],
-      "long_name": "initial seedling density for a cold-start near-bare-ground simulation. If negative sets initial tree dbh - only to be used in nocomp mode",
+      "long_name": "initial seedling density for a cold-start near-bare-ground simulation.",
       "units": "stems/m2",
       "data": [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.16, 0.2, 0.2, 0.2, 0.2]
+    },
+    "fates_recruit_init_dbh": {
+      "dtype": "float",
+      "dims": ["fates_pft"],
+      "long_name": "initial seedling dbh for a cold-start near-bare-ground simulation. Can only to be used in nocomp mode. To use it set use_dbh_init to true",
+      "units": "cm",
+      "data": [ 1, 1, 1, 1, 1, 1, 0.5, 0.5, 0.5, 0.5, 0.5, 0.1, 0.1, 0.1]
     },
     "fates_recruit_init_seed": {
       "dtype": "float",

--- a/parameter_files/fates_params_default.json
+++ b/parameter_files/fates_params_default.json
@@ -1281,7 +1281,7 @@
       "dims": ["fates_pft"],
       "long_name": "initial seed pool - per m2 of associated pft-patch for no-comp, per m2 of whole site for non no-comp",
       "units": "kg/m2",
-      "data": [0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00, 0.00]
+      "data": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     },
     "fates_recruit_prescribed_rate": {
       "dtype": "float",

--- a/parameter_files/fates_params_default.json
+++ b/parameter_files/fates_params_default.json
@@ -1262,19 +1262,19 @@
       "units": "m",
       "data": [1.3, 1.3, 1.3, 1.3, 1.3, 1.3, 0.2, 0.2, 0.2, 0.8, 0.8, 0.11, 0.2, 0.2]
     },
-    "fates_recruit_init_density": {
-      "dtype": "float",
-      "dims": ["fates_pft"],
-      "long_name": "initial seedling density for a cold-start near-bare-ground simulation.",
-      "units": "stems/m2",
-      "data": [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.16, 0.2, 0.2, 0.2, 0.2]
-    },
     "fates_recruit_init_dbh": {
       "dtype": "float",
       "dims": ["fates_pft"],
       "long_name": "initial seedling dbh for a cold-start near-bare-ground simulation. Can only to be used in nocomp mode. To use it set use_dbh_init to true",
       "units": "cm",
       "data": [ 1, 1, 1, 1, 1, 1, 0.5, 0.5, 0.5, 0.5, 0.5, 0.1, 0.1, 0.1]
+    },
+    "fates_recruit_init_density": {
+      "dtype": "float",
+      "dims": ["fates_pft"],
+      "long_name": "initial seedling density for a cold-start near-bare-ground simulation.",
+      "units": "stems/m2",
+      "data": [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.16, 0.2, 0.2, 0.2, 0.2]
     },
     "fates_recruit_init_seed": {
       "dtype": "float",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

This enables FATES to use DBH to specify initial conditions for a cold-start run with full fates. This does so by making an equal area assumption of all cohorts.  Like with nocomp, it also assumes that plants on the patch fill up a single canopy layer.

Fixes: #1566

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

@jingtao-lbl @JessicaNeedham 

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

### Description of generative AI usage (as necessary)
<!--- Please briefly describe usage of generative AI, such as  -->
<!--- platform, AI model, workflow, testing, etc. -->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [ ] The in-code documentation has been updated with descriptive comments
- [ ] The documentation has been assessed to determine if updates are necessary
- [ ] Describe use of generative AI (if necessary)

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided
- [ ] FATES-CLM6 Code Freeze: satellite phenology regression tests are b4b

*If satellite phenology regressions are **not** b4b, please hold merge and notify the FATES development team.*

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

