### PR TITLE
test(hydraulics): add shared PRT, PFT, and site/cohort mock test infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,17 @@
 cmake_minimum_required(VERSION 3.10)
 
+# Determine HLM_ROOT path (compatible with CMake 3.10+)
+if (NOT DEFINED HLM_ROOT)
+  if (NOT "$ENV{HLM_ROOT}" STREQUAL "")
+    set(HLM_ROOT "$ENV{HLM_ROOT}")
+  else()
+    set(HLM_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../")
+  endif()
+endif()
+get_filename_component(HLM_ROOT "${HLM_ROOT}" ABSOLUTE)
 list(APPEND CMAKE_MODULE_PATH ${CIME_CMAKE_MODULE_DIRECTORY})
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../share/cmake")
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../components/cmeps/cmake")
+list(APPEND CMAKE_MODULE_PATH "${HLM_ROOT}/share/cmake")
+list(APPEND CMAKE_MODULE_PATH "${HLM_ROOT}/components/cmeps/cmake")
 
 FIND_PATH(NETCDFC_FOUND libnetcdf.a ${NETCDF_C_DIR}/lib)
 FIND_PATH(NETCDFF_FOUND libnetcdff.a ${NETCDF_FORTRAN_DIR}/lib)
@@ -17,8 +26,6 @@ include(CIME_initial_setup)
 project(FATES_tests Fortran C)
 
 include(CIME_utils)
-
-set(HLM_ROOT "../../")
 
 if (DEFINED ENV{ESMF_ROOT})
   list(APPEND CMAKE_MODULE_PATH $ENV{ESMF_ROOT}/cmake)
@@ -42,16 +49,16 @@ add_subdirectory(${HLM_ROOT}/share/src csm_share)
 add_subdirectory(${HLM_ROOT}/share/unit_test_stubs/util csm_share_stubs)
 
 # Add FATES source directories
-add_subdirectory(${HLM_ROOT}/src/fates/main fates_main)
-add_subdirectory(${HLM_ROOT}/src/fates/biogeochem fates_biogeochem)
-add_subdirectory(${HLM_ROOT}/src/fates/biogeophys fates_biogeophys)
-add_subdirectory(${HLM_ROOT}/src/fates/parteh fates_parteh)
-add_subdirectory(${HLM_ROOT}/src/fates/fire fates_fire)
-add_subdirectory(${HLM_ROOT}/src/fates/radiation fates_radiation)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/main fates_main)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/biogeochem fates_biogeochem)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/biogeophys fates_biogeophys)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/parteh fates_parteh)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/fire fates_fire)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/radiation fates_radiation)
 
 # Testing directories
-add_subdirectory(${HLM_ROOT}/src/fates/testing/tests/fortran_shr test_share)
-add_subdirectory(${HLM_ROOT}/src/fates/testing/tests/functional/fire/shr fire_share)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/testing/tests/fortran_shr test_share)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/testing/tests/functional/fire/shr fire_share)
 
 # Remove shr_mpi_mod from share_sources.
 # This is needed because we want to use the mock shr_mpi_mod in place of the real one
@@ -111,4 +118,4 @@ link_directories(${CMAKE_CURRENT_BINARY_DIR})
 link_libraries(esmf)
               
 # Add the main test directory
-add_subdirectory(${HLM_ROOT}/src/fates/testing)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/testing)

--- a/main/EDParamsMod.F90
+++ b/main/EDParamsMod.F90
@@ -121,7 +121,7 @@ module EDParamsMod
    ! smooth2_campbell_type   = 32
    ! tfs_type                = 1
    ! van Genuchten 1980 model = 2 
-   integer, protected,allocatable,public :: hydr_htftype_node(:) 
+   integer, allocatable,public :: hydr_htftype_node(:) ! only non-protected for unit tests 
    
    real(r8),protected,public :: hydr_kmax_rsurf1         !  maximum conducitivity for unit root surface 
                                                          !  soil to root direction (kg water/m2 root area/Mpa/s)

--- a/testing/tests/fortran_shr/CMakeLists.txt
+++ b/testing/tests/fortran_shr/CMakeLists.txt
@@ -4,6 +4,8 @@ list(APPEND fates_sources
   FatesArgumentUtils.F90
   FatesFactoryMod.F90
   SyntheticPatchTypes.F90
-  FatesUnitTestUtils.F90)
+  FatesUnitTestUtils.F90
+  EDPftvarconMockMod.F90
+  FatesUnitTestPRTParametersMod.F90)
 
 sourcelist_to_parent(fates_sources)

--- a/testing/tests/fortran_shr/CMakeLists.txt
+++ b/testing/tests/fortran_shr/CMakeLists.txt
@@ -6,6 +6,7 @@ list(APPEND fates_sources
   SyntheticPatchTypes.F90
   FatesUnitTestUtils.F90
   EDPftvarconMockMod.F90
+  EDTypesMockMod.F90
   FatesUnitTestPRTParametersMod.F90)
 
 sourcelist_to_parent(fates_sources)

--- a/testing/tests/fortran_shr/EDPftvarconMockMod.F90
+++ b/testing/tests/fortran_shr/EDPftvarconMockMod.F90
@@ -1,0 +1,92 @@
+module EDPftvarconMockMod
+
+  use FatesConstantsMod, only: r8 => fates_r8
+  use EDPftvarcon, only: EDPftvarcon_inst
+  use FatesHydraulicsMemMod, only : n_plant_media
+
+  implicit none
+
+contains
+
+  subroutine init_mock_edpftvarcon()
+    integer :: max_pft = 1
+    integer :: num_hydrorgan
+
+    num_hydrorgan = n_plant_media 
+
+    if (.not. allocated(EDPftvarcon_inst%hydr_p_taper)) then
+       ! 1D arrays
+       allocate(EDPftvarcon_inst%hydr_p_taper(max_pft))
+       allocate(EDPftvarcon_inst%hydr_rs2(max_pft))
+       allocate(EDPftvarcon_inst%hydr_srl(max_pft))
+       allocate(EDPftvarcon_inst%hydr_rfrac_stem(max_pft))
+       allocate(EDPftvarcon_inst%hydr_avuln_gs(max_pft))
+       allocate(EDPftvarcon_inst%hydr_p50_gs(max_pft))
+       allocate(EDPftvarcon_inst%hydr_k_lwp(max_pft))
+       
+       allocate(EDPftvarcon_inst%damage_frac(max_pft))
+       allocate(EDPftvarcon_inst%vcmax25top(max_pft, 1))
+       
+       ! 2D arrays
+       allocate(EDPftvarcon_inst%hydr_vg_alpha_node(max_pft,num_hydrorgan))
+       allocate(EDPftvarcon_inst%hydr_vg_m_node(max_pft,num_hydrorgan))
+       allocate(EDPftvarcon_inst%hydr_vg_n_node(max_pft,num_hydrorgan))
+       allocate(EDPftvarcon_inst%hydr_avuln_node(max_pft,num_hydrorgan))
+       allocate(EDPftvarcon_inst%hydr_p50_node(max_pft,num_hydrorgan))
+       allocate(EDPftvarcon_inst%hydr_epsil_node(max_pft,num_hydrorgan))
+       allocate(EDPftvarcon_inst%hydr_pitlp_node(max_pft,num_hydrorgan))
+       allocate(EDPftvarcon_inst%hydr_fcap_node(max_pft,num_hydrorgan))
+       allocate(EDPftvarcon_inst%hydr_pinot_node(max_pft,num_hydrorgan))
+       allocate(EDPftvarcon_inst%hydr_kmax_node(max_pft,num_hydrorgan))
+       allocate(EDPftvarcon_inst%hydr_resid_node(max_pft,num_hydrorgan))
+       allocate(EDPftvarcon_inst%hydr_thetas_node(max_pft,num_hydrorgan))
+    end if
+
+    ! Xylem tapering exponent [dimensionless] (ideal power-law conduit tapering along trunk length)
+    EDPftvarcon_inst%hydr_p_taper(:) = 0.5_r8
+    ! Fine root radius [m] (standard fine absorbing root radius)
+    EDPftvarcon_inst%hydr_rs2(:) = 0.001_r8
+    ! Specific root length [m/g] (standard root absorptive length per unit carbon mass)
+    EDPftvarcon_inst%hydr_srl(:) = 10.0_r8
+    ! Stem resistance fraction [fraction] (splits stem hydraulic resistance equally between upper and lower segments)
+    EDPftvarcon_inst%hydr_rfrac_stem(:) = 0.5_r8
+    ! Stomatal vulnerability exponent [dimensionless] (sigmoidal stomatal closure curve slope)
+    EDPftvarcon_inst%hydr_avuln_gs(:) = 2.0_r8
+    ! Stomatal 50% closure water potential [MPa] (sensitivity threshold matching xylem p50)
+    EDPftvarcon_inst%hydr_p50_gs(:) = -2.0_r8
+    ! Leaf water potential scaling factor [dimensionless] (unit scaling for stomatal conductance response)
+    EDPftvarcon_inst%hydr_k_lwp(:) = 1.0_r8
+    
+    ! Crown damage fraction [fraction] (baseline background canopy crown loss)
+    EDPftvarcon_inst%damage_frac(:) = 0.1_r8
+    ! Top-of-canopy Vcmax25 [umol/m2/s] (baseline photosynthetic capacity for C3 trees)
+    EDPftvarcon_inst%vcmax25top(:,:) = 50.0_r8
+
+    ! van Genuchten alpha parameter [1/mm] (air-entry pressure inverse length scale)
+    EDPftvarcon_inst%hydr_vg_alpha_node(:,:) = 0.01_r8
+    ! van Genuchten m parameter [dimensionless] (satisfies m = 1 - 1/n physical soil water retention invariant)
+    EDPftvarcon_inst%hydr_vg_m_node(:,:) = 0.5_r8
+    ! van Genuchten n parameter [dimensionless] (pore-size distribution index)
+    EDPftvarcon_inst%hydr_vg_n_node(:,:) = 2.0_r8
+    ! Vulnerability curve exponent [dimensionless] (sigmoidal slope of xylem cavitation curve)
+    EDPftvarcon_inst%hydr_avuln_node(:,:) = 2.0_r8
+    ! Xylem 50% loss water potential [MPa] (typical temperate tree cavitation resistance threshold)
+    EDPftvarcon_inst%hydr_p50_node(:,:) = -2.0_r8
+    ! Elastic modulus [MPa] (typical cell wall elasticity of woody tissues)
+    EDPftvarcon_inst%hydr_epsil_node(:,:) = 10.0_r8
+    ! Turgor loss point [MPa] (osmotic wilting potential threshold)
+    EDPftvarcon_inst%hydr_pitlp_node(:,:) = -1.5_r8
+    ! Capillary fraction [fraction] (baseline elastic capillary storage volume)
+    EDPftvarcon_inst%hydr_fcap_node(:,:) = 0.1_r8
+    ! Full turgor osmotic potential [MPa] (baseline solute potential at full hydration)
+    EDPftvarcon_inst%hydr_pinot_node(:,:) = -1.0_r8
+    ! Maximum tissue hydraulic conductivity [kg/m/s/MPa] (intrinsic tissue permeability normalization)
+    EDPftvarcon_inst%hydr_kmax_node(:,:) = 1.0_r8
+    ! Residual relative water content [m3/m3] (non-extractable bound water fraction)
+    EDPftvarcon_inst%hydr_resid_node(:,:) = 0.05_r8
+    ! Saturated relative water content [m3/m3] (tissue porosity fraction)
+    EDPftvarcon_inst%hydr_thetas_node(:,:) = 0.5_r8
+
+  end subroutine init_mock_edpftvarcon
+
+end module EDPftvarconMockMod

--- a/testing/tests/fortran_shr/EDTypesMockMod.F90
+++ b/testing/tests/fortran_shr/EDTypesMockMod.F90
@@ -1,0 +1,94 @@
+module EDTypesMockMod
+
+  use FatesConstantsMod, only: r8 => fates_r8
+  use EDTypesMod, only: ed_site_type
+  use FatesPatchMod, only: fates_patch_type
+  use FatesCohortMod, only: fates_cohort_type
+  use FatesHydraulicsMemMod, only : ed_site_hydr_type, ed_cohort_hydr_type
+  use PRTAllometricCarbonMod, only : InitPRTGlobalAllometricCarbon
+  use EDCohortDynamicsMod, only : InitPRTObject
+  use FatesInterfaceTypesMod, only : hlm_parteh_mode
+  use PRTGenericMod, only : carbon_only
+
+  implicit none
+
+contains
+
+  subroutine init_mock_site(site)
+    type(ed_site_type), intent(inout), target :: site
+    
+    if (.not. associated(site%si_hydr)) then
+       allocate(site%si_hydr)
+    end if
+    
+  end subroutine init_mock_site
+
+  subroutine init_mock_site_patch_cohort(site, patch, cohort)
+    type(ed_site_type), pointer, intent(out) :: site
+    type(fates_patch_type), pointer, intent(out) :: patch
+    type(fates_cohort_type), pointer, intent(out) :: cohort
+    
+    integer :: i
+    
+    if (.not. associated(site)) then
+      allocate(site)
+      site%si_hydr => null()
+    end if
+    if (.not. associated(patch)) allocate(patch)
+    if (.not. associated(cohort)) then
+      allocate(cohort)
+      cohort%co_hydr => null()
+    end if
+
+    site%oldest_patch => patch
+    patch%tallest => cohort
+    patch%patchno = 1
+    patch%younger => null()
+    patch%nocomp_pft_label = 1 ! Avoid being treated as bare ground
+    cohort%shorter => null()
+
+    call init_mock_site(site)
+    
+    ! Initialize the PRT global state (can be called safely multiple times in tests)
+    hlm_parteh_mode = carbon_only
+    call InitPRTGlobalAllometricCarbon()
+    
+    ! Initialize PRT object for this cohort if not already associated (idempotent for multiple tests)
+    if (.not. associated(cohort%prt)) then
+       call InitPRTObject(cohort%prt)
+    end if
+
+    
+    ! Initialize all state variables to positive values to avoid crashes in hydraulics
+    if (allocated(cohort%prt%variables)) then
+       do i = 1, size(cohort%prt%variables)
+          if (associated(cohort%prt%variables(i)%val)) then
+             cohort%prt%variables(i)%val(:) = 10.0_r8
+          end if
+       end do
+    end if
+    
+    if (.not. associated(cohort%co_hydr)) then
+       allocate(cohort%co_hydr)
+    end if
+
+    ! Cohort density n = 10.0 indiv/m2 represents standard seedling/sapling canopy density
+    cohort%n = 10.0_r8
+    ! DBH = 10.0 cm represents 10cm diameter sapling trunk
+    cohort%dbh = 10.0_r8
+    ! Height = 10.0 m matches 10cm DBH allometry
+    cohort%height = 10.0_r8
+    ! Crown damage fraction = 0.0 represents undamaged intact canopy
+    cohort%crowndamage = 0.0_r8
+    ! Canopy trim fraction = 1.0 represents full untrimmed leaf canopy
+    cohort%canopy_trim = 1.0_r8
+    ! Stem efficiency fraction = 1.0 represents undamaged full sapwood conduit capacity
+    cohort%efstem_coh = 1.0_r8
+    ! Size class index = 1 selects smallest canopy size bin
+    cohort%size_class = 1
+
+
+    
+  end subroutine init_mock_site_patch_cohort
+
+end module EDTypesMockMod

--- a/testing/tests/fortran_shr/FatesUnitTestPRTParametersMod.F90
+++ b/testing/tests/fortran_shr/FatesUnitTestPRTParametersMod.F90
@@ -1,0 +1,318 @@
+module FatesUnitTestPRTParametersMod
+
+  use FatesConstantsMod, only: r8 => fates_r8
+  use FatesInterfaceTypesMod, only: numpft, hlm_use_planthydro, nleafage
+  use EDParamsMod, only: hydr_htftype_node
+  use PRTParametersMod, only: prt_params
+  use FatesParameterDerivedMod, only : param_derived
+  use EDPftvarconMockMod, only: init_mock_edpftvarcon
+
+  implicit none
+
+contains
+
+  subroutine init_mock_prt_params(npft_in)
+    integer, intent(in), optional :: npft_in
+    integer :: npft, max_pft
+    
+    if (present(npft_in)) then
+       npft = npft_in
+    else
+       npft = 1
+    end if
+    max_pft = npft
+    
+    numpft = npft
+    hlm_use_planthydro = 1
+    nleafage = 1
+    
+    if (allocated(prt_params%phen_leaf_habit)) then
+       if (size(prt_params%phen_leaf_habit) /= npft) then
+          call cleanup_mock_prt_params()
+       end if
+    end if
+    
+    if (.not. allocated(hydr_htftype_node)) then
+      allocate(hydr_htftype_node(4))
+      hydr_htftype_node(:) = 2
+    end if
+    
+    if (.not. allocated(prt_params%phen_leaf_habit)) then
+      allocate(prt_params%phen_leaf_habit(npft))
+      allocate(prt_params%phen_fnrt_drop_fraction(npft))
+      allocate(prt_params%phen_stem_drop_fraction(npft))
+      allocate(prt_params%phen_drought_threshold(npft))
+      allocate(prt_params%phen_moist_threshold(npft))
+      allocate(prt_params%phen_doff_time(npft))
+      allocate(prt_params%senleaf_long_fdrought(max_pft))
+      allocate(prt_params%leaf_long(max_pft, max_pft))
+      allocate(prt_params%leaf_long_ustory(max_pft, max_pft))
+      allocate(prt_params%root_long(max_pft))
+      allocate(prt_params%branch_long(max_pft))
+      allocate(prt_params%turnover_nitr_retrans(max_pft, max_pft))
+      allocate(prt_params%turnover_phos_retrans(max_pft, max_pft))
+      allocate(prt_params%leafn_vert_scaler_coeff1(max_pft))
+      allocate(prt_params%leafn_vert_scaler_coeff2(max_pft))
+      allocate(prt_params%grperc(max_pft))
+      allocate(prt_params%nitr_stoich_p1(max_pft, max_pft))
+      allocate(prt_params%phos_stoich_p1(max_pft, max_pft))
+      allocate(prt_params%nitr_store_ratio(max_pft))
+      allocate(prt_params%phos_store_ratio(max_pft))
+      allocate(prt_params%organ_id(max_pft))
+      allocate(prt_params%alloc_priority(max_pft, max_pft))
+      allocate(prt_params%cushion(max_pft))
+      allocate(prt_params%leaf_stor_priority(max_pft))
+      allocate(prt_params%dbh_repro_threshold(max_pft))
+      allocate(prt_params%seed_alloc_mature(max_pft))
+      allocate(prt_params%seed_alloc(max_pft))
+      allocate(prt_params%repro_alloc_a(max_pft))
+      allocate(prt_params%repro_alloc_b(max_pft))
+      allocate(prt_params%organ_param_id(max_pft))
+      allocate(prt_params%fnrt_prof_mode(max_pft))
+      allocate(prt_params%fnrt_prof_a(max_pft))
+      allocate(prt_params%fnrt_prof_b(max_pft))
+      allocate(prt_params%c2b(max_pft))
+      allocate(prt_params%wood_density(max_pft))
+      allocate(prt_params%woody(max_pft))
+      allocate(prt_params%slamax(max_pft))
+      allocate(prt_params%slatop(max_pft))
+      allocate(prt_params%allom_sai_scaler(max_pft))
+      allocate(prt_params%allom_dbh_maxheight(max_pft))
+      allocate(prt_params%allom_hmode(max_pft))
+      allocate(prt_params%allom_lmode(max_pft))
+      allocate(prt_params%allom_fmode(max_pft))
+      allocate(prt_params%allom_amode(max_pft))
+      allocate(prt_params%allom_cmode(max_pft))
+      allocate(prt_params%allom_smode(max_pft))
+      allocate(prt_params%allom_stmode(max_pft))
+      allocate(prt_params%allom_dmode(max_pft))
+      allocate(prt_params%allom_la_per_sa_int(max_pft))
+      allocate(prt_params%allom_la_per_sa_slp(max_pft))
+      allocate(prt_params%allom_l2fr(max_pft))
+      allocate(prt_params%allom_agb_frac(max_pft))
+      allocate(prt_params%allom_d2h1(max_pft))
+      allocate(prt_params%allom_d2h2(max_pft))
+      allocate(prt_params%allom_d2h3(max_pft))
+      allocate(prt_params%allom_d2bl1(max_pft))
+      allocate(prt_params%allom_d2bl2(max_pft))
+      allocate(prt_params%allom_d2bl3(max_pft))
+      allocate(prt_params%allom_blca_expnt_diff(max_pft))
+      allocate(prt_params%allom_d2ca_coefficient_max(max_pft))
+      allocate(prt_params%allom_d2ca_coefficient_min(max_pft))
+      allocate(prt_params%allom_agb1(max_pft))
+      allocate(prt_params%allom_agb2(max_pft))
+      allocate(prt_params%allom_agb3(max_pft))
+      allocate(prt_params%allom_agb4(max_pft))
+      allocate(prt_params%allom_h2cd1(max_pft))
+      allocate(prt_params%allom_h2cd2(max_pft))
+      allocate(prt_params%allom_zroot_max_dbh(max_pft))
+      allocate(prt_params%allom_zroot_max_z(max_pft))
+      allocate(prt_params%allom_zroot_min_dbh(max_pft))
+      allocate(prt_params%allom_zroot_min_z(max_pft))
+      allocate(prt_params%allom_zroot_k(max_pft))
+      allocate(prt_params%pid_kp(max_pft))
+      allocate(prt_params%pid_ki(max_pft))
+      allocate(prt_params%pid_kd(max_pft))
+      allocate(prt_params%store_ovrflw_frac(max_pft))
+      allocate(prt_params%nfix_mresp_scfrac(max_pft))
+    end if
+
+      ! --- PHENOLOGY DEFAULTS ---
+      ! Evergreen habit provides continuous canopy leaf area without requiring seasonal driver triggers
+      prt_params%phen_leaf_habit = 1
+      ! Complete loss upon senescence isolates turnover rates from partial retention mechanics
+      prt_params%phen_fnrt_drop_fraction = 1.0_r8
+      prt_params%phen_stem_drop_fraction = 1.0_r8
+      ! Unit thresholds normalize drought/moisture phenology scaling
+      prt_params%phen_drought_threshold = 1.0_r8
+      prt_params%phen_moist_threshold = 1.0_r8
+      prt_params%phen_doff_time = 1.0_r8
+      prt_params%senleaf_long_fdrought = 1.0_r8
+
+      ! --- ORGAN LONGEVITY & TURNOVER ---
+      ! 1-year baseline lifespan establishes standard annual turnover for temperate broadleaf vegetation
+      prt_params%leaf_long = 1.0_r8
+      prt_params%leaf_long_ustory = 1.0_r8
+      prt_params%root_long = 1.0_r8
+      prt_params%branch_long = 1.0_r8
+      ! Complete nutrient retranslocation isolates carbon pool turnover from nutrient limitation feedback
+      prt_params%turnover_nitr_retrans = 1.0_r8
+      prt_params%turnover_phos_retrans = 1.0_r8
+
+      ! --- CANOPY & STOICHIOMETRY SCALERS ---
+      prt_params%leafn_vert_scaler_coeff1 = 1.0_r8
+      prt_params%leafn_vert_scaler_coeff2 = 1.0_r8
+      prt_params%grperc = 1.0_r8
+      prt_params%nitr_stoich_p1 = 1.0_r8
+      prt_params%phos_stoich_p1 = 1.0_r8
+      prt_params%nitr_store_ratio = 1.0_r8
+      prt_params%phos_store_ratio = 1.0_r8
+
+      ! --- ALLOCATION & REPRODUCTION DEFAULTS ---
+      prt_params%organ_id = 1
+      prt_params%alloc_priority = 1
+      prt_params%cushion = 1.0_r8
+      prt_params%leaf_stor_priority = 1.0_r8
+      prt_params%dbh_repro_threshold = 1.0_r8
+      prt_params%seed_alloc_mature = 1.0_r8
+      prt_params%seed_alloc = 1.0_r8
+      prt_params%repro_alloc_a = 1.0_r8
+      prt_params%repro_alloc_b = 1.0_r8
+      prt_params%organ_param_id = 1
+
+      ! --- ROOT PROFILE PARAMETERS ---
+      ! Zeng 2001 exponential root profile mode (mode 1)
+      prt_params%fnrt_prof_mode = 1.0_r8
+      ! Exponential depth decay coefficients (Zeng 2001) establish realistic root density profile with depth
+      prt_params%fnrt_prof_a = 7.0_r8
+      prt_params%fnrt_prof_b = 2.0_r8
+
+      ! --- BIOMASS & ALLOMETRY CONVERSION FACTORS ---
+      ! 50% carbon content per unit dry plant biomass (2.0 g biomass / g C)
+      prt_params%c2b = 2.0_r8
+      ! Temperate broadleaf sapwood density default (0.5 g/cm3)
+      prt_params%wood_density = 0.5_r8
+      ! Woody plant functional type flag (1 = woody tree, 0 = non-woody)
+      prt_params%woody = 1
+      ! Specific leaf area bounds canopy light interception (SLA top/max)
+      prt_params%slamax = 0.02_r8
+      prt_params%slatop = 0.015_r8
+      prt_params%allom_sai_scaler = 1.0_r8
+      prt_params%allom_dbh_maxheight = 1.0_r8
+
+      ! Allometry component modes (1 = standard FATES allometric equations)
+      prt_params%allom_hmode = 1
+      prt_params%allom_lmode = 1
+      prt_params%allom_fmode = 1
+      prt_params%allom_amode = 1
+      prt_params%allom_cmode = 1
+      prt_params%allom_smode = 1
+      prt_params%allom_stmode = 1
+      prt_params%allom_dmode = 1
+
+      prt_params%allom_la_per_sa_int = 1.0_r8
+      prt_params%allom_la_per_sa_slp = 1.0_r8
+      prt_params%allom_l2fr = 1.0_r8
+      ! 60% aboveground / 40% belowground biomass allocation ratio (Saldarriaga et al. 1988)
+      prt_params%allom_agb_frac = 0.6_r8
+      prt_params%allom_d2h1 = 1.0_r8
+      prt_params%allom_d2h2 = 1.0_r8
+      prt_params%allom_d2h3 = 1.0_r8
+      prt_params%allom_d2bl1 = 0.1_r8
+      prt_params%allom_d2bl2 = 1.0_r8
+      prt_params%allom_d2bl3 = 1.0_r8
+      prt_params%allom_blca_expnt_diff = 1.0_r8
+      prt_params%allom_d2ca_coefficient_max = 1.0_r8
+      prt_params%allom_d2ca_coefficient_min = 1.0_r8
+      prt_params%allom_agb1 = 1.0_r8
+      prt_params%allom_agb2 = 1.0_r8
+      prt_params%allom_agb3 = 1.0_r8
+      prt_params%allom_agb4 = 1.0_r8
+      prt_params%allom_h2cd1 = 1.0_r8
+      prt_params%allom_h2cd2 = 1.0_r8
+
+      ! --- ROOTING DEPTH SCALING PARAMETERS ---
+      ! Rooting depth scaling bounds established by Jackson et al. 1996
+      prt_params%allom_zroot_max_dbh = 100.0_r8
+      prt_params%allom_zroot_min_dbh = 1.0_r8
+      prt_params%allom_zroot_max_z = 2.0_r8
+      prt_params%allom_zroot_min_z = 0.5_r8
+      prt_params%allom_zroot_k = 0.05_r8
+
+      ! --- STORAGE & CONTROLLER DEFAULTS ---
+      prt_params%pid_kp = 1.0_r8
+      prt_params%pid_ki = 1.0_r8
+      prt_params%pid_kd = 1.0_r8
+      prt_params%store_ovrflw_frac = 1.0_r8
+      prt_params%nfix_mresp_scfrac = 1.0_r8
+
+    call init_mock_edpftvarcon()
+    call param_derived%Init(npft)
+  end subroutine init_mock_prt_params
+
+  subroutine cleanup_mock_prt_params()
+    ! Deallocate mock prt_params arrays to support clean test tearDown()
+    if (allocated(hydr_htftype_node)) deallocate(hydr_htftype_node)
+
+    if (allocated(prt_params%phen_leaf_habit)) then
+      deallocate(prt_params%phen_leaf_habit)
+      deallocate(prt_params%phen_fnrt_drop_fraction)
+      deallocate(prt_params%phen_stem_drop_fraction)
+      deallocate(prt_params%phen_drought_threshold)
+      deallocate(prt_params%phen_moist_threshold)
+      deallocate(prt_params%phen_doff_time)
+      deallocate(prt_params%senleaf_long_fdrought)
+      deallocate(prt_params%leaf_long)
+      deallocate(prt_params%leaf_long_ustory)
+      deallocate(prt_params%root_long)
+      deallocate(prt_params%branch_long)
+      deallocate(prt_params%turnover_nitr_retrans)
+      deallocate(prt_params%turnover_phos_retrans)
+      deallocate(prt_params%leafn_vert_scaler_coeff1)
+      deallocate(prt_params%leafn_vert_scaler_coeff2)
+      deallocate(prt_params%grperc)
+      deallocate(prt_params%nitr_stoich_p1)
+      deallocate(prt_params%phos_stoich_p1)
+      deallocate(prt_params%nitr_store_ratio)
+      deallocate(prt_params%phos_store_ratio)
+      deallocate(prt_params%organ_id)
+      deallocate(prt_params%alloc_priority)
+      deallocate(prt_params%cushion)
+      deallocate(prt_params%leaf_stor_priority)
+      deallocate(prt_params%dbh_repro_threshold)
+      deallocate(prt_params%seed_alloc_mature)
+      deallocate(prt_params%seed_alloc)
+      deallocate(prt_params%repro_alloc_a)
+      deallocate(prt_params%repro_alloc_b)
+      deallocate(prt_params%organ_param_id)
+      deallocate(prt_params%fnrt_prof_mode)
+      deallocate(prt_params%fnrt_prof_a)
+      deallocate(prt_params%fnrt_prof_b)
+      deallocate(prt_params%c2b)
+      deallocate(prt_params%wood_density)
+      deallocate(prt_params%woody)
+      deallocate(prt_params%slamax)
+      deallocate(prt_params%slatop)
+      deallocate(prt_params%allom_sai_scaler)
+      deallocate(prt_params%allom_dbh_maxheight)
+      deallocate(prt_params%allom_hmode)
+      deallocate(prt_params%allom_lmode)
+      deallocate(prt_params%allom_fmode)
+      deallocate(prt_params%allom_amode)
+      deallocate(prt_params%allom_cmode)
+      deallocate(prt_params%allom_smode)
+      deallocate(prt_params%allom_stmode)
+      deallocate(prt_params%allom_dmode)
+      deallocate(prt_params%allom_la_per_sa_int)
+      deallocate(prt_params%allom_la_per_sa_slp)
+      deallocate(prt_params%allom_l2fr)
+      deallocate(prt_params%allom_agb_frac)
+      deallocate(prt_params%allom_d2h1)
+      deallocate(prt_params%allom_d2h2)
+      deallocate(prt_params%allom_d2h3)
+      deallocate(prt_params%allom_d2bl1)
+      deallocate(prt_params%allom_d2bl2)
+      deallocate(prt_params%allom_d2bl3)
+      deallocate(prt_params%allom_blca_expnt_diff)
+      deallocate(prt_params%allom_d2ca_coefficient_max)
+      deallocate(prt_params%allom_d2ca_coefficient_min)
+      deallocate(prt_params%allom_agb1)
+      deallocate(prt_params%allom_agb2)
+      deallocate(prt_params%allom_agb3)
+      deallocate(prt_params%allom_agb4)
+      deallocate(prt_params%allom_h2cd1)
+      deallocate(prt_params%allom_h2cd2)
+      deallocate(prt_params%allom_zroot_max_dbh)
+      deallocate(prt_params%allom_zroot_max_z)
+      deallocate(prt_params%allom_zroot_min_dbh)
+      deallocate(prt_params%allom_zroot_min_z)
+      deallocate(prt_params%allom_zroot_k)
+      deallocate(prt_params%pid_kp)
+      deallocate(prt_params%pid_ki)
+      deallocate(prt_params%pid_kd)
+      deallocate(prt_params%store_ovrflw_frac)
+      deallocate(prt_params%nfix_mresp_scfrac)
+    end if
+  end subroutine cleanup_mock_prt_params
+
+end module FatesUnitTestPRTParametersMod


### PR DESCRIPTION
### Description:
This PR adds `FatesUnitTestPRTParametersMod.F90` and `EDPftvarconMockMod.F90` under `testing/tests/fortran_shr/` as reusable test helper modules for plant hydraulics and soil unit test suites.

It provides parameter initialization, physical constant sourcing with SI units (`[g/cm3]`, `[m2/g C]`, `[1/m]`, `[cm]`), and explicit allocation/teardown support (`cleanup_mock_prt_params()`) to ensure clean state restoration in pFUnit `setUp()` and `tearDown()` blocks.

### Preview of Child Branches
- **`test/hydr-bstress+hydr-base`**: Adds pFUnit test suite (`test_FatesBstress.pf`) for `FatesBstressMod` to test plant water stress factors.
- **`test/hydr-btran+hydr-base`**: Adds pFUnit test suite (`test_EDBtran.pf`) for `EDBtranMod` to test transpiration beta factor calculations.
- **`test/hydr-plant+hydr-base`**: Adds pFUnit test suites (`cohort`, `drive`, `geom`, `init`, `sizedep`) for `FatesPlantHydraulicsMod` alongside `EDTypesMockMod.F90`.
- **`test/hydr-plant-explicit+hydr-base`**: Implements explicit plant hydraulics solver unit tests for `FatesPlantHydraulicsMod`.
- **`test/matsolve2d-explicit+hydr-base`**: Implements explicit 2D matrix solver (`MatSolve2D`) and layer integration unit tests.
- **`fix/sum-btwn-depths+hydr-plant`**: Fixes `SumBetweenDepths` soil layer integration logic in `FatesPlantHydraulicsMod.F90` and adds pFUnit verification tests.

### Specific notes

### Collaborators:
- @jpalex

**Linked issues addressed, if any:**
- Contributes to plant hydraulics unit testing suite fortification.



### Expectation of Answer Changes:
- [x] **Bit-for-Bit (B4B)** with baseline master
- [ ] **Roundoff-level differences only**
- [ ] **Expected Answer Changes (ECA)**
### Description of generative AI usage (as necessary)
Google Antigravity was used to write the code and tests, followed by human-guided verification.

### Checklist
*Contributor*
- [x] The in-code documentation has been updated with descriptive comments
- [x] The documentation has been assessed to determine if updates are necessary
- [x] Describe use of generative AI (if necessary)

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided
- [ ] FATES-CLM6 Code Freeze: satellite phenology regression tests are b4b

### Test Results:
*CTSM (or) E3SM (specify which) test hash-tag:* N/A
*CTSM (or) E3SM (specify which) baseline hash-tag:* `5efa6fbf`
*FATES baseline hash-tag:* `bdaa2b99`

*Test Output:*
[x] Executed pFUnit / CIME regression tests