### PR TITLE
set radiation upper boundary to normalized for diagnostics

### DIFF
--- a/radiation/FatesRadiationDriveMod.F90
+++ b/radiation/FatesRadiationDriveMod.F90
@@ -182,9 +182,13 @@ contains
                              bc_out(s)%ftid_parb(ifp,ib), &  ! out
                              bc_out(s)%ftii_parb(ifp,ib))
 
-                        if(debug) then
-                           currentPatch%twostr%band(ib)%Rbeam_atm = 1._r8
-                           currentPatch%twostr%band(ib)%Rdiff_atm = 1._r8
+
+                        ! Set upper boundary conditions to unit normalized
+                        ! which allows for normalized diagnostics
+                        currentPatch%twostr%band(ib)%Rbeam_atm = 1._r8
+                        currentPatch%twostr%band(ib)%Rdiff_atm = 1._r8
+                        
+                        if(debug)then
                            call CheckPatchRadiationBalance(currentPatch, sites(s)%snow_depth, & 
                                 ib, bc_out(s)%fabd_parb(ifp,ib),bc_out(s)%fabi_parb(ifp,ib))
                            currentPatch%twostr%band(ib)%Rbeam_atm = fates_unset_r8


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

### Description:

This bug was identified in #1586 and a proposed fix was provided by @r-ward .  In summary, we make sure that the upper boundary condition for radiation is set to the normalized value when filling diagnostic arrays. The solver itself uses arguments instead of these patch level values, so was not affected.

<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

### Collaborators:

@r-ward  identified and came up with the solution

<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:
<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

### Description of generative AI usage (as necessary)
<!--- Please briefly describe usage of generative AI, such as  -->
<!--- platform, AI model, workflow, testing, etc. -->

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [x] The in-code documentation has been updated with descriptive comments
- [x] The documentation has been assessed to determine if updates are necessary
- [x] Describe use of generative AI (if necessary)

No generative AI was used here

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided
- [ ] FATES-CLM6 Code Freeze: satellite phenology regression tests are b4b

*If satellite phenology regressions are **not** b4b, please hold merge and notify the FATES development team.*

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

