### PR TITLE
Fix bugs in the Tree Recruitment Scheme with seedling dynamics

### DIFF
--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -2340,12 +2340,11 @@ contains
           
           ! Step 3. Sum modes of mortality (including background mortality) and send dead seedlings
           ! to litter        
-          ! Cap total mortality rate at 1 to prevent negative seed pool 
-           litt%seed_germ_decay(pft) = litt%seed_germ(pft) * &
-               min(1.0_r8, seedling_light_mort_rate + &
-                           seedling_h2o_mort_rate + &
-                           (EDPftvarcon_inst%background_seedling_mort(pft) * &
-                           years_per_day))
+          ! Cap total mortality rate at 1 to prevent negative seedling pool
+          litt%seed_germ_decay(pft) = litt%seed_germ(pft) * &
+            min(1.0_r8, seedling_light_mort_rate + &
+                        seedling_h2o_mort_rate + &
+                        (EDPftvarcon_inst%background_seedling_mort(pft) * years_per_day))
 
        else
           
@@ -2449,10 +2448,11 @@ contains
 
           ! If SMP is below a pft-specific value, then no germination occurs
           if ( seedling_layer_smp .GE. EDPftvarcon_inst%seedling_psi_emerg(pft) ) then
+             seedling_emerg_rate = photoblastic_germ_modifier * EDPftvarcon_inst%a_emerg(pft) * &
+                  wetness_index**EDPftvarcon_inst%b_emerg(pft)
              ! Cap emergence rate at 1, rate can exceed 1 for some parameter combinations,
              ! leading to negative seed bank
-             seedling_emerg_rate = min(1.0_r8, photoblastic_germ_modifier * EDPftvarcon_inst%a_emerg(pft) * &
-                  wetness_index**EDPftvarcon_inst%b_emerg(pft))
+             seedling_emerg_rate = min(1.0_r8, seedling_emerg_rate )
           else 
 
              seedling_emerg_rate = 0.0_r8
@@ -2683,7 +2683,7 @@ contains
                      mass_avail = currentPatch%area*                           &
                         currentPatch%litter(el)%seed_germ(ft)*                 & 
                         EDPftvarcon_inst%seedling_light_rec_a(ft)*             &
-                        sdlng2sap_par**EDPftvarcon_inst%seedling_light_rec_b(ft) 
+                        sdlng2sap_par**EDPftvarcon_inst%seedling_light_rec_b(ft)
                      
                      ! If soil moisture is below pft-specific seedling  moisture stress threshold the 
                      ! recruitment does not occur.

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -541,6 +541,7 @@ contains
     integer :: nlevsoil    ! number of soil layers
     integer :: ilyr        ! soil layer loop counter
     integer :: dcmpy       ! decomposability index
+    real(r8) :: net_seed_available  ! Available seed after inputs and decay
 
     do el = 1, num_elements
 
@@ -550,30 +551,42 @@ contains
        ! -----------------------------------------------------------------------------------
 
        do pft = 1,numpft
-          litt%seed(pft) = litt%seed(pft) + &
-               litt%seed_in_local(pft) +   &
-               litt%seed_in_extern(pft) -  &
-               litt%seed_decay(pft) -      &
-               litt%seed_germ_in(pft)
 
-          ! Note that the recruitment scheme will use seed_germ
-          ! for its construction costs.
-          litt%seed_germ(pft) = litt%seed_germ(pft) + &
+         ! Calculate net available seed after inputs and decay
+         net_seed_available = litt%seed(pft) + litt%seed_in_local(pft) + &
+            litt%seed_in_extern(pft) - litt%seed_decay(pft)
+
+         ! Cap germination at available seed
+         litt%seed_germ_in(pft) = min(litt%seed_germ_in(pft), net_seed_available)
+
+         ! RW - commenting out for reference
+         ! litt%seed(pft) = litt%seed(pft) + &
+         !      litt%seed_in_local(pft) +   &
+         !      litt%seed_in_extern(pft) -  &
+         !      litt%seed_decay(pft) -      &
+         !      litt%seed_germ_in(pft)
+
+         ! Update pools 
+         litt%seed(pft) = net_seed_available - litt%seed_germ_in(pft)
+
+         ! Note that the recruitment scheme will use seed_germ
+         ! for its construction costs.
+         litt%seed_germ(pft) = litt%seed_germ(pft) + &
                litt%seed_germ_in(pft) - &
                litt%seed_germ_decay(pft)
 
-          ! RW BEBUG BLOCK START 
-            write(fates_log(),*) '=== PreDisturbanceIntegrateLitter DIAGNOSTICS ==='
-            write(fates_log(),*) 'Model Day:', hlm_model_day
-            write(fates_log(),*) 'PFT:', pft
-            write(fates_log(),*) 'seed_germ (before update):', litt%seed_germ(pft) - litt%seed_germ_in(pft) + &
+         ! RW DEBUG BLOCK START 
+         write(fates_log(),*) '=== PreDisturbanceIntegrateLitter DIAGNOSTICS ==='
+         write(fates_log(),*) 'Model Day:', hlm_model_day
+         write(fates_log(),*) 'PFT:', pft
+         write(fates_log(),*) 'seed_germ (before update):', litt%seed_germ(pft) - litt%seed_germ_in(pft) + &
             litt%seed_germ_decay(pft)
-            write(fates_log(),*) 'seed_germ_in:', litt%seed_germ_in(pft)
-            write(fates_log(),*) 'seed_germ_decay:', litt%seed_germ_decay(pft)
-            write(fates_log(),*) 'seed_germ (after update):', litt%seed_germ(pft)
-            write(fates_log(),*) 'Net change:', litt%seed_germ_in(pft) - litt%seed_germ_decay(pft)
-            write(fates_log(),*) 'Decay exceeds pool?:', litt%seed_germ(pft) < 0.0_r8
-          ! RW DEBUG BLOCK END 
+         write(fates_log(),*) 'seed_germ_in:', litt%seed_germ_in(pft)
+         write(fates_log(),*) 'seed_germ_decay:', litt%seed_germ_decay(pft)
+         write(fates_log(),*) 'seed_germ (after update):', litt%seed_germ(pft)
+         write(fates_log(),*) 'Net change:', litt%seed_germ_in(pft) - litt%seed_germ_decay(pft)
+         write(fates_log(),*) 'Decay exceeds pool?:', litt%seed_germ(pft) < 0.0_r8
+         ! RW DEBUG BLOCK END 
 
        enddo
 
@@ -2469,9 +2482,10 @@ contains
           ! rate modifier (Step 1). See Eq. 4 of Hanbury-Brown et al., 2022
 
           ! If SMP is below a pft-specific value, then no germination occurs
+          ! RW - cap emerg rate at 1
           if ( seedling_layer_smp .GE. EDPftvarcon_inst%seedling_psi_emerg(pft) ) then
-             seedling_emerg_rate = photoblastic_germ_modifier * EDPftvarcon_inst%a_emerg(pft) * &
-                  wetness_index**EDPftvarcon_inst%b_emerg(pft)
+             seedling_emerg_rate = min(1.0_r8, photoblastic_germ_modifier * EDPftvarcon_inst%a_emerg(pft) * &
+                  wetness_index**EDPftvarcon_inst%b_emerg(pft))
           else 
 
              seedling_emerg_rate = 0.0_r8

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -2349,7 +2349,7 @@ contains
             write(fates_log(),*) 'Seed germ pool:', litt%seed_germ(pft)
             write(fates_log(),*) 'Seed germ decay:',litt%seed_germ_decay(pft)
           ! DEBUG BLOCK END
-          
+
        else
           
           litt%seed_germ_decay(pft) = litt%seed_germ(pft) * &
@@ -2691,7 +2691,7 @@ contains
                         write(fates_log(),*) 'Model day:', hlm_model_day
                         write(fates_log(),*) 'PFT:', ft
                         write(fates_log(),*) 'Element:', element_id
-                        write(fates_log(),*) 'sdlng2sap_par (raw GetMean):', currentPatch%sdlng2sap_par%GetMean()
+                        write(fates_log(),*) 'sdlng2sap_par (raw):', currentPatch%sdlng2sap_par%GetMean()
                         write(fates_log(),*) 'sdlng2sap_par (converted):', sdlng2sap_par
                         write(fates_log(),*) 'seed_germ before calc:', currentPatch%litter(el)%seed_germ(ft)
                         write(fates_log(),*) 'seedling_light_rec_a:', EDPftvarcon_inst%seedling_light_rec_a(ft)

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -2335,7 +2335,21 @@ contains
                (litt%seed_germ(pft) * seedling_h2o_mort_rate) + &
                (litt%seed_germ(pft) * EDPftvarcon_inst%background_seedling_mort(pft) &
                * years_per_day)
-       
+
+          ! DEBUG BLOCK START 
+            write(fates_log(),*) '===DEBUG SEED DECAY===='
+            write(fates_log(),*) 'Model Day = ', hlm_model_day
+            write(fates_log(),*) 'PFT:', pft, 
+            write(fates_log(),*) 'Seedling par (raw):', currentPatch%sdlng_mort_par%GetMean()
+            write(fates_log(),*) 'Seedling par (converted):', seedling_layer_par
+            write(fates_log(),*) 'Seedling light mort rate:', seedling_light_mort_rate
+            write(fates_log(),*) 'Seedling mdds:', seedling_light_mort_rate     
+            write(fates_log(),*) 'Seedling mdd crit:', EDPftvarcon_inst%seedling_mdd_crit(pft) 
+            write(fates_log(),*) 'Seedling h2o mort rate:', seedling_h2o_mort_rate      
+            write(fates_log(),*) 'Seed germ pool:', litt%seed_germ(pft)
+            write(fates_log(),*) 'Seed germ decay:',litt%seed_germ_decay(pft)
+          ! DEBUG BLOCK END
+          
        else
           
           litt%seed_germ_decay(pft) = litt%seed_germ(pft) * &
@@ -2672,6 +2686,19 @@ contains
                         EDPftvarcon_inst%seedling_light_rec_a(ft)*             &
                         sdlng2sap_par**EDPftvarcon_inst%seedling_light_rec_b(ft) 
 
+                      ! DEBUG BLOCK START
+                        write(fates_log(),*) '=== DEBUG RECRUITMENT TRS ==='
+                        write(fates_log(),*) 'Model day:', hlm_model_day
+                        write(fates_log(),*) 'PFT:', ft
+                        write(fates_log(),*) 'Element:', element_id
+                        write(fates_log(),*) 'sdlng2sap_par (raw GetMean):', currentPatch%sdlng2sap_par%GetMean()
+                        write(fates_log(),*) 'sdlng2sap_par (converted):', sdlng2sap_par
+                        write(fates_log(),*) 'seed_germ before calc:', currentPatch%litter(el)%seed_germ(ft)
+                        write(fates_log(),*) 'seedling_light_rec_a:', EDPftvarcon_inst%seedling_light_rec_a(ft)
+                        write(fates_log(),*) 'seedling_light_rec_b:', EDPftvarcon_inst%seedling_light_rec_b(ft)
+                        write(fates_log(),*) 'currentPatch%area:', currentPatch%area
+                      ! DEBUG BLOCK END
+                     
                      ! If soil moisture is below pft-specific seedling  moisture stress threshold the 
                      ! recruitment does not occur.
                      ilayer_seedling_root = minloc(abs(bc_in%z_sisl(:) -       &
@@ -2682,6 +2709,13 @@ contains
                      if (seedling_layer_smp < EDPftvarcon_inst%seedling_psi_crit(ft)) then
                         mass_avail = 0.0_r8
                      end if 
+
+                     ! DEBUG BLOCK START
+                     write(fates_log(),*) 'ilayer_seedling_root', ilayer_seedling_root
+                     write(fates_log(),*) 'seedling_layer_smp', seedling_layer_smp
+                     write(fates_log(),*) 'seedling_psi_crit', EDPftvarcon_inst%seedling_psi_crit(ft)
+                     write(fates_log(),*) 'mass_avail after calc:', mass_avail
+                     ! DEBUG BLOCK END
 
                   end if ! End use TRS with seedling dynamics
 

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -2353,31 +2353,42 @@ contains
              seedling_h2o_mort_rate = EDPftvarcon_inst%seedling_h2o_mort_a(pft) * seedling_mdds**2 + &
                   EDPftvarcon_inst%seedling_h2o_mort_b(pft) * seedling_mdds + &
                   EDPftvarcon_inst%seedling_h2o_mort_c(pft)
+             ! RW: capping h20 mortality rate at 1
+             seedling_h2o_mort_rate = min(1.0_r8, seedling_h2o_mort_rate)
           end if ! mdd threshold check
           
           ! Step 3. Sum modes of mortality (including background mortality) and send dead seedlings
           ! to litter        
-          litt%seed_germ_decay(pft) = (litt%seed_germ(pft) * seedling_light_mort_rate) + &
-               (litt%seed_germ(pft) * seedling_h2o_mort_rate) + &
-               (litt%seed_germ(pft) * EDPftvarcon_inst%background_seedling_mort(pft) &
-               * years_per_day)
+          ! litt%seed_germ_decay(pft) = (litt%seed_germ(pft) * seedling_light_mort_rate) + &
+          !     (litt%seed_germ(pft) * seedling_h2o_mort_rate) + &
+          !     (litt%seed_germ(pft) * EDPftvarcon_inst%background_seedling_mort(pft) &
+          !     * years_per_day)
+
+          ! RW: capping total mortality rate at 1
+           litt%seed_germ_decay(pft) = litt%seed_germ(pft) * &
+               min(1.0_r8, seedling_light_mort_rate + &
+                           seedling_h2o_mort_rate + &
+                           (EDPftvarcon_inst%background_seedling_mort(pft) * &
+                           years_per_day))
+           
+
 
           ! RW DEBUG BLOCK START 
-          !  write(fates_log(),*) '===SEED DECAY DIADNOSTICS===='
-          !  write(fates_log(),*) 'Model Day = ', hlm_model_day
-          !  write(fates_log(),*) 'PFT:', pft 
-          !  write(fates_log(),*) 'Seedling par (raw):', currentPatch%sdlng_mort_par%GetMean()
-          !  write(fates_log(),*) 'Seedling par (converted):', seedling_layer_par
-          !  write(fates_log(),*) 'Seedling mdds:', currentPatch%sdlng_mdd(pft)%p%GetMean()     
-          !  write(fates_log(),*) 'Seedling mdd crit:', EDPftvarcon_inst%seedling_mdd_crit(pft) 
-          !  write(fates_log(),*) 'Seedling light mort rate:', seedling_light_mort_rate
-          !  write(fates_log(),*) 'Seedling h2o mort rate:', seedling_h2o_mort_rate
-          !  write(fates_log(),*) 'Seed_germ pool (before decay):', litt%seed_germ(pft)
-          !  write(fates_log(),*) 'Seed_germ_decay (calculated):', litt%seed_germ_decay(pft)            
-          !  write(fates_log(),*) 'Background_seedling_mort:', EDPftvarcon_inst%background_seedling_mort(pft) * years_per_day
-          !  write(fates_log(),*) 'Total mort rate:', seedling_light_mort_rate + seedling_h2o_mort_rate + &
-          !     (EDPftvarcon_inst%background_seedling_mort(pft) * years_per_day)
-          !  write(fates_log(),*) 'Does seed decay exceeds pool?:', litt%seed_germ_decay(pft) > litt%seed_germ(pft)
+            write(fates_log(),*) '===SEED DECAY DIADNOSTICS===='
+            write(fates_log(),*) 'Model Day = ', hlm_model_day
+            write(fates_log(),*) 'PFT:', pft 
+            write(fates_log(),*) 'Seedling par (raw):', currentPatch%sdlng_mort_par%GetMean()
+            write(fates_log(),*) 'Seedling par (converted):', seedling_layer_par
+            write(fates_log(),*) 'Seedling mdds:', currentPatch%sdlng_mdd(pft)%p%GetMean()     
+            write(fates_log(),*) 'Seedling mdd crit:', EDPftvarcon_inst%seedling_mdd_crit(pft) 
+            write(fates_log(),*) 'Seedling light mort rate:', seedling_light_mort_rate
+            write(fates_log(),*) 'Seedling h2o mort rate:', seedling_h2o_mort_rate
+            write(fates_log(),*) 'Seed_germ pool (before decay):', litt%seed_germ(pft)
+            write(fates_log(),*) 'Seed_germ_decay (calculated):', litt%seed_germ_decay(pft)            
+            write(fates_log(),*) 'Background_seedling_mort:', EDPftvarcon_inst%background_seedling_mort(pft) * years_per_day
+            write(fates_log(),*) 'Total mort rate:', seedling_light_mort_rate + seedling_h2o_mort_rate + &
+               (EDPftvarcon_inst%background_seedling_mort(pft) * years_per_day)
+            write(fates_log(),*) 'Does seed decay exceeds pool?:', litt%seed_germ_decay(pft) > litt%seed_germ(pft)
          ! RW DEBUG BLOCK END
 
 

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -576,16 +576,16 @@ contains
                litt%seed_germ_decay(pft)
 
          ! RW DEBUG BLOCK START 
-         write(fates_log(),*) '=== PreDisturbanceIntegrateLitter DIAGNOSTICS ==='
-         write(fates_log(),*) 'Model Day:', hlm_model_day
-         write(fates_log(),*) 'PFT:', pft
-         write(fates_log(),*) 'seed_germ (before update):', litt%seed_germ(pft) - litt%seed_germ_in(pft) + &
-            litt%seed_germ_decay(pft)
-         write(fates_log(),*) 'seed_germ_in:', litt%seed_germ_in(pft)
-         write(fates_log(),*) 'seed_germ_decay:', litt%seed_germ_decay(pft)
-         write(fates_log(),*) 'seed_germ (after update):', litt%seed_germ(pft)
-         write(fates_log(),*) 'Net change:', litt%seed_germ_in(pft) - litt%seed_germ_decay(pft)
-         write(fates_log(),*) 'Decay exceeds pool?:', litt%seed_germ(pft) < 0.0_r8
+         ! write(fates_log(),*) '=== PreDisturbanceIntegrateLitter DIAGNOSTICS ==='
+         ! write(fates_log(),*) 'Model Day:', hlm_model_day
+         ! write(fates_log(),*) 'PFT:', pft
+         ! write(fates_log(),*) 'seed_germ (before update):', litt%seed_germ(pft) - litt%seed_germ_in(pft) + &
+         !   litt%seed_germ_decay(pft)
+         ! write(fates_log(),*) 'seed_germ_in:', litt%seed_germ_in(pft)
+         !write(fates_log(),*) 'seed_germ_decay:', litt%seed_germ_decay(pft)
+         ! write(fates_log(),*) 'seed_germ (after update):', litt%seed_germ(pft)
+         ! write(fates_log(),*) 'Net change:', litt%seed_germ_in(pft) - litt%seed_germ_decay(pft)
+         ! write(fates_log(),*) 'Decay exceeds pool?:', litt%seed_germ(pft) < 0.0_r8
          ! RW DEBUG BLOCK END 
 
        enddo
@@ -2363,21 +2363,21 @@ contains
                * years_per_day)
 
           ! RW DEBUG BLOCK START 
-            write(fates_log(),*) '===SEED DECAY DIADNOSTICS===='
-            write(fates_log(),*) 'Model Day = ', hlm_model_day
-            write(fates_log(),*) 'PFT:', pft 
-            write(fates_log(),*) 'Seedling par (raw):', currentPatch%sdlng_mort_par%GetMean()
-            write(fates_log(),*) 'Seedling par (converted):', seedling_layer_par
-            write(fates_log(),*) 'Seedling mdds:', currentPatch%sdlng_mdd(pft)%p%GetMean()     
-            write(fates_log(),*) 'Seedling mdd crit:', EDPftvarcon_inst%seedling_mdd_crit(pft) 
-            write(fates_log(),*) 'Seedling light mort rate:', seedling_light_mort_rate
-            write(fates_log(),*) 'Seedling h2o mort rate:', seedling_h2o_mort_rate
-            write(fates_log(),*) 'Seed_germ pool (before decay):', litt%seed_germ(pft)
-            write(fates_log(),*) 'Seed_germ_decay (calculated):', litt%seed_germ_decay(pft)            
-            write(fates_log(),*) 'Background_seedling_mort:', EDPftvarcon_inst%background_seedling_mort(pft) * years_per_day
-            write(fates_log(),*) 'Total mort rate:', seedling_light_mort_rate + seedling_h2o_mort_rate + &
-               (EDPftvarcon_inst%background_seedling_mort(pft) * years_per_day)
-            write(fates_log(),*) 'Does seed decay exceeds pool?:', litt%seed_germ_decay(pft) > litt%seed_germ(pft)
+          !  write(fates_log(),*) '===SEED DECAY DIADNOSTICS===='
+          !  write(fates_log(),*) 'Model Day = ', hlm_model_day
+          !  write(fates_log(),*) 'PFT:', pft 
+          !  write(fates_log(),*) 'Seedling par (raw):', currentPatch%sdlng_mort_par%GetMean()
+          !  write(fates_log(),*) 'Seedling par (converted):', seedling_layer_par
+          !  write(fates_log(),*) 'Seedling mdds:', currentPatch%sdlng_mdd(pft)%p%GetMean()     
+          !  write(fates_log(),*) 'Seedling mdd crit:', EDPftvarcon_inst%seedling_mdd_crit(pft) 
+          !  write(fates_log(),*) 'Seedling light mort rate:', seedling_light_mort_rate
+          !  write(fates_log(),*) 'Seedling h2o mort rate:', seedling_h2o_mort_rate
+          !  write(fates_log(),*) 'Seed_germ pool (before decay):', litt%seed_germ(pft)
+          !  write(fates_log(),*) 'Seed_germ_decay (calculated):', litt%seed_germ_decay(pft)            
+          !  write(fates_log(),*) 'Background_seedling_mort:', EDPftvarcon_inst%background_seedling_mort(pft) * years_per_day
+          !  write(fates_log(),*) 'Total mort rate:', seedling_light_mort_rate + seedling_h2o_mort_rate + &
+          !     (EDPftvarcon_inst%background_seedling_mort(pft) * years_per_day)
+          !  write(fates_log(),*) 'Does seed decay exceeds pool?:', litt%seed_germ_decay(pft) > litt%seed_germ(pft)
          ! RW DEBUG BLOCK END
 
 
@@ -2856,14 +2856,14 @@ contains
                      (m_struct + m_leaf + m_fnrt + m_sapw + m_store + m_repro)
                      
                    ! RW DEBUG BLOCK START 
-                     write(fates_log(),*) '=== recruitment remove mass DIAGNOSTICS ==='
-                     write(fates_log(),*) 'cohort_n:', cohort_n
-                     write(fates_log(),*) 'currentPatch%area:', currentPatch%area
-                     write(fates_log(),*) 'cohort_n / area:', cohort_n / currentPatch%area
-                     write(fates_log(),*) 'm demand', (m_struct + m_leaf + m_fnrt + m_sapw + m_store + m_repro)
-                     write(fates_log(),*) 'm removed from seed_germ', cohort_n / currentPatch%area *   &
-                     (m_struct + m_leaf + m_fnrt + m_sapw + m_store + m_repro)
-                     write(fates_log(),*) 'Is seed_germ negative?:', currentPatch%litter(el)%seed_germ(ft) < 0.0_r8
+                   !  write(fates_log(),*) '=== recruitment remove mass DIAGNOSTICS ==='
+                   !  write(fates_log(),*) 'cohort_n:', cohort_n
+                   !  write(fates_log(),*) 'currentPatch%area:', currentPatch%area
+                   !  write(fates_log(),*) 'cohort_n / area:', cohort_n / currentPatch%area
+                   !  write(fates_log(),*) 'm demand', (m_struct + m_leaf + m_fnrt + m_sapw + m_store + m_repro)
+                   !  write(fates_log(),*) 'm removed from seed_germ', cohort_n / currentPatch%area *   &
+                   !  (m_struct + m_leaf + m_fnrt + m_sapw + m_store + m_repro)
+                   !  write(fates_log(),*) 'Is seed_germ negative?:', currentPatch%litter(el)%seed_germ(ft) < 0.0_r8
                    ! RW DEBUG BLOCK END 
 
                   end if

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -2682,8 +2682,8 @@ contains
 
                      mass_avail = currentPatch%area*                           &
                         currentPatch%litter(el)%seed_germ(ft)*                 & 
-                        EDPftvarcon_inst%seedling_light_rec_a(ft)*             &
-                        sdlng2sap_par**EDPftvarcon_inst%seedling_light_rec_b(ft)
+                        min(1.0_r8, EDPftvarcon_inst%seedling_light_rec_a(ft)*             &
+                        sdlng2sap_par**EDPftvarcon_inst%seedling_light_rec_b(ft))
                      
                      ! If soil moisture is below pft-specific seedling  moisture stress threshold the 
                      ! recruitment does not occur.

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -2259,6 +2259,7 @@ contains
     real(r8) ::  seedling_light_mort_rate    ! daily seedling mortality rate from light stress
     real(r8) ::  seedling_h2o_mort_rate      ! daily seedling mortality rate from moisture stress
     real(r8) ::  seedling_mdds               ! moisture deficit days accumulated in the seedling layer
+    real(r8) ::  total_seedling_mort_rate    ! summed seedling mortality rates
    
     !----------------------------------------------------------------------
 
@@ -2327,6 +2328,7 @@ contains
           
           ! Calculate seedling mortality as a function of moisture deficit days (mdd)
           ! If the seedling mmd value is below a critical threshold then moisture-based mortality is zero
+          
           if (seedling_mdds < EDPftvarcon_inst%seedling_mdd_crit(pft)) then
              seedling_h2o_mort_rate = 0.0_r8
           else
@@ -2334,17 +2336,29 @@ contains
                   EDPftvarcon_inst%seedling_h2o_mort_b(pft) * seedling_mdds + &
                   EDPftvarcon_inst%seedling_h2o_mort_c(pft)
              ! Cap h2o mortality rate at 1, quadratic can produce values >1 for large moisture
-             ! deficit days 
+             ! deficit days, if rate exceeds 1 write to fates log 
+
+             if (seedling_h2o_mort_rate > 1.0_r8) then
+               write(fates_log(), *) 'TRS seedling_h2o_mort_rate > 1', &
+                     'pft=', pft, 'uncapped=', seedling_h2o_mort_rate, 'mdds=', seedling_mdds
+             end if 
              seedling_h2o_mort_rate = min(1.0_r8, seedling_h2o_mort_rate)
           end if ! mdd threshold check
           
           ! Step 3. Sum modes of mortality (including background mortality) and send dead seedlings
           ! to litter        
           ! Cap total mortality rate at 1 to prevent negative seedling pool
-          litt%seed_germ_decay(pft) = litt%seed_germ(pft) * &
-            min(1.0_r8, seedling_light_mort_rate + &
+          total_seedling_mort_rate = seedling_light_mort_rate + &
                         seedling_h2o_mort_rate + &
-                        (EDPftvarcon_inst%background_seedling_mort(pft) * years_per_day))
+                        (EDPftvarcon_inst%background_seedling_mort(pft) * years_per_day)
+          if (total_seedling_mort_rate > 1.0_r8) then 
+            write(fates_log(), *) 'TRS total seedling mortatliy rate > 1', &
+                  'pft=', pft, 'uncapped=', total_seedling_mort_rate, &
+                  'seedling_light_mort_rate=', seedling_light_mort_rate, & 
+                  'seedling_h2o_mort_rate=', seedling_h2o_mort_rate
+          end if
+          litt%seed_germ_decay(pft) = litt%seed_germ(pft) * &
+            min(1.0_r8, total_seedling_mort_rate)
 
        else
           
@@ -2451,7 +2465,13 @@ contains
              seedling_emerg_rate = photoblastic_germ_modifier * EDPftvarcon_inst%a_emerg(pft) * &
                   wetness_index**EDPftvarcon_inst%b_emerg(pft)
              ! Cap emergence rate at 1, rate can exceed 1 for some parameter combinations,
-             ! leading to negative seed bank
+             ! leading to negative seed bank, write to log if this is the case 
+             if (seedling_emerg_rate > 1.0_r8) then
+               write(fates_log(),*) 'TRS seedling_emerg_rate > 1' &
+                     'pft=', pft, 'uncapped=', seedling_emerg_rate, &
+                     'photoblastic_germ_modifier=', photoblastic_germ_modifier, &
+                     'wetness_index=', wetness_index
+             end if 
              seedling_emerg_rate = min(1.0_r8, seedling_emerg_rate )
           else 
 
@@ -2535,6 +2555,7 @@ contains
       real(r8)                          :: stem_drop_fraction ! 
       real(r8)                          :: fnrt_drop_fraction ! 
       real(r8)                          :: sdlng2sap_par      ! running mean of PAR at the seedling layer [MJ/m2/day]
+      real(r8)                          :: sdlng2sap_rate     ! seedling-to-sapling transition rate factor (unitless)
       real(r8)                          :: seedling_layer_smp ! soil matric potential at seedling rooting depth [mm H2O suction]
       integer, parameter                :: recruitstatus = 1  ! whether the newly created cohorts are recruited or initialized
       integer                           :: ilayer_seedling_root ! the soil layer at seedling rooting depth
@@ -2680,10 +2701,21 @@ contains
                      sdlng2sap_par = currentPatch%sdlng2sap_par%GetMean()*     &
                         sec_per_day*megajoules_per_joule
 
+                     sdlng2sap_rate = EDPftvarcon_inst%seedling_light_rec_a(ft)*             &
+                        sdlng2sap_par**EDPftvarcon_inst%seedling_light_rec_b(ft)
+
+                     ! If the seedling to sapling transition rate exceeds 1, 
+                     ! cap at 1 (prevent seed_germ from going negative) and write to fates log 
+
+                     if (sdlng2sap_rate > 1.0_r8) then
+                        write(fates_log(), *) 'TRS seedling-to-sapling transition rate > 1' &
+                              'pft=', ft, 'uncapped=', sdlng2sap_rate, 
+                              'sdlng2sap_par=', sdlng2sap_par
+                     end if 
+                      
                      mass_avail = currentPatch%area*                           &
                         currentPatch%litter(el)%seed_germ(ft)*                 & 
-                        min(1.0_r8, EDPftvarcon_inst%seedling_light_rec_a(ft)*             &
-                        sdlng2sap_par**EDPftvarcon_inst%seedling_light_rec_b(ft))
+                        min(1.0_r8, sdlng2sap_rate)
                      
                      ! If soil moisture is below pft-specific seedling  moisture stress threshold the 
                      ! recruitment does not occur.

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -2339,7 +2339,7 @@ contains
           ! DEBUG BLOCK START 
             write(fates_log(),*) '===DEBUG SEED DECAY===='
             write(fates_log(),*) 'Model Day = ', hlm_model_day
-            write(fates_log(),*) 'PFT:', pft, 
+            write(fates_log(),*) 'PFT:', pft 
             write(fates_log(),*) 'Seedling par (raw):', currentPatch%sdlng_mort_par%GetMean()
             write(fates_log(),*) 'Seedling par (converted):', seedling_layer_par
             write(fates_log(),*) 'Seedling light mort rate:', seedling_light_mort_rate

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -2352,7 +2352,7 @@ contains
                         seedling_h2o_mort_rate + &
                         (EDPftvarcon_inst%background_seedling_mort(pft) * years_per_day)
           if (total_seedling_mort_rate > 1.0_r8) then 
-            write(fates_log(), *) 'TRS total seedling mortatliy rate > 1', &
+            write(fates_log(), *) 'TRS total seedling mortality rate > 1', &
                   'pft=', pft, 'uncapped=', total_seedling_mort_rate, &
                   'seedling_light_mort_rate=', seedling_light_mort_rate, & 
                   'seedling_h2o_mort_rate=', seedling_h2o_mort_rate
@@ -2467,7 +2467,7 @@ contains
              ! Cap emergence rate at 1, rate can exceed 1 for some parameter combinations,
              ! leading to negative seed bank, write to log if this is the case 
              if (seedling_emerg_rate > 1.0_r8) then
-               write(fates_log(),*) 'TRS seedling_emerg_rate > 1' &
+               write(fates_log(),*) 'TRS seedling_emerg_rate > 1', &
                      'pft=', pft, 'uncapped=', seedling_emerg_rate, &
                      'photoblastic_germ_modifier=', photoblastic_germ_modifier, &
                      'wetness_index=', wetness_index
@@ -2708,11 +2708,11 @@ contains
                      ! cap at 1 (prevent seed_germ from going negative) and write to fates log 
 
                      if (sdlng2sap_rate > 1.0_r8) then
-                        write(fates_log(), *) 'TRS seedling-to-sapling transition rate > 1' &
-                              'pft=', ft, 'uncapped=', sdlng2sap_rate, 
+                        write(fates_log(), *) 'TRS seedling-to-sapling transition rate > 1', &
+                              'pft=', ft, 'uncapped=', sdlng2sap_rate,         &
                               'sdlng2sap_par=', sdlng2sap_par
                      end if 
-                      
+
                      mass_avail = currentPatch%area*                           &
                         currentPatch%litter(el)%seed_germ(ft)*                 & 
                         min(1.0_r8, sdlng2sap_rate)

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -556,15 +556,8 @@ contains
          net_seed_available = litt%seed(pft) + litt%seed_in_local(pft) + &
             litt%seed_in_extern(pft) - litt%seed_decay(pft)
 
-         ! Cap germination at available seed
+         ! Cap germination at available seed to prevent negative seed pool
          litt%seed_germ_in(pft) = min(litt%seed_germ_in(pft), net_seed_available)
-
-         ! RW - commenting out for reference
-         ! litt%seed(pft) = litt%seed(pft) + &
-         !      litt%seed_in_local(pft) +   &
-         !      litt%seed_in_extern(pft) -  &
-         !      litt%seed_decay(pft) -      &
-         !      litt%seed_germ_in(pft)
 
          ! Update pools 
          litt%seed(pft) = net_seed_available - litt%seed_germ_in(pft)
@@ -574,19 +567,6 @@ contains
          litt%seed_germ(pft) = litt%seed_germ(pft) + &
                litt%seed_germ_in(pft) - &
                litt%seed_germ_decay(pft)
-
-         ! RW DEBUG BLOCK START 
-         ! write(fates_log(),*) '=== PreDisturbanceIntegrateLitter DIAGNOSTICS ==='
-         ! write(fates_log(),*) 'Model Day:', hlm_model_day
-         ! write(fates_log(),*) 'PFT:', pft
-         ! write(fates_log(),*) 'seed_germ (before update):', litt%seed_germ(pft) - litt%seed_germ_in(pft) + &
-         !   litt%seed_germ_decay(pft)
-         ! write(fates_log(),*) 'seed_germ_in:', litt%seed_germ_in(pft)
-         !write(fates_log(),*) 'seed_germ_decay:', litt%seed_germ_decay(pft)
-         ! write(fates_log(),*) 'seed_germ (after update):', litt%seed_germ(pft)
-         ! write(fates_log(),*) 'Net change:', litt%seed_germ_in(pft) - litt%seed_germ_decay(pft)
-         ! write(fates_log(),*) 'Decay exceeds pool?:', litt%seed_germ(pft) < 0.0_r8
-         ! RW DEBUG BLOCK END 
 
        enddo
 
@@ -2353,44 +2333,19 @@ contains
              seedling_h2o_mort_rate = EDPftvarcon_inst%seedling_h2o_mort_a(pft) * seedling_mdds**2 + &
                   EDPftvarcon_inst%seedling_h2o_mort_b(pft) * seedling_mdds + &
                   EDPftvarcon_inst%seedling_h2o_mort_c(pft)
-             ! RW: capping h20 mortality rate at 1
+             ! Cap h2o mortality rate at 1, quadratic can produce values >1 for large moisture
+             ! deficit days 
              seedling_h2o_mort_rate = min(1.0_r8, seedling_h2o_mort_rate)
           end if ! mdd threshold check
           
           ! Step 3. Sum modes of mortality (including background mortality) and send dead seedlings
           ! to litter        
-          ! litt%seed_germ_decay(pft) = (litt%seed_germ(pft) * seedling_light_mort_rate) + &
-          !     (litt%seed_germ(pft) * seedling_h2o_mort_rate) + &
-          !     (litt%seed_germ(pft) * EDPftvarcon_inst%background_seedling_mort(pft) &
-          !     * years_per_day)
-
-          ! RW: capping total mortality rate at 1
+          ! Cap total mortality rate at 1 to prevent negative seed pool 
            litt%seed_germ_decay(pft) = litt%seed_germ(pft) * &
                min(1.0_r8, seedling_light_mort_rate + &
                            seedling_h2o_mort_rate + &
                            (EDPftvarcon_inst%background_seedling_mort(pft) * &
                            years_per_day))
-           
-
-
-          ! RW DEBUG BLOCK START 
-            write(fates_log(),*) '===SEED DECAY DIADNOSTICS===='
-            write(fates_log(),*) 'Model Day = ', hlm_model_day
-            write(fates_log(),*) 'PFT:', pft 
-            write(fates_log(),*) 'Seedling par (raw):', currentPatch%sdlng_mort_par%GetMean()
-            write(fates_log(),*) 'Seedling par (converted):', seedling_layer_par
-            write(fates_log(),*) 'Seedling mdds:', currentPatch%sdlng_mdd(pft)%p%GetMean()     
-            write(fates_log(),*) 'Seedling mdd crit:', EDPftvarcon_inst%seedling_mdd_crit(pft) 
-            write(fates_log(),*) 'Seedling light mort rate:', seedling_light_mort_rate
-            write(fates_log(),*) 'Seedling h2o mort rate:', seedling_h2o_mort_rate
-            write(fates_log(),*) 'Seed_germ pool (before decay):', litt%seed_germ(pft)
-            write(fates_log(),*) 'Seed_germ_decay (calculated):', litt%seed_germ_decay(pft)            
-            write(fates_log(),*) 'Background_seedling_mort:', EDPftvarcon_inst%background_seedling_mort(pft) * years_per_day
-            write(fates_log(),*) 'Total mort rate:', seedling_light_mort_rate + seedling_h2o_mort_rate + &
-               (EDPftvarcon_inst%background_seedling_mort(pft) * years_per_day)
-            write(fates_log(),*) 'Does seed decay exceeds pool?:', litt%seed_germ_decay(pft) > litt%seed_germ(pft)
-         ! RW DEBUG BLOCK END
-
 
        else
           
@@ -2493,8 +2448,9 @@ contains
           ! rate modifier (Step 1). See Eq. 4 of Hanbury-Brown et al., 2022
 
           ! If SMP is below a pft-specific value, then no germination occurs
-          ! RW - cap emerg rate at 1
           if ( seedling_layer_smp .GE. EDPftvarcon_inst%seedling_psi_emerg(pft) ) then
+             ! Cap emergence rate at 1, rate can exceed 1 for some parameter combinations,
+             ! leading to negative seed bank
              seedling_emerg_rate = min(1.0_r8, photoblastic_germ_modifier * EDPftvarcon_inst%a_emerg(pft) * &
                   wetness_index**EDPftvarcon_inst%b_emerg(pft))
           else 
@@ -2505,19 +2461,6 @@ contains
 
           ! Step 4. Calculate the amount of carbon germinating out of the seed bank
           litt%seed_germ_in(pft) = litt%seed(pft) * seedling_emerg_rate
-
-          ! RW DEBUG BLOCK START 
-          write(fates_log(),*) '=== SeedGermination DIAGNOSTICS ==='
-          write(fates_log(),*) 'Model Day:', hlm_model_day
-          write(fates_log(),*) 'PFT:', pft
-          write(fates_log(),*) 'seed pool:', litt%seed(pft)
-          write(fates_log(),*) 'seedling_layer_par:', seedling_layer_par
-          write(fates_log(),*) 'photoblastic_germ_modifier:', photoblastic_germ_modifier
-          write(fates_log(),*) 'seedling_layer_smp:', seedling_layer_smp
-          write(fates_log(),*) 'wetness_index:', wetness_index
-          write(fates_log(),*) 'seedling_emerg_rate:', seedling_emerg_rate
-          write(fates_log(),*) 'seed_germ_in (calculated):', litt%seed_germ_in(pft)          
-         ! RW DEBUG BLOCK END 
 
        end if if_tfs_or_def
 
@@ -2753,21 +2696,6 @@ contains
                         mass_avail = 0.0_r8
                      end if 
 
-                     ! RW DEBUG BLOCK START
-                     write(fates_log(),*) '=== recruitment DIAGNOSTICS ==='
-                     write(fates_log(),*) 'Model Day:', hlm_model_day
-                     write(fates_log(),*) 'PFT:', ft
-                     write(fates_log(),*) 'Element:', element_id
-                     write(fates_log(),*) 'Seed_germ', currentPatch%area*    &
-                        currentPatch%litter(el)%seed_germ(ft)
-                     write(fates_log(),*) 'Mass_avail', mass_avail
-                     write(fates_log(),*) 'Mass_demand', mass_demand
-                     write(fates_log(),*) 'ilayer_seedling_root', ilayer_seedling_root
-                     write(fates_log(),*) 'seedling_layer_smp', seedling_layer_smp
-                     write(fates_log(),*) 'seedling_psi_crit', EDPftvarcon_inst%seedling_psi_crit(ft)
-                     write(fates_log(),*) 'sdlng2sap_par', sdlng2sap_par
-                     ! RW DEBUG BLOCK END
-
                   end if ! End use TRS with seedling dynamics
 
                   ! update number density if this is the limiting mass
@@ -2866,17 +2794,6 @@ contains
                      currentPatch%litter(el)%seed_germ(ft) - cohort_n / currentPatch%area *   &
                      (m_struct + m_leaf + m_fnrt + m_sapw + m_store + m_repro)
                      
-                   ! RW DEBUG BLOCK START 
-                   !  write(fates_log(),*) '=== recruitment remove mass DIAGNOSTICS ==='
-                   !  write(fates_log(),*) 'cohort_n:', cohort_n
-                   !  write(fates_log(),*) 'currentPatch%area:', currentPatch%area
-                   !  write(fates_log(),*) 'cohort_n / area:', cohort_n / currentPatch%area
-                   !  write(fates_log(),*) 'm demand', (m_struct + m_leaf + m_fnrt + m_sapw + m_store + m_repro)
-                   !  write(fates_log(),*) 'm removed from seed_germ', cohort_n / currentPatch%area *   &
-                   !  (m_struct + m_leaf + m_fnrt + m_sapw + m_store + m_repro)
-                   !  write(fates_log(),*) 'Is seed_germ negative?:', currentPatch%litter(el)%seed_germ(ft) < 0.0_r8
-                   ! RW DEBUG BLOCK END 
-
                   end if
                   
                end do

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -2317,7 +2317,7 @@ contains
           
           ! Get the current seedling moisture deficit days (tracked as a pft-specific exponential
           ! average)
-          seedling_mdds = currentPatch%sdlng_mdd(pft)%p%GetMean()     
+          seedling_mdds = currentPatch%sdlng_mdd(pft)%p%GetMean()
           
           ! Calculate seedling mortality as a function of moisture deficit days (mdd)
           ! If the seedling mmd value is below a critical threshold then moisture-based mortality is zero

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -562,6 +562,19 @@ contains
                litt%seed_germ_in(pft) - &
                litt%seed_germ_decay(pft)
 
+          ! RW BEBUG BLOCK START 
+            write(fates_log(),*) '=== PreDisturbanceIntegrateLitter DIAGNOSTICS ==='
+            write(fates_log(),*) 'Model Day:', hlm_model_day
+            write(fates_log(),*) 'PFT:', pft
+            write(fates_log(),*) 'seed_germ (before update):', litt%seed_germ(pft) - litt%seed_germ_in(pft) + &
+            litt%seed_germ_decay(pft)
+            write(fates_log(),*) 'seed_germ_in:', litt%seed_germ_in(pft)
+            write(fates_log(),*) 'seed_germ_decay:', litt%seed_germ_decay(pft)
+            write(fates_log(),*) 'seed_germ (after update):', litt%seed_germ(pft)
+            write(fates_log(),*) 'Net change:', litt%seed_germ_in(pft) - litt%seed_germ_decay(pft)
+            write(fates_log(),*) 'Decay exceeds pool?:', litt%seed_germ(pft) < 0.0_r8
+          ! RW DEBUG BLOCK END 
+
        enddo
 
        ! Update the Coarse Woody Debris pools (above and below)
@@ -2336,19 +2349,24 @@ contains
                (litt%seed_germ(pft) * EDPftvarcon_inst%background_seedling_mort(pft) &
                * years_per_day)
 
-          ! DEBUG BLOCK START 
-            write(fates_log(),*) '===DEBUG SEED DECAY===='
+          ! RW DEBUG BLOCK START 
+            write(fates_log(),*) '===SEED DECAY DIADNOSTICS===='
             write(fates_log(),*) 'Model Day = ', hlm_model_day
             write(fates_log(),*) 'PFT:', pft 
             write(fates_log(),*) 'Seedling par (raw):', currentPatch%sdlng_mort_par%GetMean()
             write(fates_log(),*) 'Seedling par (converted):', seedling_layer_par
-            write(fates_log(),*) 'Seedling light mort rate:', seedling_light_mort_rate
-            write(fates_log(),*) 'Seedling mdds:', seedling_light_mort_rate     
+            write(fates_log(),*) 'Seedling mdds:', currentPatch%sdlng_mdd(pft)%p%GetMean()     
             write(fates_log(),*) 'Seedling mdd crit:', EDPftvarcon_inst%seedling_mdd_crit(pft) 
-            write(fates_log(),*) 'Seedling h2o mort rate:', seedling_h2o_mort_rate      
-            write(fates_log(),*) 'Seed germ pool:', litt%seed_germ(pft)
-            write(fates_log(),*) 'Seed germ decay:',litt%seed_germ_decay(pft)
-          ! DEBUG BLOCK END
+            write(fates_log(),*) 'Seedling light mort rate:', seedling_light_mort_rate
+            write(fates_log(),*) 'Seedling h2o mort rate:', seedling_h2o_mort_rate
+            write(fates_log(),*) 'Seed_germ pool (before decay):', litt%seed_germ(pft)
+            write(fates_log(),*) 'Seed_germ_decay (calculated):', litt%seed_germ_decay(pft)            
+            write(fates_log(),*) 'Background_seedling_mort:', EDPftvarcon_inst%background_seedling_mort(pft) * years_per_day
+            write(fates_log(),*) 'Total mort rate:', seedling_light_mort_rate + seedling_h2o_mort_rate + &
+               (EDPftvarcon_inst%background_seedling_mort(pft) * years_per_day)
+            write(fates_log(),*) 'Does seed decay exceeds pool?:', litt%seed_germ_decay(pft) > litt%seed_germ(pft)
+         ! RW DEBUG BLOCK END
+
 
        else
           
@@ -2462,6 +2480,19 @@ contains
 
           ! Step 4. Calculate the amount of carbon germinating out of the seed bank
           litt%seed_germ_in(pft) = litt%seed(pft) * seedling_emerg_rate
+
+          ! RW DEBUG BLOCK START 
+          write(fates_log(),*) '=== SeedGermination DIAGNOSTICS ==='
+          write(fates_log(),*) 'Model Day:', hlm_model_day
+          write(fates_log(),*) 'PFT:', pft
+          write(fates_log(),*) 'seed pool:', litt%seed(pft)
+          write(fates_log(),*) 'seedling_layer_par:', seedling_layer_par
+          write(fates_log(),*) 'photoblastic_germ_modifier:', photoblastic_germ_modifier
+          write(fates_log(),*) 'seedling_layer_smp:', seedling_layer_smp
+          write(fates_log(),*) 'wetness_index:', wetness_index
+          write(fates_log(),*) 'seedling_emerg_rate:', seedling_emerg_rate
+          write(fates_log(),*) 'seed_germ_in (calculated):', litt%seed_germ_in(pft)          
+         ! RW DEBUG BLOCK END 
 
        end if if_tfs_or_def
 
@@ -2685,19 +2716,6 @@ contains
                         currentPatch%litter(el)%seed_germ(ft)*                 & 
                         EDPftvarcon_inst%seedling_light_rec_a(ft)*             &
                         sdlng2sap_par**EDPftvarcon_inst%seedling_light_rec_b(ft) 
-
-                      ! DEBUG BLOCK START
-                        write(fates_log(),*) '=== DEBUG RECRUITMENT TRS ==='
-                        write(fates_log(),*) 'Model day:', hlm_model_day
-                        write(fates_log(),*) 'PFT:', ft
-                        write(fates_log(),*) 'Element:', element_id
-                        write(fates_log(),*) 'sdlng2sap_par (raw):', currentPatch%sdlng2sap_par%GetMean()
-                        write(fates_log(),*) 'sdlng2sap_par (converted):', sdlng2sap_par
-                        write(fates_log(),*) 'seed_germ before calc:', currentPatch%litter(el)%seed_germ(ft)
-                        write(fates_log(),*) 'seedling_light_rec_a:', EDPftvarcon_inst%seedling_light_rec_a(ft)
-                        write(fates_log(),*) 'seedling_light_rec_b:', EDPftvarcon_inst%seedling_light_rec_b(ft)
-                        write(fates_log(),*) 'currentPatch%area:', currentPatch%area
-                      ! DEBUG BLOCK END
                      
                      ! If soil moisture is below pft-specific seedling  moisture stress threshold the 
                      ! recruitment does not occur.
@@ -2710,12 +2728,20 @@ contains
                         mass_avail = 0.0_r8
                      end if 
 
-                     ! DEBUG BLOCK START
+                     ! RW DEBUG BLOCK START
+                     write(fates_log(),*) '=== recruitment DIAGNOSTICS ==='
+                     write(fates_log(),*) 'Model Day:', hlm_model_day
+                     write(fates_log(),*) 'PFT:', ft
+                     write(fates_log(),*) 'Element:', element_id
+                     write(fates_log(),*) 'Seed_germ', currentPatch%area*    &
+                        currentPatch%litter(el)%seed_germ(ft)
+                     write(fates_log(),*) 'Mass_avail', mass_avail
+                     write(fates_log(),*) 'Mass_demand', mass_demand
                      write(fates_log(),*) 'ilayer_seedling_root', ilayer_seedling_root
                      write(fates_log(),*) 'seedling_layer_smp', seedling_layer_smp
                      write(fates_log(),*) 'seedling_psi_crit', EDPftvarcon_inst%seedling_psi_crit(ft)
-                     write(fates_log(),*) 'mass_avail after calc:', mass_avail
-                     ! DEBUG BLOCK END
+                     write(fates_log(),*) 'sdlng2sap_par', sdlng2sap_par
+                     ! RW DEBUG BLOCK END
 
                   end if ! End use TRS with seedling dynamics
 
@@ -2814,6 +2840,18 @@ contains
                      currentPatch%litter(el)%seed_germ(ft) =                   &
                      currentPatch%litter(el)%seed_germ(ft) - cohort_n / currentPatch%area *   &
                      (m_struct + m_leaf + m_fnrt + m_sapw + m_store + m_repro)
+                     
+                   ! RW DEBUG BLOCK START 
+                     write(fates_log(),*) '=== recruitment remove mass DIAGNOSTICS ==='
+                     write(fates_log(),*) 'cohort_n:', cohort_n
+                     write(fates_log(),*) 'currentPatch%area:', currentPatch%area
+                     write(fates_log(),*) 'cohort_n / area:', cohort_n / currentPatch%area
+                     write(fates_log(),*) 'm demand', (m_struct + m_leaf + m_fnrt + m_sapw + m_store + m_repro)
+                     write(fates_log(),*) 'm removed from seed_germ', cohort_n / currentPatch%area *   &
+                     (m_struct + m_leaf + m_fnrt + m_sapw + m_store + m_repro)
+                     write(fates_log(),*) 'Is seed_germ negative?:', currentPatch%litter(el)%seed_germ(ft) < 0.0_r8
+                   ! RW DEBUG BLOCK END 
+
                   end if
                   
                end do

--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -2336,12 +2336,7 @@ contains
                   EDPftvarcon_inst%seedling_h2o_mort_b(pft) * seedling_mdds + &
                   EDPftvarcon_inst%seedling_h2o_mort_c(pft)
              ! Cap h2o mortality rate at 1, quadratic can produce values >1 for large moisture
-             ! deficit days, if rate exceeds 1 write to fates log 
-
-             if (seedling_h2o_mort_rate > 1.0_r8) then
-               write(fates_log(), *) 'TRS seedling_h2o_mort_rate > 1', &
-                     'pft=', pft, 'uncapped=', seedling_h2o_mort_rate, 'mdds=', seedling_mdds
-             end if 
+             ! deficit days 
              seedling_h2o_mort_rate = min(1.0_r8, seedling_h2o_mort_rate)
           end if ! mdd threshold check
           
@@ -2351,12 +2346,6 @@ contains
           total_seedling_mort_rate = seedling_light_mort_rate + &
                         seedling_h2o_mort_rate + &
                         (EDPftvarcon_inst%background_seedling_mort(pft) * years_per_day)
-          if (total_seedling_mort_rate > 1.0_r8) then 
-            write(fates_log(), *) 'TRS total seedling mortality rate > 1', &
-                  'pft=', pft, 'uncapped=', total_seedling_mort_rate, &
-                  'seedling_light_mort_rate=', seedling_light_mort_rate, & 
-                  'seedling_h2o_mort_rate=', seedling_h2o_mort_rate
-          end if
           litt%seed_germ_decay(pft) = litt%seed_germ(pft) * &
             min(1.0_r8, total_seedling_mort_rate)
 
@@ -2465,13 +2454,7 @@ contains
              seedling_emerg_rate = photoblastic_germ_modifier * EDPftvarcon_inst%a_emerg(pft) * &
                   wetness_index**EDPftvarcon_inst%b_emerg(pft)
              ! Cap emergence rate at 1, rate can exceed 1 for some parameter combinations,
-             ! leading to negative seed bank, write to log if this is the case 
-             if (seedling_emerg_rate > 1.0_r8) then
-               write(fates_log(),*) 'TRS seedling_emerg_rate > 1', &
-                     'pft=', pft, 'uncapped=', seedling_emerg_rate, &
-                     'photoblastic_germ_modifier=', photoblastic_germ_modifier, &
-                     'wetness_index=', wetness_index
-             end if 
+             ! leading to negative seed bank
              seedling_emerg_rate = min(1.0_r8, seedling_emerg_rate )
           else 
 
@@ -2705,14 +2688,7 @@ contains
                         sdlng2sap_par**EDPftvarcon_inst%seedling_light_rec_b(ft)
 
                      ! If the seedling to sapling transition rate exceeds 1, 
-                     ! cap at 1 (prevent seed_germ from going negative) and write to fates log 
-
-                     if (sdlng2sap_rate > 1.0_r8) then
-                        write(fates_log(), *) 'TRS seedling-to-sapling transition rate > 1', &
-                              'pft=', ft, 'uncapped=', sdlng2sap_rate,         &
-                              'sdlng2sap_par=', sdlng2sap_par
-                     end if 
-
+                     ! cap at 1 (prevent seed_germ from going negative)
                      mass_avail = currentPatch%area*                           &
                         currentPatch%litter(el)%seed_germ(ft)*                 & 
                         min(1.0_r8, sdlng2sap_rate)

--- a/biogeochem/FatesPatchMod.F90
+++ b/biogeochem/FatesPatchMod.F90
@@ -666,7 +666,7 @@ module FatesPatchMod
         call this%seedling_layer_par24%InitRMean(fixed_24hr,                   &
           init_value=init_seedling_par, init_offset=real(current_tod, r8))
         call this%sdlng_mort_par%InitRMean(ema_sdlng_mort_par,                 &
-          init_value=temp_init_veg)
+          init_value=init_seedling_par)
         call this%sdlng2sap_par%InitRMean(ema_sdlng2sap_par,                   &
           init_value=init_seedling_par)
 

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -2317,7 +2317,7 @@ contains
               write(fates_log(),*) '=== Seedling Layer PAR Debug ==== Day:', hlm_model_day
               write(fates_log(),*) 'Seedling par high:', seedling_par_high, 'Par frac high:', par_high_frac
               write(fates_log(),*) 'Seedling par low:', seedling_par_low, 'Par frac low:', par_low_frac
-              write(fates_log(),*) 'New seedling layer par', new_seedling_layer_par 
+              write(fates_log(),*) 'New seedling layer par:', new_seedling_layer_par 
               ! DEBUG BLOCK END
               
               call cpatch%seedling_layer_par24%UpdateRMean(new_seedling_layer_par)
@@ -2342,19 +2342,17 @@ contains
                  endif
 
                 ! === DEBUG BLOCK START  ===
-                   write(fates_log(),*) '=== MDD DEBUG Day:', hlm_model_day
-                   write(fates_log(),*) 'PFT:', pft, 'Soil layer:', ilayer_seedling_root
-                   write(fates_log(),*) 'Raw SMP from host:', bc_in(s)%smp_sl(ilayer_seedling_root)
-                   write(fates_log(),*) 'new_seedling_layer_smp:', new_seedling_layer_smp
-                   write(fates_log(),*) 'seedling_psi_crit:', EDPftvarcon_inst%seedling_psi_crit(pft)
-                   write(fates_log(),*) 'Deficit check val for check', abs(EDPftvarcon_inst%seedling_psi_crit(pft)) - abs(new_seedling_layer_smp)
-                   write(fates_log(),*) 'new_seedling_mdd (after zero check):', new_seedling_mdd
-                   write(fates_log(),*) 'Current EMA c_mean:', cpatch%sdlng_mdd(pft)%p%c_mean
-                   write(fates_log(),*) 'Current c_index:', cpatch%sdlng_mdd(pft)%p%c_index
-                   write(fates_log(),*) 'n_mem:', cpatch%sdlng_mdd(pft)%p%def_type%n_mem
-                   write(fates_log(),*) 'sdlng_mdd_timescale:', sdlng_mdd_timescale
-                   write(fates_log(),*) '========================'
-                 end if
+                  write(fates_log(),*) '=== MDD DEBUG Day:', hlm_model_day
+                  write(fates_log(),*) 'PFT:', pft, 'Soil layer:', ilayer_seedling_root
+                  write(fates_log(),*) 'Raw SMP from host:', bc_in(s)%smp_sl(ilayer_seedling_root)
+                  write(fates_log(),*) 'new_seedling_layer_smp:', new_seedling_layer_smp
+                  write(fates_log(),*) 'seedling_psi_crit:', EDPftvarcon_inst%seedling_psi_crit(pft)
+                  write(fates_log(),*) 'Deficit check val for check', abs(EDPftvarcon_inst%seedling_psi_crit(pft)) - abs(new_seedling_layer_smp)
+                  write(fates_log(),*) 'new_seedling_mdd (after zero check):', new_seedling_mdd
+                  write(fates_log(),*) 'Current EMA c_mean:', cpatch%sdlng_mdd(pft)%p%c_mean
+                  write(fates_log(),*) 'Current c_index:', cpatch%sdlng_mdd(pft)%p%c_index
+                  write(fates_log(),*) 'n_mem:', cpatch%sdlng_mdd(pft)%p%def_type%n_mem
+                  write(fates_log(),*) 'sdlng_mdd_timescale:', sdlng_mdd_timescale
                 ! === DEBUG BLOCK END ===
 
                  ! Update the seedling layer smp and mdd running means

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -2410,8 +2410,9 @@ subroutine SeedlingParPatch(cpatch, &
 
   ! Start with the assumption that there is a single canopy layer
   seedling_par_high = atm_par_dir+atm_par_dif
-  par_high_frac     = 1._r8-cpatch%total_canopy_area
-  par_low_frac      = cpatch%total_canopy_area
+  ! RW - edit to make these fractional rather than absolute area [m2]
+  par_high_frac     = 1._r8 - (cpatch%total_canopy_area / cpatch%area)
+  par_low_frac      = cpatch%total_canopy_area / cpatch%area
 
   ! Work up through the canopy layers from the bottom layer
   do cl = cpatch%NCL_p,max(1,cpatch%NCL_p-1),-1

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -2312,13 +2312,6 @@ contains
                    & par_low_frac)
               
               new_seedling_layer_par = seedling_par_high*par_high_frac + seedling_par_low*par_low_frac
-
-              ! DEBUG BLOCK START 
-              write(fates_log(),*) '=== Seedling Layer PAR Debug ==== Day:', hlm_model_day
-              write(fates_log(),*) 'Seedling par high:', seedling_par_high, 'Par frac high:', par_high_frac
-              write(fates_log(),*) 'Seedling par low:', seedling_par_low, 'Par frac low:', par_low_frac
-              write(fates_log(),*) 'New seedling layer par:', new_seedling_layer_par 
-              ! DEBUG BLOCK END
               
               call cpatch%seedling_layer_par24%UpdateRMean(new_seedling_layer_par)
               call cpatch%sdlng_mort_par%UpdateRMean(new_seedling_layer_par)

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -2335,10 +2335,10 @@ contains
                  endif
 
                  ! Update the seedling layer smp and mdd running means
-                 call cpatch%sdlng_mdd(pft)%p%UpdateRMean(new_seedling_mdd)
                  ! RW - only update after first model day to avoid adding
                  ! spike in smp (~negative billions) to running means
-                 if (hlm_model_day > 1.0_r8) then 
+                 if (hlm_model_day > 1.5_r8) then 
+                   call cpatch%sdlng_mdd(pft)%p%UpdateRMean(new_seedling_mdd)
                    call cpatch%sdlng_emerg_smp(pft)%p%UpdateRMean(new_seedling_layer_smp)
                  endif
 

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -2312,6 +2312,13 @@ contains
                    & par_low_frac)
               
               new_seedling_layer_par = seedling_par_high*par_high_frac + seedling_par_low*par_low_frac
+
+              ! DEBUG BLOCK START 
+              write(fates_log(),*) '=== Seedling Layer PAR Debug ==== Day:', hlm_model_day
+              write(fates_log(),*) 'Seedling par high:', seedling_par_high, 'Par frac high:', par_high_frac
+              write(fates_log(),*) 'Seedling par low:', seedling_par_low, 'Par frac low:', par_low_frac
+              write(fates_log(),*) 'New seedling layer par', new_seedling_layer_par 
+              ! DEBUG BLOCK END
               
               call cpatch%seedling_layer_par24%UpdateRMean(new_seedling_layer_par)
               call cpatch%sdlng_mort_par%UpdateRMean(new_seedling_layer_par)
@@ -2333,6 +2340,22 @@ contains
                  if (new_seedling_mdd < 0.0_r8) then
                     new_seedling_mdd = 0.0_r8
                  endif
+
+                ! === DEBUG BLOCK START  ===
+                   write(fates_log(),*) '=== MDD DEBUG Day:', hlm_model_day
+                   write(fates_log(),*) 'PFT:', pft, 'Soil layer:', ilayer_seedling_root
+                   write(fates_log(),*) 'Raw SMP from host:', bc_in(s)%smp_sl(ilayer_seedling_root)
+                   write(fates_log(),*) 'new_seedling_layer_smp:', new_seedling_layer_smp
+                   write(fates_log(),*) 'seedling_psi_crit:', EDPftvarcon_inst%seedling_psi_crit(pft)
+                   write(fates_log(),*) 'Deficit check val for check', abs(EDPftvarcon_inst%seedling_psi_crit(pft)) - abs(new_seedling_layer_smp)
+                   write(fates_log(),*) 'new_seedling_mdd (after zero check):', new_seedling_mdd
+                   write(fates_log(),*) 'Current EMA c_mean:', cpatch%sdlng_mdd(pft)%p%c_mean
+                   write(fates_log(),*) 'Current c_index:', cpatch%sdlng_mdd(pft)%p%c_index
+                   write(fates_log(),*) 'n_mem:', cpatch%sdlng_mdd(pft)%p%def_type%n_mem
+                   write(fates_log(),*) 'sdlng_mdd_timescale:', sdlng_mdd_timescale
+                   write(fates_log(),*) '========================'
+                 end if
+                ! === DEBUG BLOCK END ===
 
                  ! Update the seedling layer smp and mdd running means
                  ! RW - only update after first model day to avoid adding

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -2335,11 +2335,11 @@ contains
                  endif
 
                  ! Update the seedling layer smp and mdd running means
+                 call cpatch%sdlng_mdd(pft)%p%UpdateRMean(new_seedling_mdd)
                  ! RW - only update after first model day to avoid adding
                  ! spike in smp (~negative billions) to running means
                  if (hlm_model_day > 1.0_r8) then 
                    call cpatch%sdlng_emerg_smp(pft)%p%UpdateRMean(new_seedling_layer_smp)
-                   call cpatch%sdlng_mdd(pft)%p%UpdateRMean(new_seedling_mdd)
                  endif
 
               enddo !end pft loop

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -2335,7 +2335,7 @@ contains
                  endif
 
                  ! Update the seedling layer smp and mdd running means
-                 ! RW - only update after first model day to avoid adding
+                 ! Only update after first model day to avoid adding
                  ! initialization spike in smp to running means
                  if (hlm_model_day > 2.0_r8) then 
                    call cpatch%sdlng_mdd(pft)%p%UpdateRMean(new_seedling_mdd)
@@ -2414,7 +2414,6 @@ subroutine SeedlingParPatch(cpatch, &
 
   ! Start with the assumption that there is a single canopy layer
   seedling_par_high = atm_par_dir+atm_par_dif
-  ! RW - edit to make these fractional rather than absolute area [m2]
   par_high_frac     = 1._r8 - (cpatch%total_canopy_area / cpatch%area)
   par_low_frac      = cpatch%total_canopy_area / cpatch%area
 

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -2335,8 +2335,13 @@ contains
                  endif
 
                  ! Update the seedling layer smp and mdd running means
-                 call cpatch%sdlng_emerg_smp(pft)%p%UpdateRMean(new_seedling_layer_smp)
                  call cpatch%sdlng_mdd(pft)%p%UpdateRMean(new_seedling_mdd)
+                 ! RW - only update after first model day to avoid adding
+                 ! spike in smp (~negative billions) to running means
+                 if (hlm_model_day > 1.0_r8) then 
+                   call cpatch%sdlng_mdd(pft)%p%UpdateRMean(new_seedling_mdd)
+                   call cpatch%sdlng_emerg_smp(pft)%p%UpdateRMean(new_seedling_layer_smp)
+                 endif
 
               enddo !end pft loop
               

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -2341,24 +2341,10 @@ contains
                     new_seedling_mdd = 0.0_r8
                  endif
 
-                ! === DEBUG BLOCK START  ===
-                  write(fates_log(),*) '=== MDD DEBUG Day:', hlm_model_day
-                  write(fates_log(),*) 'PFT:', pft, 'Soil layer:', ilayer_seedling_root
-                  write(fates_log(),*) 'Raw SMP from host:', bc_in(s)%smp_sl(ilayer_seedling_root)
-                  write(fates_log(),*) 'new_seedling_layer_smp:', new_seedling_layer_smp
-                  write(fates_log(),*) 'seedling_psi_crit:', EDPftvarcon_inst%seedling_psi_crit(pft)
-                  write(fates_log(),*) 'Deficit check val for check', abs(EDPftvarcon_inst%seedling_psi_crit(pft)) - abs(new_seedling_layer_smp)
-                  write(fates_log(),*) 'new_seedling_mdd (after zero check):', new_seedling_mdd
-                  write(fates_log(),*) 'Current EMA c_mean:', cpatch%sdlng_mdd(pft)%p%c_mean
-                  write(fates_log(),*) 'Current c_index:', cpatch%sdlng_mdd(pft)%p%c_index
-                  write(fates_log(),*) 'n_mem:', cpatch%sdlng_mdd(pft)%p%def_type%n_mem
-                  write(fates_log(),*) 'sdlng_mdd_timescale:', sdlng_mdd_timescale
-                ! === DEBUG BLOCK END ===
-
                  ! Update the seedling layer smp and mdd running means
                  ! RW - only update after first model day to avoid adding
-                 ! spike in smp (~negative billions) to running means
-                 if (hlm_model_day > 1.5_r8) then 
+                 ! initialization spike in smp to running means
+                 if (hlm_model_day > 2.0_r8) then 
                    call cpatch%sdlng_mdd(pft)%p%UpdateRMean(new_seedling_mdd)
                    call cpatch%sdlng_emerg_smp(pft)%p%UpdateRMean(new_seedling_layer_smp)
                  endif

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -2335,12 +2335,11 @@ contains
                  endif
 
                  ! Update the seedling layer smp and mdd running means
-                 call cpatch%sdlng_mdd(pft)%p%UpdateRMean(new_seedling_mdd)
                  ! RW - only update after first model day to avoid adding
                  ! spike in smp (~negative billions) to running means
                  if (hlm_model_day > 1.0_r8) then 
-                   call cpatch%sdlng_mdd(pft)%p%UpdateRMean(new_seedling_mdd)
                    call cpatch%sdlng_emerg_smp(pft)%p%UpdateRMean(new_seedling_layer_smp)
+                   call cpatch%sdlng_mdd(pft)%p%UpdateRMean(new_seedling_mdd)
                  endif
 
               enddo !end pft loop


### PR DESCRIPTION

### Description:
Fixes several bugs that cause the model to crash when running FATES with the Tree Recruitment Scheme (TRS; namelist option `fates_regeneration_model = 'trs'`). 

#### Bug fixes: 
#1499 - Fix PAR fraction calculations (normalization by patch area was previously missing, causing NaN errors)
#1500 - Skip updating seedling layer SMP running mean on first model day (host model SMP spike leads to 100% seedling mortality; the host model spike itself is a separate issue: https://github.com/ESCOMP/CTSM/issues/3584#issue-3591631905)
#1501 - Fix initial value for `sdlng_mort_par` (was set to `temp_init_veg`,  should be `init_seedling_par`)
#1504 - Add rate caps for TRS seedling emergence and decay rates so that they cannot exceed 1; rates > 1 unrealistically drive the TRS seedling pool negative, eventually crashing the model

### Collaborators:
@rgknox @glemieux 

### Expectation of Answer Changes:
Results using other regeneration models (`default`, `trs_no_seed_dyn`) are unchanged, results will differ when using `fates_regeneration_model='trs'` (model previously crashed)


<img width="1089" height="446" alt="image" src="https://github.com/user-attachments/assets/3672ee76-93cc-4f23-9606-7001a4cc1f6a" />

### Description of generative AI usage (as necessary)
None

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [x] The in-code documentation has been updated with descriptive comments
- [x] The documentation has been assessed to determine if updates are necessary
- [x] Describe use of generative AI (if necessary)

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided
- [ ] FATES-CLM6 Code Freeze: satellite phenology regression tests are b4b

*If satellite phenology regressions are **not** b4b, please hold merge and notify the FATES development team.*

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:* 

*CTSM (or) E3SM (specify which) baseline hash-tag:* 

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->
<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

