### PR TITLE
Patch fusion crash in historic land only simulation fix

### DIFF
--- a/biogeochem/EDCanopyStructureMod.F90
+++ b/biogeochem/EDCanopyStructureMod.F90
@@ -85,6 +85,18 @@ module EDCanopyStructureMod
   
   real(r8), parameter :: co_area_target_precision = 1.0E-9_r8 
 
+  ! Relative precision target used alongside the absolute targets above.
+  !    Area conservation checks compare differences of two large, similarly
+  !    sized areas (e.g. cohort crown areas, layer areas, patch areas). For
+  !    such differences a fixed absolute threshold becomes meaningless once
+  !    the operands are large, because a single rounding of an operand of
+  !    magnitude x already produces a residual of order ulp(x) ~ 2.2e-16*x.
+  !    To avoid spuriously tripping error checks on rounding noise, the
+  !    comparisons below use max(absolute_target, rel_area_precision*|operand|).
+  !    rel_area_precision is set to relative machine precision for r8 so that
+  !    a difference below machine precision is never treated as a real error.
+  real(r8), parameter :: rel_area_precision = 1.0E-15_r8
+
   integer, parameter :: demotion_phase  = 1
   integer, parameter :: promotion_phase = 2
   
@@ -564,7 +576,8 @@ contains
 
          sumpd_area = 0._r8
          ic  = 1
-         do while( ic<=n_layer .and. (promdem_area-sumpd_area)>co_area_target_precision) 
+         do while( ic<=n_layer .and. (promdem_area-sumpd_area) > &
+              max(co_area_target_precision, rel_area_precision*promdem_area)) 
 
             cohort => layer_co(ic)%p
 
@@ -611,7 +624,8 @@ contains
          !    the cohort area within precision checks then fail
          
          
-         whole_or_part: if( ((layer_co(ic)%pd_area - cohort%c_area) > co_area_target_precision ) .or. &
+         whole_or_part: if( ((layer_co(ic)%pd_area - cohort%c_area) > &
+              max(co_area_target_precision, rel_area_precision*cohort%c_area) ) .or. &
               (layer_co(ic)%pd_area < 0._r8) ) then
             write(fates_log(),*) 'negative,or more area than the cohort has is being promoted/demoted'
             write(fates_log(),*) 'change: ',layer_co(ic)%pd_area
@@ -620,7 +634,8 @@ contains
             call endrun(msg=errMsg(sourcefile, __LINE__))
 
          
-         elseif ( abs(layer_co(ic)%pd_area - cohort%c_area) < co_area_target_precision ) then
+         elseif ( abs(layer_co(ic)%pd_area - cohort%c_area) < &
+              max(co_area_target_precision, rel_area_precision*cohort%c_area) ) then
 
             ! Whole cohort promotion/demotion
             cohort%canopy_layer = cohort%canopy_layer + ilyr_change
@@ -875,7 +890,8 @@ contains
                    call endrun(msg=errMsg(sourcefile, __LINE__))
                 end if
 
-                if (currentPatch%total_canopy_area - (1._r8-imperfect_fraction)*currentPatch%area > area_error_1) then
+                if (currentPatch%total_canopy_area - (1._r8-imperfect_fraction)*currentPatch%area > &
+                     max(area_error_1, rel_area_precision*currentPatch%area)) then
                    write(fates_log(),*) 'too much canopy in summary', s, &
                         currentPatch%nocomp_pft_label, currentPatch%total_canopy_area - (1._r8-imperfect_fraction)*currentPatch%area
                    call endrun(msg=errMsg(sourcefile, __LINE__))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

Changing EDCanopyStructureMod.F90 to have relative rather than absolute error comparisons so that errors are not triggered by differences which are in the noise of r8 precisions numbers

Addresses https://github.com/NorESMhub/CTSM/issues/223.  Cherry-picked from NorESMhub/ctsm#66.

### Collaborators:
<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->
@maritsandstad 

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

### Description of generative AI usage (as necessary)
<!--- Please briefly describe usage of generative AI, such as  -->
<!--- platform, AI model, workflow, testing, etc. -->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [ ] The in-code documentation has been updated with descriptive comments
- [ ] The documentation has been assessed to determine if updates are necessary
- [ ] Describe use of generative AI (if necessary)

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided
- [ ] FATES-CLM6 Code Freeze: satellite phenology regression tests are b4b

*If satellite phenology regressions are **not** b4b, please hold merge and notify the FATES development team.*

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

