### PR TITLE
Initialize prescribed fire site-level variables

### DIFF
--- a/fire/SFMainMod.F90
+++ b/fire/SFMainMod.F90
@@ -220,6 +220,8 @@ contains
 
     ! initialize site parameters to zero
     currentSite%NF_successful = 0.0_r8
+    currentSite%rxfire_area_fi = 0.0_r8
+    currentSite%rxfire_area_fuel = 0.0_r8
 
     ! Equation 7 from Venevsky et al GCB 2002 (modification of equation 8 in Thonicke et al. 2010) 
     ! FDI 0.1 = low, 0.3 moderate, 0.75 high, and 1 = extreme ignition potential for alpha 0.000337


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Addresses issue #1470

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->
This initializes `rxfire_area_fi` and rxfire_area_fuel` which are currently uninitialized on the main branch.

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->
@samsrabin @XiulinGao @mvdebolskiy 

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->
None, should be B4B

### Description of generative AI usage (as necessary)
<!--- Please briefly describe usage of generative AI, such as  -->
<!--- platform, AI model, workflow, testing, etc. -->
No AI usage

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [x] The in-code documentation has been updated with descriptive comments
- [x] The documentation has been assessed to determine if updates are necessary
- [x] Describe use of generative AI (if necessary)

*Integrator*
- [x] FATES PASS/FAIL regression tests were run
- [x] Evaluation of test results for answer changes was performed and results provided
- [x] FATES-CLM6 Code Freeze: satellite phenology regression tests are b4b

*If satellite phenology regressions are **not** b4b, please hold merge and notify the FATES development team.*

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

`/glade/u/home/glemieux/scratch/ctsm-tests/tests_0605-094948de`
<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

