### PR TITLE
Add coarse root history vars

### DIFF
--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -231,6 +231,7 @@ module FatesHistoryInterfaceMod
   integer :: ih_leafc_si
   integer :: ih_sapwc_si
   integer :: ih_fnrtc_si
+  integer :: ih_crtc_si
   integer :: ih_fnrtc_sl
   integer :: ih_reproc_si
   integer :: ih_totvegc_si
@@ -603,6 +604,7 @@ module FatesHistoryInterfaceMod
   integer :: ih_resp_m_canopy_si_scls
   integer :: ih_leaf_md_canopy_si_scls
   integer :: ih_root_md_canopy_si_scls
+  integer :: ih_croot_md_canopy_si_scls
   integer :: ih_carbon_balance_canopy_si_scls
   integer :: ih_bstore_md_canopy_si_scls
   integer :: ih_bdead_md_canopy_si_scls
@@ -623,6 +625,7 @@ module FatesHistoryInterfaceMod
   integer :: ih_resp_m_understory_si_scls
   integer :: ih_leaf_md_understory_si_scls
   integer :: ih_root_md_understory_si_scls
+  integer :: ih_croot_md_understory_si_scls
   integer :: ih_carbon_balance_understory_si_scls
   integer :: ih_bsw_md_understory_si_scls
   integer :: ih_bdead_md_understory_si_scls
@@ -2425,6 +2428,7 @@ contains
     real(r8) :: struct_m           ! Structural mass ""
     real(r8) :: leaf_m             ! Leaf mass ""
     real(r8) :: fnrt_m             ! Fineroot mass ""
+    real(r8) :: crt_m              ! Coarse root mass ""
     real(r8) :: store_m            ! Storage mass ""
     real(r8) :: alive_m            ! Alive biomass (sap+leaf+fineroot+repro+storage) ""
     real(r8) :: total_m            ! Total vegetation mass
@@ -2825,6 +2829,7 @@ contains
                   call ccohort%prt%GetBiomass(element_list(el), &
                        sapw_m, struct_m, leaf_m, fnrt_m, store_m, repro_m, alive_m, total_m)
 
+                  
                   ! Plant multi-element states and fluxes
                   ! Zero states, and set the fluxes
                   if( element_list(el).eq.carbon12_element )then
@@ -2839,6 +2844,12 @@ contains
                      this%hvars(ih_fnrtc_si)%r81d(io_si) =                        &
                           this%hvars(ih_fnrtc_si)%r81d(io_si) + ccohort%n *         &
                           fnrt_m / m2_per_ha
+
+                     crt_m = (sapw_m + struct_m) *  prt_params%allom_agb_frac(ccohort%pft)
+
+                     this%hvars(ih_crtc_si)%r81d(io_si) =                        &
+                          this%hvars(ih_crtc_si)%r81d(io_si) + ccohort%n *         &
+                          crt_m / m2_per_ha
                      this%hvars(ih_reproc_si)%r81d(io_si) =                       &
                           this%hvars(ih_reproc_si)%r81d(io_si)+ ccohort%n *         &
                           repro_m / m2_per_ha
@@ -3146,6 +3157,7 @@ contains
     real(r8) :: store_m_turnover   ! storage turnover rate [kg/yr]
     real(r8) :: leaf_m_turnover    ! leaf turnover rate [kg/yr]
     real(r8) :: fnrt_m_turnover    ! fine-root turnover rate [kg/yr]
+    real(r8) :: crt_m_turnover     ! coarse-root turnover rate [kg/yr]
     real(r8) :: struct_m_turnover  ! structural turnover rate [kg/yr]
     real(r8) :: sapw_m_net_alloc   ! mass allocated to sapwood [kg/yr]
     real(r8) :: store_m_net_alloc  ! mass allocated to storage [kg/yr]
@@ -3315,6 +3327,7 @@ contains
            hio_crown_fracarea_understory_si_scls => this%hvars(ih_crown_fracarea_understory_si_scls)%r82d, &
            hio_leaf_md_canopy_si_scls           => this%hvars(ih_leaf_md_canopy_si_scls)%r82d, &
            hio_root_md_canopy_si_scls           => this%hvars(ih_root_md_canopy_si_scls)%r82d, &
+           hio_croot_md_canopy_si_scls           => this%hvars(ih_croot_md_canopy_si_scls)%r82d, &
            hio_carbon_balance_canopy_si_scls    => this%hvars(ih_carbon_balance_canopy_si_scls)%r82d, &
            hio_bsw_md_canopy_si_scls            => this%hvars(ih_bsw_md_canopy_si_scls)%r82d, &
            hio_bdead_md_canopy_si_scls          => this%hvars(ih_bdead_md_canopy_si_scls)%r82d, &
@@ -3328,6 +3341,7 @@ contains
            hio_npp_stor_canopy_si_scls         => this%hvars(ih_npp_stor_canopy_si_scls)%r82d, &
            hio_leaf_md_understory_si_scls       => this%hvars(ih_leaf_md_understory_si_scls)%r82d, &
            hio_root_md_understory_si_scls       => this%hvars(ih_root_md_understory_si_scls)%r82d, &
+           hio_croot_md_understory_si_scls       => this%hvars(ih_croot_md_understory_si_scls)%r82d, &
            hio_carbon_balance_understory_si_scls=> this%hvars(ih_carbon_balance_understory_si_scls)%r82d, &
            hio_bstore_md_understory_si_scls     => this%hvars(ih_bstore_md_understory_si_scls)%r82d, &
            hio_bsw_md_understory_si_scls        => this%hvars(ih_bsw_md_understory_si_scls)%r82d, &
@@ -3714,6 +3728,8 @@ contains
                       fnrt_m_turnover   = ccohort%prt%GetTurnover(fnrt_organ, carbon12_element) * days_per_year
                       struct_m_turnover = ccohort%prt%GetTurnover(struct_organ, carbon12_element) * days_per_year
 
+                      crt_m_turnover = (sapw_m_turnover + struct_m_turnover) * prt_params%allom_agb_frac(ccohort%pft)
+                      
                       ! Net change from allocation and transport [kgC/day] * [day/yr] = [kgC/yr]
                       sapw_m_net_alloc   = ccohort%prt%GetNetAlloc(sapw_organ, carbon12_element) * days_per_year
                       store_m_net_alloc  = ccohort%prt%GetNetAlloc(store_organ, carbon12_element) * days_per_year
@@ -4030,6 +4046,8 @@ contains
                                 leaf_m_turnover * ccohort%n / m2_per_ha / days_per_year / sec_per_day
                            hio_root_md_canopy_si_scls(io_si,scls) = hio_root_md_canopy_si_scls(io_si,scls) + &
                                 fnrt_m_turnover * ccohort%n / m2_per_ha / days_per_year / sec_per_day
+                           hio_croot_md_canopy_si_scls(io_si,scls) = hio_croot_md_canopy_si_scls(io_si,scls) + &
+                                crt_m_turnover * ccohort%n / m2_per_ha / days_per_year / sec_per_day
                            hio_bsw_md_canopy_si_scls(io_si,scls) = hio_bsw_md_canopy_si_scls(io_si,scls) + &
                                 sapw_m_turnover * ccohort%n / m2_per_ha / days_per_year / sec_per_day
                            hio_bstore_md_canopy_si_scls(io_si,scls) = hio_bstore_md_canopy_si_scls(io_si,scls) + &
@@ -4153,6 +4171,8 @@ contains
                                 leaf_m_turnover * ccohort%n / m2_per_ha / days_per_year / sec_per_day
                            hio_root_md_understory_si_scls(io_si,scls) = hio_root_md_understory_si_scls(io_si,scls) + &
                                 fnrt_m_turnover * ccohort%n / m2_per_ha / days_per_year / sec_per_day
+                           hio_croot_md_understory_si_scls(io_si,scls) = hio_croot_md_understory_si_scls(io_si,scls) + &
+                                crt_m_turnover * ccohort%n / m2_per_ha / days_per_year / sec_per_day
                            hio_bsw_md_understory_si_scls(io_si,scls) = hio_bsw_md_understory_si_scls(io_si,scls) + &
                                 sapw_m_turnover * ccohort%n / m2_per_ha / days_per_year / sec_per_day
                            hio_bstore_md_understory_si_scls(io_si,scls) = hio_bstore_md_understory_si_scls(io_si,scls) + &
@@ -6911,6 +6931,12 @@ contains
             upfreq=group_dyna_simple, ivar=ivar, initialize=initialize_variables,                 &
             index = ih_fnrtc_si)
 
+       call this%set_history_var(vname='FATES_CROOTC', units='kg m-2',            &
+            long='total biomass in live plant coarse roots in kg carbon per m2',    &
+            use_default='active', avgflag='A', vtype=site_r8, hlms='CLM:ALM',     &
+            upfreq=group_dyna_simple, ivar=ivar, initialize=initialize_variables,                 &
+            index = ih_crtc_si)
+
        call this%set_history_var(vname='FATES_REPROC', units='kg m-2',            &
             long='total biomass in live plant reproductive tissues in kg carbon per m2', &
             use_default='active', avgflag='A', vtype=site_r8, hlms='CLM:ALM',     &
@@ -8843,6 +8869,13 @@ contains
                hlms='CLM:ALM', upfreq=group_dyna_complx, ivar=ivar,                                 &
                initialize=initialize_variables, index = ih_root_md_canopy_si_scls)
 
+          call this%set_history_var(vname='FATES_CROOTCTURN_CANOPY_SZ',              &
+               units = 'kg m-2 s-1',                                                &
+               long='coarse root turnover (non-mortal) for canopy plants by size class in kg carbon per m2 per second', &
+               use_default='inactive', avgflag='A', vtype=site_size_r8,             &
+               hlms='CLM:ALM', upfreq=group_dyna_complx, ivar=ivar,                                 &
+               initialize=initialize_variables, index = ih_croot_md_canopy_si_scls)
+
           call this%set_history_var(vname='FATES_STORECTURN_CANOPY_SZ',              &
                units = 'kg m-2 s-1',                                                &
                long='storage turnover (non-mortal) for canopy plants by size class in kg carbon per m2 per second', &
@@ -8928,6 +8961,14 @@ contains
                hlms='CLM:ALM', upfreq=group_dyna_complx, ivar=ivar,                                 &
                initialize=initialize_variables,                                     &
                index = ih_root_md_understory_si_scls)
+
+          call this%set_history_var(vname='FATES_CROOTCTURN_USTORY_SZ',          &
+               units = 'kg m-2 s-1',                                                &
+               long='coarse root turnover (non-mortal) for understory plants by size class in kg carbon per m2 per second', &
+               use_default='inactive', avgflag='A', vtype=site_size_r8,             &
+               hlms='CLM:ALM', upfreq=group_dyna_complx, ivar=ivar,                                 &
+               initialize=initialize_variables,                                     &
+               index = ih_croot_md_understory_si_scls)
 
           call this%set_history_var(vname='FATES_STORECTURN_USTORY_SZ',              &
                units = 'kg m-2 s-1',                                                &

--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -2845,7 +2845,7 @@ contains
                           this%hvars(ih_fnrtc_si)%r81d(io_si) + ccohort%n *         &
                           fnrt_m / m2_per_ha
 
-                     crt_m = (sapw_m + struct_m) *  prt_params%allom_agb_frac(ccohort%pft)
+                     crt_m = (sapw_m + struct_m) *  (1.0_r8 - prt_params%allom_agb_frac(ccohort%pft))
 
                      this%hvars(ih_crtc_si)%r81d(io_si) =                        &
                           this%hvars(ih_crtc_si)%r81d(io_si) + ccohort%n *         &
@@ -3728,7 +3728,7 @@ contains
                       fnrt_m_turnover   = ccohort%prt%GetTurnover(fnrt_organ, carbon12_element) * days_per_year
                       struct_m_turnover = ccohort%prt%GetTurnover(struct_organ, carbon12_element) * days_per_year
 
-                      crt_m_turnover = (sapw_m_turnover + struct_m_turnover) * prt_params%allom_agb_frac(ccohort%pft)
+                      crt_m_turnover = (sapw_m_turnover + struct_m_turnover) * (1.0_r8 - prt_params%allom_agb_frac(ccohort%pft))
                       
                       ! Net change from allocation and transport [kgC/day] * [day/yr] = [kgC/yr]
                       sapw_m_net_alloc   = ccohort%prt%GetNetAlloc(sapw_organ, carbon12_element) * days_per_year


### PR DESCRIPTION
### Description:
For WIEMIP (and maybe other projects) we need to output carbon in roots and carbon flux from roots to litter. In FATES we don't output coarse root carbon or coarse root carbon turnover. Since aboveground biomass fraction can vary by PFT, the only  way to post-process these variables from sapwood and structural history variables is to output everything on PFT dimensions which is expensive. This PR adds these variables as FATES history variables. 


### Collaborators:
@rosiealice 

### Expectation of Answer Changes:
Not answer changing

### Description of generative AI usage (as necessary)
No AI used

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [ ] The in-code documentation has been updated with descriptive comments
- [ ] The documentation has been assessed to determine if updates are necessary
- [ ] Describe use of generative AI (if necessary)

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided
- [ ] FATES-CLM6 Code Freeze: satellite phenology regression tests are b4b

*If satellite phenology regressions are **not** b4b, please hold merge and notify the FATES development team.*

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:

Running a short 5 year test to look at outputs now.
Here's croot: 
<img width="735" height="374" alt="image" src="https://github.com/user-attachments/assets/521a5c45-42fa-4c9e-b63f-1ba7adeb54c9" />

And sapwood and structural carbon for comparison (different scales). Croot should be around 0.4 - 0.2 x the sum of these. 

<img width="749" height="374" alt="image" src="https://github.com/user-attachments/assets/4d6bd6f6-5e29-414a-8fab-bd9153f1dfbf" />

<img width="747" height="374" alt="image" src="https://github.com/user-attachments/assets/e9caa6af-6c99-47d6-bca1-9cff8e4c8e25" />

