### PR TITLE
update hydraulic conductivity scaling model

### DIFF
--- a/biogeophys/FatesPlantHydraulicsMod.F90
+++ b/biogeophys/FatesPlantHydraulicsMod.F90
@@ -4596,7 +4596,7 @@ end subroutine shellGeom
 
 ! =====================================================================================
 
-function xylemtaper(pexp, dz) result(chi_tapnotap)
+function xylemtaper_Savage(pexp, dz) result(chi_tapnotap)
 
     use FatesConstantsMod, only : pi => pi_const
 
@@ -4654,8 +4654,50 @@ function xylemtaper(pexp, dz) result(chi_tapnotap)
 
     return
 
-end function xylemtaper
+end function xylemtaper_Savage
+# =====================================================================================
+# xylem hydraulic conductance  following scaling for conduit width from Olson 2020 (https://nph.onlinelibrary.wiley.com/doi/10.1111/nph.16961)
+function xylemtaper(a, L) result(ratio)
 
+  implicit none
+
+  real(r8), intent(in) :: a      ! taper exponent
+  real(r8), intent(in) :: L      ! distance from branch tip (m)
+  real(r8) :: ratio
+
+  real(r8), parameter :: x0  = 0.005_r8  ! finite cutoff (m) at petiole, to prevent singularity in function at L=0.  
+  real(r8), parameter :: eps = 1.e-8_r8
+
+  real(r8) :: Leff
+  real(r8) :: expo
+  real(r8) :: denom
+
+  !------------------------------------------------------------
+  ! Enforce finite cutoff 
+  !------------------------------------------------------------
+  Leff = max(L, x0 * (1._r8 + eps))
+
+  !------------------------------------------------------------
+  ! No taper case
+  !------------------------------------------------------------
+  if (a <= 0._r8) then
+     ratio = 1._r8
+     return
+  end if
+
+  !------------------------------------------------------------
+  ! Critical case: a = 1/4
+  !------------------------------------------------------------
+  if (abs(a - 0.25_r8) < eps) then
+     ratio = (Leff - x0) / log(Leff / x0)
+  else
+     expo  = 1._r8 - 4._r8 * a
+     denom = Leff**expo - x0**expo
+
+     ratio = (Leff - x0) * expo / denom
+  end if
+
+end function xylemtaper
 ! =====================================================================================
 
 subroutine Hydraulics_Tridiagonal(a, b, c, r, u, ierr)

--- a/biogeophys/FatesPlantHydraulicsMod.F90
+++ b/biogeophys/FatesPlantHydraulicsMod.F90
@@ -4667,6 +4667,7 @@ function xylemtaper(a, L) result(ratio)
 
   real(r8), parameter :: x0  = 0.005_r8  ! finite cutoff (m) at petiole, to prevent singularity in function at L=0.  
   real(r8), parameter :: eps = 1.e-8_r8
+  real(r8), parameter :: xref = 0.6_r8    ! measurement distance from branch tip (m)
 
   real(r8) :: Leff
   real(r8) :: expo
@@ -4689,10 +4690,10 @@ function xylemtaper(a, L) result(ratio)
   ! Critical case: a = 1/4
   !------------------------------------------------------------
   if (abs(a - 0.25_r8) < eps) then
-     ratio = (Leff - x0) / log(Leff / x0)
+     ratio = (Leff - x0) / (xref * log(Leff / x0))
   else
      expo  = 1._r8 - 4._r8 * a
-     denom = Leff**expo - x0**expo
+     denom = xref**(4._r8 * a) * (Leff**expo - x0**expo)
 
      ratio = (Leff - x0) * expo / denom
   end if

--- a/biogeophys/FatesPlantHydraulicsMod.F90
+++ b/biogeophys/FatesPlantHydraulicsMod.F90
@@ -4655,8 +4655,8 @@ function xylemtaper_Savage(pexp, dz) result(chi_tapnotap)
     return
 
 end function xylemtaper_Savage
-# =====================================================================================
-# xylem hydraulic conductance  following scaling for conduit width from Olson 2020 (https://nph.onlinelibrary.wiley.com/doi/10.1111/nph.16961)
+! =====================================================================================
+! xylem hydraulic conductance  following scaling for conduit width from Olson 2020 (https://nph.onlinelibrary.wiley.com/doi/10.1111/nph.16961)
 function xylemtaper(a, L) result(ratio)
 
   implicit none

--- a/biogeophys/FatesPlantHydraulicsMod.F90
+++ b/biogeophys/FatesPlantHydraulicsMod.F90
@@ -4620,7 +4620,7 @@ function xylemtaper(pexp, dz) result(chi_tapnotap)
     !
     ! !LOCAL VARIABLES:
     real(r8) :: qexp                ! total conductance exponent (as in Fig. 2b of Savage et al. (2010) minus a0 term
-    real(r8) :: lN=0.005_r8         ! petiole length[m]
+    real(r8) :: lN=0.15_r8          ! petiole length[m], updated to match the scaling for conduit width from Olson 2020 (https://nph.onlinelibrary.wiley.com/doi/10.1111/nph.16961)
     real(r8) :: n_ext=2._r8         ! number of daughter branches per parent branch, assumed constant throughout tree (self-similarity)  [-]
     real(r8) :: big_n               ! number of branching levels (allowed here to take on non-integer values): increases with tree size  [-]
     real(r8) :: r0rN                ! ratio of stem radius to terminal twig radius; r.ext0/r.extN (x-axis of Savage et al. (2010) Fig 2a)[-]

--- a/parameter_files/fates_params_default.json
+++ b/parameter_files/fates_params_default.json
@@ -721,7 +721,7 @@
       "dims": ["fates_pft"],
       "long_name": "xylem taper exponent",
       "units": "unitless",
-      "data": [0.333, 0.333, 0.333, 0.333, 0.333, 0.333, 0.333, 0.333, 0.333, 0.333, 0.333, 0.333, 0.333, 0.333]
+      "data": [0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2]
     },
     "fates_hydro_pinot_node": {
       "dtype": "float",


### PR DESCRIPTION

[Taper improvement.pdf](https://github.com/user-attachments/files/27539508/Taper.improvement.pdf)
<!--- Provide a general summary of your changes in the Title above -->
This pull request update the petiole length parameter to match the scaling of conduit size from Olson 2020 (https://nph.onlinelibrary.wiley.com/doi/10.1111/nph.16961)
### Description:
The original scaling model has a much larger scaling of conduit size compared to the data from Olson 2020. To resolve this issue,  I have added a new taper function based on Olson 2020. Please see attached the derivation of the taper components. Our hydraulic model optimization showed that this version of the taper function should be much closer to observations. This could also resolve the issue of size distribution of water potential. By lowering the hydraulic conductivity for taller trees, it will give a higher water stress for larger size of tree and thus higher mortality.

### Collaborators:
@bchristo 
### Expectation of Answer Changes:
By change this values, we will see more reasonable scaling and make the model easier to fit to observed sapflow.

### Description of generative AI usage (as necessary)
No AI used.
### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [ x] The in-code documentation has been updated with descriptive comments
- [ ] The documentation has been assessed to determine if updates are necessary
- [ ] Describe use of generative AI (if necessary)

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided
- [ ] FATES-CLM6 Code Freeze: satellite phenology regression tests are b4b

*If satellite phenology regressions are **not** b4b, please hold merge and notify the FATES development team.*

### Documentation
No need to change to the documentation. 
### Test Results:
See attached figures of scaling with the impact of change. 

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*


<!--- paste in test results here -->



<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

