### PR TITLE
bug fix - termination for grazed cohorts

### DIFF
--- a/biogeochem/EDCohortDynamicsMod.F90
+++ b/biogeochem/EDCohortDynamicsMod.F90
@@ -15,6 +15,7 @@ Module EDCohortDynamicsMod
   use FatesConstantsMod     , only : fates_unset_r8
   use FatesConstantsMod     , only : nearzero
   use FatesConstantsMod     , only : calloc_abs_error
+  use FatesConstantsMod     , only : ievergreen
   use FatesInterfaceTypesMod     , only : nleafage
   use SFParamsMod           , only : SF_val_CWD_frac
   use EDPftvarcon           , only : EDPftvarcon_inst
@@ -384,6 +385,20 @@ contains
             endif
 
          endif
+
+         ! live biomass pools are terminally depleted by grazing in grasses. 
+         if(prt_params%phen_leaf_habit(currentCohort%pft) == ievergreen .and. &
+              prt_params%woody(currentCohort%) .eq. itrue) then
+            if ( ( leaf_c + fnrt_c ) < 1e-10_r8) then
+               terminate = itrue
+               termination_type = i_term_mort_type_cstarv
+               if ( debug ) then
+                  write(fates_log(),*) 'terminating cohorts 5', &
+                       sapw_c,leaf_c,fnrt_c,store_c,currentCohort%pft,call_index
+               endif
+            endif
+         endif
+
 
       end if if_level_2
       


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

This is a critical bug fix, documented here:
https://github.com/NorESMhub/CTSM/issues/218

This solution and changes were written by @JessicaNeedham 

Summary: Cohorts were being grazed such that evergreen plants had no leaf or fine-root biomass, this was causing numerical chaos in other aspects of the model.  The solution is to terminate these plants. 

<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

### Collaborators:

Several, see discussion in https://github.com/NorESMhub/CTSM/issues/218

<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:

This can hypothetically change answers in all non-sp configurations, but presumably the differences would be negligable.

<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

### Description of generative AI usage (as necessary)
<!--- Please briefly describe usage of generative AI, such as  -->
<!--- platform, AI model, workflow, testing, etc. -->

None AFAIK

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [ ] The in-code documentation has been updated with descriptive comments
- [ ] The documentation has been assessed to determine if updates are necessary
- [ ] Describe use of generative AI (if necessary)

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided
- [ ] FATES-CLM6 Code Freeze: satellite phenology regression tests are b4b

*If satellite phenology regressions are **not** b4b, please hold merge and notify the FATES development team.*

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

