### PR TITLE
allocate space to disturbance_rates in the restart file

### DIFF
--- a/main/FatesInterfaceMod.F90
+++ b/main/FatesInterfaceMod.F90
@@ -38,6 +38,7 @@ module FatesInterfaceMod
    use FatesConstantsMod         , only : TRS_regeneration
    use FatesConstantsMod         , only : g_per_kg
    use FatesConstantsMod         , only : n_landuse_cats
+   use FatesConstantsMod         , only : n_dist_types
    use FatesConstantsMod         , only : primaryland
    use FatesConstantsMod         , only : secondaryland
    use FatesConstantsMod         , only : n_crop_lu_types
@@ -946,12 +947,17 @@ contains
          end if
          
          fates_maxElementsPerSite = max(fates_maxPatchesPerSite * fates_maxElementsPerPatch, &
-              numWatermem*numpft, num_vegtemp_mem, num_elements, nlevsclass*numpft*n_term_mort_types)
+              numWatermem*numpft, num_vegtemp_mem, num_elements*ncwd, num_elements*numpft, &
+              nlevsclass*numpft*n_term_mort_types)
 
          if(hlm_use_planthydro==itrue)then
             fates_maxElementsPerSite = max(fates_maxElementsPerSite, nshell*nlevsoi_hyd_max )
          end if
-         
+
+         ! Need enough restart elements to accomodate sites(s)%disturbance_rates
+         fates_maxElementsPerSite = max(fates_maxElementsPerSite,n_landuse_cats*n_landuse_cats*n_dist_types)
+         fates_maxElementsPerSite = max(fates_maxElementsPerSite,n_landuse_cats*numpft)
+
          
          ! Set the maximum number of nutrient aquisition competitors per site
          ! This is used to set array sizes for the boundary conditions.

--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -1764,9 +1764,10 @@ contains
          long_name='24-hour patch veg temp', &
          units='K', initialize=initialize_variables,ivar=ivar, index = ir_tveg24_pa)
 
-    call this%DefineRMeanRestartVar(vname='fates_disturbance_rates',vtype=cohort_r8, &
+    call this%set_restart_var(vname='fates_disturbance_rates',vtype=cohort_r8, &
          long_name='disturbance rates by donor land-use type, receiver land-use type, and disturbance type', &
-         units='1/day', initialize=initialize_variables,ivar=ivar, index = ir_disturbance_rates_siluludi)
+         units='1/day', flushval = flushzero, &
+         hlms='CLM:ALM',initialize=initialize_variables, ivar=ivar, index = ir_disturbance_rates_siluludi)
 
    if ( hlm_regeneration_model == TRS_regeneration ) then
       


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:
<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

For FATES variables that are restarted, and are longer than column level (ie most of our variables), we end up folding all of these variables into a restart vector of one prescribed length.  We call this the cohort dimension, but it really is a catch all for any variable that requires more space than the site/column.  So, the size of this vector must be the largest possible vector that we need to remember.  We have some tricks to get around making this vector super large, one of them is to actually define multiple copies of the variable with name extensions. 
But its very important when we add new restart variables that are big, that we make sure we allocate restart space.  Its hard to know which dimensions are going to require the most restart space, because many of things are modified by the user, and contextual to the type of run.

This set of changes makes sure that we allocate enough restart space for "disturbance_rates" which is a 3D variable (n_landuse_cats x n_landuse_cats * n_dist_type = 5 * 5 * 4 = 100)

I came across this while reviewing one of @mpaiao 's old PRs.

cc: @mvdebolskiy @maritsandstad @JessicaNeedham @rosiealice 

(I'm not sure if this is affecting noresm nocomp lu runs, seems possible though)

### Collaborators:

@mpaiao 

<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

### Description of generative AI usage (as necessary)
<!--- Please briefly describe usage of generative AI, such as  -->
<!--- platform, AI model, workflow, testing, etc. -->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [ ] The in-code documentation has been updated with descriptive comments
- [ ] The documentation has been assessed to determine if updates are necessary
- [ ] Describe use of generative AI (if necessary)

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided
- [ ] FATES-CLM6 Code Freeze: satellite phenology regression tests are b4b

*If satellite phenology regressions are **not** b4b, please hold merge and notify the FATES development team.*

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

