### PR TITLE
Add output dimension: canopy layer x patch age x pft

### DIFF
--- a/main/FatesHistoryInterfaceMod.F90
+++ b/main/FatesHistoryInterfaceMod.F90
@@ -76,7 +76,7 @@ module FatesHistoryInterfaceMod
   use FatesIOVariableKindMod, only : site_size_r8, site_pft_r8, site_age_r8
   use FatesIOVariableKindMod, only : site_coage_r8, site_coage_pft_r8
   use FatesIOVariableKindMod, only : site_fuel_r8, site_cwdsc_r8, site_scag_r8
-  use FatesIOVariableKindMod, only : site_scagpft_r8, site_agepft_r8
+  use FatesIOVariableKindMod, only : site_scagpft_r8, site_agepft_r8, site_canagepft_r8
   use FatesIOVariableKindMod, only : site_can_r8, site_cnlf_r8, site_cnlfpft_r8
   use FatesIOVariableKindMod, only : site_height_r8, site_agefuel_r8
   use FatesIOVariableKindMod, only : site_elem_r8, site_elpft_r8
@@ -134,6 +134,7 @@ module FatesHistoryInterfaceMod
   use FatesSizeAgeTypeIndicesMod, only : get_sizeage_class_index
   use FatesSizeAgeTypeIndicesMod, only : get_sizeagepft_class_index
   use FatesSizeAgeTypeIndicesMod, only : get_agepft_class_index
+  use FatesSizeAgeTypeIndicesMod, only : get_layeragepft_class_index
   use FatesSizeAgeTypeIndicesMod, only : get_agefuel_class_index
   use FatesSizeAgeTypeIndicesMod, only : get_height_index
   use FatesSizeAgeTypeIndicesMod, only : sizetype_class_index
@@ -407,6 +408,10 @@ module FatesHistoryInterfaceMod
   integer :: ih_npp_si_agepft
   integer :: ih_scorch_height_si_pft
   integer :: ih_scorch_height_si_agepft
+  integer :: ih_crownarea_si_agepft
+
+  ! Indices to site by canopy layer by patch age by pft variables
+  integer :: ih_crownarea_si_layeragepft
 
   ! Indices to (site) variables
   integer :: ih_tveg24_si
@@ -847,7 +852,7 @@ module FatesHistoryInterfaceMod
      integer, private :: levfuel_index_, levcwdsc_index_, levscag_index_
      integer, private :: levcan_index_, levcnlf_index_, levcnlfpft_index_
      integer, private :: levcdpf_index_, levcdsc_index_, levcdam_index_ 
-     integer, private :: levscagpft_index_, levagepft_index_
+     integer, private :: levscagpft_index_, levagepft_index_, levcanagepft_index_
      integer, private :: levheight_index_, levagefuel_index_
      integer, private :: levelem_index_, levelpft_index_
      integer, private :: levelcwd_index_, levelage_index_
@@ -897,6 +902,7 @@ module FatesHistoryInterfaceMod
      procedure :: levscag_index
      procedure :: levscagpft_index
      procedure :: levagepft_index
+     procedure :: levcanagepft_index
      procedure :: levheight_index
      procedure :: levelem_index
      procedure :: levelpft_index
@@ -933,6 +939,7 @@ module FatesHistoryInterfaceMod
      procedure, private :: set_levscag_index
      procedure, private :: set_levscagpft_index
      procedure, private :: set_levagepft_index
+     procedure, private :: set_levcanagepft_index
      procedure, private :: set_levheight_index
      procedure, private :: set_levagefuel_index
      procedure, private :: set_levclscpf_index
@@ -969,7 +976,7 @@ contains
     use FatesIODimensionsMod, only : levscls, levpft, levage
     use FatesIODimensionsMod, only : levcacls, levcapf
     use FatesIODimensionsMod, only : levfuel, levcwdsc, levscag
-    use FatesIODimensionsMod, only : levscagpft, levagepft
+    use FatesIODimensionsMod, only : levscagpft, levagepft, levcanagepft
     use FatesIODimensionsMod, only : levcan, levcnlf, levcnlfpft
     use FatesIODimensionsMod, only : fates_bounds_type
     use FatesIODimensionsMod, only : levheight, levagefuel
@@ -1080,6 +1087,11 @@ contains
     call this%set_levagepft_index(dim_count)
     call this%dim_bounds(dim_count)%Init(levagepft, num_threads, &
          fates_bounds%agepft_class_begin, fates_bounds%agepft_class_end)
+
+    dim_count = dim_count + 1
+    call this%set_levcanagepft_index(dim_count)
+    call this%dim_bounds(dim_count)%Init(levcanagepft, num_threads, &
+         fates_bounds%layeragepft_class_begin, fates_bounds%layeragepft_class_end)
 
     dim_count = dim_count + 1
     call this%set_levheight_index(dim_count)
@@ -1223,6 +1235,10 @@ contains
     call this%dim_bounds(index)%SetThreadBounds(thread_index, &
          thread_bounds%agepft_class_begin, thread_bounds%agepft_class_end)
 
+    index = this%levcanagepft_index()
+    call this%dim_bounds(index)%SetThreadBounds(thread_index, &
+         thread_bounds%layeragepft_class_begin, thread_bounds%layeragepft_class_end)
+
     index = this%levheight_index()
     call this%dim_bounds(index)%SetThreadBounds(thread_index, &
          thread_bounds%height_begin, thread_bounds%height_end)
@@ -1332,6 +1348,9 @@ contains
 
     call this%set_dim_indices(site_agepft_r8, 1, this%column_index())
     call this%set_dim_indices(site_agepft_r8, 2, this%levagepft_index())
+
+    call this%set_dim_indices(site_canagepft_r8, 1, this%column_index())
+    call this%set_dim_indices(site_canagepft_r8, 2, this%levcanagepft_index())
 
     call this%set_dim_indices(site_height_r8, 1, this%column_index())
     call this%set_dim_indices(site_height_r8, 2, this%levheight_index())
@@ -1672,6 +1691,20 @@ contains
   end function levagepft_index
 
   ! ======================================================================================
+  subroutine set_levcanagepft_index(this, index)
+    implicit none
+    class(fates_history_interface_type), intent(inout) :: this
+    integer, intent(in) :: index
+    this%levcanagepft_index_ = index
+  end subroutine set_levcanagepft_index
+
+  integer function levcanagepft_index(this)
+    implicit none
+    class(fates_history_interface_type), intent(in) :: this
+    levcanagepft_index = this%levcanagepft_index_
+  end function levcanagepft_index
+
+  ! ======================================================================================
   subroutine set_levheight_index(this, index)
     implicit none
     class(fates_history_interface_type), intent(inout) :: this
@@ -1993,7 +2026,7 @@ contains
     use FatesIOVariableKindMod, only : site_size_r8, site_pft_r8, site_age_r8
     use FatesIOVariableKindMod, only : site_coage_r8, site_coage_pft_r8
     use FatesIOVariableKindMod, only : site_fuel_r8, site_cwdsc_r8, site_scag_r8
-    use FatesIOVariableKindMod, only : site_scagpft_r8, site_agepft_r8
+    use FatesIOVariableKindMod, only : site_scagpft_r8, site_agepft_r8, site_canagepft_r8
     use FatesIOVariableKindMod, only : site_can_r8, site_cnlf_r8, site_cnlfpft_r8
     use FatesIOVariableKindMod, only : site_height_r8, site_agefuel_r8
     use FatesIOVariableKindMod, only : site_elem_r8, site_elpft_r8
@@ -2083,6 +2116,10 @@ contains
     ! site x age class x pft
     index = index + 1
     call this%dim_kinds(index)%Init(site_agepft_r8, 2)
+
+    ! site x canopy layer x age class x pft
+    index = index + 1
+    call this%dim_kinds(index)%Init(site_canagepft_r8, 2)
 
     ! site x height
     index = index + 1
@@ -4806,12 +4843,14 @@ contains
     integer                 , intent(in)            :: nc   ! clump index
     integer                 , intent(in)            :: nsites
     type(ed_site_type)      , intent(inout), target :: sites(nsites)
-
+ 
     type(fates_cohort_type), pointer :: ccohort
-    type(fates_patch_type),  pointer :: cpatch
-    integer :: s, ft, iagepft, i_agefuel, iscag, iscagpft, i_fuel, i_scls, io_si
-    integer :: iscag_anthrodist  ! what is the equivalent age class for
-                                 ! time-since-anthropogenic-disturbance of secondary forest
+    type(fates_patch_type),  pointer :: cpatch, cpatchq
+    integer :: s, ft, iagepft, icanagepft, i_agefuel, iscag, iscagpft, i_fuel, i_scls, io_si
+    integer :: iscag_anthrodist     ! what is the equivalent age class for
+                                    ! time-since-anthropogenic-disturbance of secondary forest
+    integer :: n_patch_in_age_class ! number of patches in a patch's age class 
+    integer :: age_class            ! patch's age class 
     real(r8) :: mort
     real(r8) :: sapw_m             ! Sapwood mass (elemental, c,n or p) [kg/plant]
     real(r8) :: struct_m           ! Structural mass ""
@@ -4826,20 +4865,22 @@ contains
     real(r8) :: cohort_n_div_site_area       ! Weighting based on cohort density relative to site area
 
     associate( &
-         hio_lai_si_age => this%hvars(ih_lai_si_age)%r82d, &
-         hio_ncl_si_age => this%hvars(ih_ncl_si_age)%r82d, &
-         hio_scorch_height_si_agepft => this%hvars(ih_scorch_height_si_agepft)%r82d, &
-         hio_zstar_si_age        => this%hvars(ih_zstar_si_age)%r82d, &
-         hio_fracarea_burnt_si_age          => this%hvars(ih_fracarea_burnt_si_age)%r82d, &
-         hio_rx_fracarea_burnt_si_age           => this%hvars(ih_rx_fracarea_burnt_si_age)%r82d, &
-         hio_nonrx_fracarea_burnt_si_age        => this%hvars(ih_nonrx_fracarea_burnt_si_age)%r82d, &
-         hio_fire_sum_fuel_si_age           => this%hvars(ih_fire_sum_fuel_si_age)%r82d, &
-         hio_fuel_amount_si_agfc            => this%hvars(ih_fuel_amount_si_agfc)%r82d, &
+         hio_lai_si_age                       => this%hvars(ih_lai_si_age)%r82d, &
+         hio_ncl_si_age                       => this%hvars(ih_ncl_si_age)%r82d, &
+         hio_scorch_height_si_agepft          => this%hvars(ih_scorch_height_si_agepft)%r82d, &
+         hio_zstar_si_age                     => this%hvars(ih_zstar_si_age)%r82d, &
+         hio_fracarea_burnt_si_age            => this%hvars(ih_fracarea_burnt_si_age)%r82d, &
+         hio_rx_fracarea_burnt_si_age         => this%hvars(ih_rx_fracarea_burnt_si_age)%r82d, &
+         hio_nonrx_fracarea_burnt_si_age      => this%hvars(ih_nonrx_fracarea_burnt_si_age)%r82d, &
+         hio_fire_sum_fuel_si_age             => this%hvars(ih_fire_sum_fuel_si_age)%r82d, &
+         hio_fuel_amount_si_agfc              => this%hvars(ih_fuel_amount_si_agfc)%r82d, &
 !         hio_fire_rate_of_spread_front_si_age => this%hvars(ih_fire_rate_of_spread_front_si_age)%r82d, &
          hio_mortality_canopy_si_scag         => this%hvars(ih_mortality_canopy_si_scag)%r82d, &
          hio_mortality_understory_si_scag     => this%hvars(ih_mortality_understory_si_scag)%r82d, &
-         hio_biomass_si_age        => this%hvars(ih_biomass_si_age)%r82d, &
+         hio_biomass_si_age                   => this%hvars(ih_biomass_si_age)%r82d, &
          hio_biomass_si_agepft                => this%hvars(ih_biomass_si_agepft)%r82d, &
+         hio_crownarea_si_agepft              => this%hvars(ih_crownarea_si_agepft)%r82d, &
+         hio_crownarea_si_layeragepft         => this%hvars(ih_crownarea_si_layeragepft)%r82d, &
          hio_npp_si_age                       => this%hvars(ih_npp_si_age)%r82d, &
          hio_npp_si_agepft                    => this%hvars(ih_npp_si_agepft)%r82d, &
          hio_ddbh_canopy_si_scag              => this%hvars(ih_ddbh_canopy_si_scag)%r82d, &
@@ -4990,6 +5031,15 @@ contains
        patchloop2: do while(associated(cpatch))
           cpatch%age_class  = get_age_class_index(cpatch%age)
 
+          ! get number of pathces in this patch's age bin
+          n_patch_in_age_class = 0
+          cpatchq => sites(s)%oldest_patch
+          patchloopq: do while(associated(cpatchq))
+             age_class = get_age_class_index(cpatchq%age)
+             if(age_class == cpatch%age_class) n_patch_in_age_class = n_patch_in_age_class + 1
+             cpatchq => cpatchq%younger
+          end do patchloopq
+
           ! Loop through cohorts on patch
           ccohort => cpatch%shortest
           cohortloop2: do while(associated(ccohort))
@@ -4997,9 +5047,10 @@ contains
              ! If you SUM across all age classes, you should get the mean site value.
              cohort_n_div_site_area = ccohort%n * AREA_INV
    
-             iscag = get_sizeage_class_index(ccohort%dbh, cpatch%age)
-             iagepft = get_agepft_class_index(cpatch%age,ccohort%pft)
-             iscagpft = get_sizeagepft_class_index(ccohort%dbh,cpatch%age,ccohort%pft)
+             iscag      = get_sizeage_class_index(ccohort%dbh, cpatch%age)
+             iagepft    = get_agepft_class_index(cpatch%age,ccohort%pft)
+             icanagepft = get_layeragepft_class_index(ccohort%canopy_layer,cpatch%age,ccohort%pft)
+             iscagpft   = get_sizeagepft_class_index(ccohort%dbh,cpatch%age,ccohort%pft)
 
              ! Biomass
              call ccohort%prt%GetBiomass(carbon12_element, &
@@ -5009,6 +5060,12 @@ contains
              hio_biomass_si_agepft(io_si,iagepft) = hio_biomass_si_agepft(io_si,iagepft) &
                   + total_m * cohort_n_div_site_area
 
+             ! Crown Area              
+             hio_crownarea_si_agepft(io_si, iagepft) = hio_crownarea_si_agepft(io_si, iagepft) & 
+                  + ccohort%c_area / cpatch%area / n_patch_in_age_class
+             hio_crownarea_si_layeragepft(io_si, icanagepft) = hio_crownarea_si_layeragepft(io_si, icanagepft) & 
+                  + ccohort%c_area / cpatch%area / n_patch_in_age_class
+ 
              if (.not. (ccohort%isnew)) then
                 hio_npp_si_agepft(io_si,iagepft) = hio_npp_si_agepft(io_si,iagepft) + &
                      ccohort%npp_acc_hold / days_per_year / sec_per_day &  ! [kgC/indiv/yr] -> [kgC/s]
@@ -6513,7 +6570,7 @@ contains
     use FatesIOVariableKindMod, only : site_fuel_r8, site_cwdsc_r8, site_scag_r8
     use FatesIOVariableKindMod, only : site_can_r8, site_cnlf_r8, site_cnlfpft_r8
     use FatesIOVariableKindMod, only : site_cdsc_r8, site_cdpf_r8, site_cdam_r8
-    use FatesIOVariableKindMod, only : site_scagpft_r8, site_agepft_r8
+    use FatesIOVariableKindMod, only : site_scagpft_r8, site_agepft_r8, site_canagepft_r8
     use FatesIOVariableKindMod, only : site_elem_r8, site_elpft_r8, site_clscpf_r8
     use FatesIOVariableKindMod, only : site_elcwd_r8, site_elage_r8
 
@@ -6545,16 +6602,17 @@ contains
     ! cohort crown damage      (site_cd_r8)     : CD
 
     ! Multiple dimensions should have multiple two-code suffixes:
-    ! cohort age x pft                (site_cooage_r8)   : ACPF
-    ! patch age x fuel class          (site_agefuel_r8)  : APFC
-    ! patch age x pft                 (site_agepft_r8)   : APPF
-    ! canopy layer x leaf layer       (site_cnlf_r8)     : CLLL
-    ! canopy layer x leaf layer x pft (site_cnlfpft_r8)  : CLLLPF
-    ! element x cwd size              (site_elcwd_r8)    : ELDC
-    ! cohort size x patch age         (site_scag_r8)     : SZAP
-    ! cohort size x patch age x pft   (site_scagpft_r8)  : SZAPPF
-    ! cohort size x pft               (site_size_pft_r8) : SZPF
-    ! canopy layer x size x pft       (site_clscpf_r8)   : CLSZPF (NOT ACTIVE)
+    ! cohort age x pft                (site_cooage_r8)    : ACPF
+    ! patch age x fuel class          (site_agefuel_r8)   : APFC
+    ! patch age x pft                 (site_agepft_r8)    : APPF
+    ! canopy layer x patch age x pft  (site_canagepft_r8) : CLAPPF
+    ! canopy layer x leaf layer       (site_cnlf_r8)      : CLLL
+    ! canopy layer x leaf layer x pft (site_cnlfpft_r8)   : CLLLPF
+    ! element x cwd size              (site_elcwd_r8)     : ELDC
+    ! cohort size x patch age         (site_scag_r8)      : SZAP
+    ! cohort size x patch age x pft   (site_scagpft_r8)   : SZAPPF
+    ! cohort size x pft               (site_size_pft_r8)  : SZPF
+    ! canopy layer x size x pft       (site_clscpf_r8)    : CLSZPF (NOT ACTIVE)
     ! cohort size x crown damage       (site_cdsc_r8)     : SZCD
     ! cohort size x crown damage x pft (site_cdpf_r8)     : CDPF
 
@@ -8036,7 +8094,7 @@ contains
           call this%set_history_var(vname='FATES_NPLANT_CANOPY_SZAP', units = 'm-2', &
                long='number of canopy plants per m2, per size x age class'//   &
                this%per_ageclass_norm_info('FATES_PATCHAREA/FATES_PATCHAREA_AP'),  &
-               use_default='inactive', avgflag='A', vtype=site_scag_r8,             &
+               use_default='active', avgflag='A', vtype=site_scag_r8,             &
                hlms='CLM:ALM', upfreq=group_dyna_complx, ivar=ivar,                                 &
                initialize=initialize_variables, index = ih_nplant_canopy_si_scag)
 
@@ -8081,7 +8139,7 @@ contains
           call this%set_history_var(vname='FATES_NPLANT_SZAPPF',units = 'm-2',       &
                long='number of plants per m2, per size x age x pft class'//        &
                this%per_ageclass_norm_info('FATES_PATCHAREA/FATES_PATCHAREA_AP'),  &
-               use_default='inactive', avgflag='A', vtype=site_scagpft_r8,          &
+               use_default='active', avgflag='A', vtype=site_scagpft_r8,          &
                hlms='CLM:ALM', upfreq=group_dyna_complx, ivar=ivar,                                 &
                initialize=initialize_variables, index = ih_nplant_si_scagpft)
 
@@ -8104,6 +8162,18 @@ contains
                use_default='inactive', avgflag='A', vtype=site_agepft_r8,           &
                hlms='CLM:ALM', upfreq=group_dyna_complx, ivar=ivar,                                 &
                initialize=initialize_variables, index = ih_biomass_si_agepft)
+
+          call this%set_history_var(vname='FATES_CROWNAREA_APPF',units = 'proportion',        &
+               long='Crown area per PFT in each age bin as proportion of patch age class area',   &
+               use_default='inactive', avgflag='A', vtype=site_agepft_r8,                 &
+               hlms='CLM:ALM', upfreq=group_dyna_complx, ivar=ivar,                       &
+               initialize=initialize_variables, index = ih_crownarea_si_agepft)
+
+          call this%set_history_var(vname='FATES_CROWNAREA_CLAPPF',units = 'proportion',        &
+               long='Crown area per canopy layer per PFT in each age bin as proportion of patch age class area',   &
+               use_default='inactive', avgflag='A', vtype=site_canagepft_r8,                 &
+               hlms='CLM:ALM', upfreq=group_dyna_complx, ivar=ivar,                       &
+               initialize=initialize_variables, index = ih_crownarea_si_layeragepft)
 
           call this%set_history_var(vname='FATES_SCORCH_HEIGHT_APPF',units = 'm',    &
                long='SPITFIRE flame Scorch Height (calculated per PFT in each patch age bin)'// &

--- a/main/FatesHistoryVariableType.F90
+++ b/main/FatesHistoryVariableType.F90
@@ -11,7 +11,7 @@ module FatesHistoryVariableType
   use FatesIOVariableKindMod, only : site_coage_r8, site_coage_pft_r8
   use FatesIOVariableKindMod, only : site_height_r8
   use FatesIOVariableKindMod, only : site_fuel_r8, site_cwdsc_r8, site_scag_r8
-  use FatesIOVariableKindMod, only : site_scagpft_r8, site_agepft_r8
+  use FatesIOVariableKindMod, only : site_scagpft_r8, site_agepft_r8, site_canagepft_r8
   use FatesIOVariableKindMod, only : site_can_r8, site_cnlf_r8, site_cnlfpft_r8 
   use FatesIOVariableKindMod, only : site_cdsc_r8, site_cdpf_r8
   use FatesIOVariableKindMod, only : site_elem_r8, site_elpft_r8
@@ -197,6 +197,10 @@ contains
        allocate(this%r82d(lb1:ub1, lb2:ub2))
        this%r82d(:,:) = flushval
 
+    case(site_canagepft_r8)
+       allocate(this%r82d(lb1:ub1, lb2:ub2))
+       this%r82d(:,:) = flushval
+
    case(site_elem_r8)
        allocate(this%r82d(lb1:ub1, lb2:ub2))
        this%r82d(:,:) = flushval
@@ -346,6 +350,8 @@ contains
     case(site_scagpft_r8) 
        this%r82d(lb1:ub1, lb2:ub2) = this%flushval
     case(site_agepft_r8) 
+       this%r82d(lb1:ub1, lb2:ub2) = this%flushval
+    case(site_canagepft_r8)
        this%r82d(lb1:ub1, lb2:ub2) = this%flushval
     case(site_elem_r8)
        this%r82d(lb1:ub1, lb2:ub2) = this%flushval

--- a/main/FatesIODimensionsMod.F90
+++ b/main/FatesIODimensionsMod.F90
@@ -16,6 +16,7 @@ module FatesIODimensionsMod
     character(*), parameter, public  :: levscag = 'fates_levscag'      ! matches histFileMod
     character(*), parameter, public  :: levscagpft = 'fates_levscagpf' ! matches histFileMod
     character(*), parameter, public  :: levagepft = 'fates_levagepft'  ! matches histFileMod
+    character(*), parameter, public  :: levcanagepft = 'fates_levcnagpf' ! matches histFileMod
     character(*), parameter, public  :: levscpf = 'fates_levscpf'      ! matches histFileMod
     character(*), parameter, public  :: levscls = 'fates_levscls'      ! matches histFileMod
     character(*), parameter, public  :: levpft = 'fates_levpft'        ! matches histFileMod
@@ -100,6 +101,9 @@ module FatesIODimensionsMod
     ! levagepft = This is a strcture that records the boundaries for the 
     ! number of patch age x pft
 
+    ! levcanagepft = This is a strcture that records the boundaries for the 
+    ! number of canopy layers x patch age x pft
+
     ! levagefuel = This is a strcture that records the boundaries for the 
     ! number of patch age x fuel size class
 
@@ -141,6 +145,8 @@ module FatesIODimensionsMod
        integer :: sizeagepft_class_end
        integer :: agepft_class_begin
        integer :: agepft_class_end
+       integer :: layeragepft_class_begin
+       integer :: layeragepft_class_end
        integer :: sizepft_class_begin
        integer :: sizepft_class_end
        integer :: coagepf_class_begin

--- a/main/FatesIOVariableKindMod.F90
+++ b/main/FatesIOVariableKindMod.F90
@@ -39,6 +39,7 @@ module FatesIOVariableKindMod
   character(*), parameter, public :: site_scag_r8 = 'SI_SCAG_R8'
   character(*), parameter, public :: site_scagpft_r8 = 'SI_SCAGPFT_R8'
   character(*), parameter, public :: site_agepft_r8 = 'SI_AGEPFT_R8'
+  character(*), parameter, public :: site_canagepft_r8 = 'SI_CANAGEPFT_R8'
   character(*), parameter, public :: site_agefuel_r8 = 'SI_AGEFUEL_R8'
   character(*), parameter, public :: site_clscpf_r8 = 'SI_CLSCPF_R8'
   character(*), parameter, public :: site_landuse_r8 = 'SI_LANDUSE_R8'

--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -1265,6 +1265,9 @@ contains
        allocate( fates_hdim_pftmap_levscagpft(nlevsclass * nlevage * numpft))
        allocate( fates_hdim_agmap_levagepft(nlevage * numpft))
        allocate( fates_hdim_pftmap_levagepft(nlevage * numpft))
+       allocate( fates_hdim_agmap_levcanagepft(nclmax * nlevage * numpft))
+       allocate( fates_hdim_pftmap_levcanagepft(nclmax * nlevage * numpft))
+       allocate( fates_hdim_canmap_levcanagepft(nclmax * nlevage * numpft))
        allocate( fates_hdim_agmap_levagefuel(nlevage * num_fuel_classes))
        allocate( fates_hdim_fscmap_levagefuel(nlevage * num_fuel_classes))
 
@@ -1436,6 +1439,18 @@ contains
              i=i+1
              fates_hdim_agmap_levagepft(i) = iage
              fates_hdim_pftmap_levagepft(i) = ipft
+          end do
+       end do
+
+       i=0
+       do ipft=1,numpft
+          do iage=1,nlevage
+             do ican=1,nclmax
+                i=i+1
+                fates_hdim_pftmap_levcanagepft(i) = ipft
+                fates_hdim_agmap_levcanagepft(i) = iage
+                fates_hdim_canmap_levcanagepft(i) = ican
+             end do
           end do
        end do
 

--- a/main/FatesInterfaceTypesMod.F90
+++ b/main/FatesInterfaceTypesMod.F90
@@ -314,6 +314,9 @@ module FatesInterfaceTypesMod
    integer , public, allocatable :: fates_hdim_pftmap_levscagpft(:)    ! map of pft into size-class x patch age x pft dimension
    integer , public, allocatable :: fates_hdim_agmap_levagepft(:)      ! map of patch-age into patch age x pft dimension
    integer , public, allocatable :: fates_hdim_pftmap_levagepft(:)     ! map of pft into patch age x pft dimension
+   integer , public, allocatable :: fates_hdim_agmap_levcanagepft(:)   ! map of patch-age into canopy-layer x patch age x pft dimension
+   integer , public, allocatable :: fates_hdim_pftmap_levcanagepft(:)  ! map of pft into canopy-layer x patch age x pft dimension
+   integer , public, allocatable :: fates_hdim_canmap_levcanagepft(:)  ! map of canopy-layer into canopy-layer x patch age x pft dimension
    integer , public, allocatable :: fates_hdim_agmap_levagefuel(:)     ! map of patch-age into patch age x fsc dimension
    integer , public, allocatable :: fates_hdim_fscmap_levagefuel(:)    ! map of fuel size-class into patch age x fsc dimension
    

--- a/main/FatesSizeAgeTypeIndicesMod.F90
+++ b/main/FatesSizeAgeTypeIndicesMod.F90
@@ -26,6 +26,7 @@ module FatesSizeAgeTypeIndicesMod
   public :: get_height_index
   public :: get_sizeagepft_class_index
   public :: get_agepft_class_index
+  public :: get_layeragepft_class_index
   public :: get_cdamagesize_class_index
   public :: get_cdamagesizepft_class_index
   public :: coagetype_class_index
@@ -226,6 +227,27 @@ contains
           (pft-1) * nlevsclass * nlevdamage
 
   end function get_cdamagesizepft_class_index
+
+  ! =====================================================================================
+
+  function get_layeragepft_class_index(layer,age,pft) result(layer_by_age_by_pft_class)
+     
+     ! Get the 1D index for a canopy layer x patch age x pft triplet
+     
+     ! Arguments
+     integer,intent(in) :: layer
+     real(r8),intent(in) :: age
+     integer,intent(in)  :: pft
+
+     integer             :: age_class
+     integer             :: layer_by_age_by_pft_class
+     
+     age_class         = get_age_class_index(age)
+     
+     layer_by_age_by_pft_class = (pft-1)*nclmax*nlevage + &
+          (age_class-1)*nclmax + layer
+          
+  end function get_layeragepft_class_index
 
   ! =====================================================================================
 


### PR DESCRIPTION
### Description:
Adds a new history variable type (vtype) 'site_canagepft_r8' / compound dimension in output file 'fates_levcnagpf' that is dimensioned by canopy layer, patch age class, and PFT. 

Requires E3SM commit ffc91d2 to work, currently on: https://github.com/walkeranthonyp/E3SM/tree/walkeranthonyp/fates_output 

Also adds two history variables FATES_CROWNAREA_APPF and FATES_CROWNAREA_CLAPPF  

### Collaborators:
Discussion with Jenny, Charlie  

### Expectation of Answer Changes:
None expected

### Description of generative AI usage (as necessary)
None

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [x] The in-code documentation has been updated with descriptive comments
- [ ] The documentation has been assessed to determine if updates are necessary
- [ ] Describe use of generative AI (if necessary)

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided
- [ ] FATES-CLM6 Code Freeze: satellite phenology regression tests are b4b

*If satellite phenology regressions are **not** b4b, please hold merge and notify the FATES development team.*

### Documentation
User guide may need update if history variables or history variable types are listed

### Test Results:
*CTSM (or) E3SM (specify which) baseline hash-tag: 5ac83789c0

*FATES baseline hash-tag: 83863e93

*Test Output:*
Works with site level simulation run for a single ad_spinup case
