### PR TITLE
fix(restart): read, write, and register fates_c13disc_acc in FatesRestartInterfaceMod

### DIFF
--- a/main/FatesRestartInterfaceMod.F90
+++ b/main/FatesRestartInterfaceMod.F90
@@ -149,6 +149,7 @@ module FatesRestartInterfaceMod
   integer :: ir_height_co
   integer :: ir_nplant_co
   integer :: ir_gpp_acc_co
+  integer :: ir_c13disc_acc_co
   integer :: ir_npp_acc_co
   integer :: ir_resp_m_acc_co
   integer :: ir_gpp_acc_hold_co
@@ -933,6 +934,11 @@ contains
          long_name='ed cohort - accumulated gpp over dynamics step', &
          units='kgC/indiv', flushval = flushzero, &
          hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_gpp_acc_co )
+
+    call this%set_restart_var(vname='fates_c13disc_acc', vtype=cohort_r8, &
+         long_name='ed cohort - accumulated c13 discrimination over dynamics step', &
+         units='per mil', flushval = flushzero, &
+         hlms='CLM:ALM', initialize=initialize_variables, ivar=ivar, index = ir_c13disc_acc_co )
 
     call this%set_restart_var(vname='fates_npp_acc', vtype=cohort_r8, &
          long_name='ed cohort - accumulated npp over dynamics step', &
@@ -2379,6 +2385,7 @@ contains
            rio_height_co               => this%rvars(ir_height_co)%r81d, &
            rio_nplant_co               => this%rvars(ir_nplant_co)%r81d, &
            rio_gpp_acc_co              => this%rvars(ir_gpp_acc_co)%r81d, &
+           rio_c13disc_acc_co          => this%rvars(ir_c13disc_acc_co)%r81d, &
            rio_npp_acc_co              => this%rvars(ir_npp_acc_co)%r81d, &
            rio_resp_m_acc_co           => this%rvars(ir_resp_m_acc_co)%r81d, &
            rio_gpp_acc_hold_co         => this%rvars(ir_gpp_acc_hold_co)%r81d, &
@@ -2788,6 +2795,7 @@ contains
                 rio_g_sb_laweight_co(io_idx_co)= ccohort%g_sb_laweight
                 rio_nplant_co(io_idx_co)       = ccohort%n
                 rio_gpp_acc_co(io_idx_co)      = ccohort%gpp_acc
+                rio_c13disc_acc_co(io_idx_co)  = ccohort%c13disc_acc
                 rio_npp_acc_co(io_idx_co)      = ccohort%npp_acc
                 rio_resp_m_acc_co(io_idx_co)     = ccohort%resp_m_acc
                 rio_gpp_acc_hold_co(io_idx_co) = ccohort%gpp_acc_hold
@@ -3454,6 +3462,7 @@ contains
           rio_height_co               => this%rvars(ir_height_co)%r81d, &
           rio_nplant_co               => this%rvars(ir_nplant_co)%r81d, &
           rio_gpp_acc_co              => this%rvars(ir_gpp_acc_co)%r81d, &
+          rio_c13disc_acc_co          => this%rvars(ir_c13disc_acc_co)%r81d, &
           rio_npp_acc_co              => this%rvars(ir_npp_acc_co)%r81d, &
           rio_resp_m_acc_co           => this%rvars(ir_resp_m_acc_co)%r81d, &
           rio_gpp_acc_hold_co         => this%rvars(ir_gpp_acc_hold_co)%r81d, &
@@ -3828,6 +3837,7 @@ contains
                 ccohort%height       = rio_height_co(io_idx_co)
                 ccohort%n            = rio_nplant_co(io_idx_co)
                 ccohort%gpp_acc      = rio_gpp_acc_co(io_idx_co)
+                ccohort%c13disc_acc  = rio_c13disc_acc_co(io_idx_co)
                 ccohort%npp_acc      = rio_npp_acc_co(io_idx_co)
                 ccohort%resp_m_acc   = rio_resp_m_acc_co(io_idx_co)
                 ccohort%gpp_acc_hold = rio_gpp_acc_hold_co(io_idx_co)


### PR DESCRIPTION
### Description:
This change registers, reads, writes, and packs/unpacks the cohort-level accumulated C13 isotope discrimination variable `fates_c13disc_acc` in `FatesRestartInterfaceMod.F90`. Without this restart variable in the restart stream, restarting runs with carbon isotope tracking enabled could lead to missing state accumulation across restart boundaries.

**Dependencies / Blockers:**
- Blocks [ESCOMP/CTSM#4172](https://github.com/ESCOMP/CTSM/pull/4172) (which in turn blocks [ESCOMP/CTSM#4171](https://github.com/ESCOMP/CTSM/pull/4171))

### Collaborators:
- @jpalex

**Linked issues addressed, if any:**
- Pre-requisite for [ESCOMP/CTSM#3660](https://github.com/ESCOMP/CTSM/issues/3660) (Fixes FATES `FATES_C13DISC_SZPF` restart mismatch)

### Expectation of Answer Changes:
- [x] **Bit-for-Bit (B4B)** with baseline master
- [ ] **Roundoff-level differences only**
- [ ] **Expected Answer Changes (ECA)**

### Description of generative AI usage (as necessary)
Google Antigravity was used to write the code and tests, followed by human-guided verification.

### Checklist
*Contributor*
- [x] The in-code documentation has been updated with descriptive comments
- [x] The documentation has been assessed to determine if updates are necessary
- [x] Describe use of generative AI (if necessary)

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided
- [ ] FATES-CLM6 Code Freeze: satellite phenology regression tests are b4b

### Test Results:
*CTSM (or) E3SM (specify which) test hash-tag:* N/A
*CTSM (or) E3SM (specify which) baseline hash-tag:* N/A
*FATES baseline hash-tag:* 8a33108361eb798b7cde79a99c9574ec1790b325

*Test Output:*
[x] Executed pFUnit / CIME regression tests