### PR TITLE
build(fates): Add dynamic HLM_ROOT configuration for standalone FATES builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,17 @@
 cmake_minimum_required(VERSION 3.10)
 
+# Determine HLM_ROOT path (compatible with CMake 3.10+)
+if (NOT DEFINED HLM_ROOT)
+  if (NOT "$ENV{HLM_ROOT}" STREQUAL "")
+    set(HLM_ROOT "$ENV{HLM_ROOT}")
+  else()
+    set(HLM_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../")
+  endif()
+endif()
+get_filename_component(HLM_ROOT "${HLM_ROOT}" ABSOLUTE)
 list(APPEND CMAKE_MODULE_PATH ${CIME_CMAKE_MODULE_DIRECTORY})
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../share/cmake")
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../components/cmeps/cmake")
+list(APPEND CMAKE_MODULE_PATH "${HLM_ROOT}/share/cmake")
+list(APPEND CMAKE_MODULE_PATH "${HLM_ROOT}/components/cmeps/cmake")
 
 FIND_PATH(NETCDFC_FOUND libnetcdf.a ${NETCDF_C_DIR}/lib)
 FIND_PATH(NETCDFF_FOUND libnetcdff.a ${NETCDF_FORTRAN_DIR}/lib)
@@ -17,8 +26,6 @@ include(CIME_initial_setup)
 project(FATES_tests Fortran C)
 
 include(CIME_utils)
-
-set(HLM_ROOT "../../")
 
 if (DEFINED ENV{ESMF_ROOT})
   list(APPEND CMAKE_MODULE_PATH $ENV{ESMF_ROOT}/cmake)
@@ -42,16 +49,16 @@ add_subdirectory(${HLM_ROOT}/share/src csm_share)
 add_subdirectory(${HLM_ROOT}/share/unit_test_stubs/util csm_share_stubs)
 
 # Add FATES source directories
-add_subdirectory(${HLM_ROOT}/src/fates/main fates_main)
-add_subdirectory(${HLM_ROOT}/src/fates/biogeochem fates_biogeochem)
-add_subdirectory(${HLM_ROOT}/src/fates/biogeophys fates_biogeophys)
-add_subdirectory(${HLM_ROOT}/src/fates/parteh fates_parteh)
-add_subdirectory(${HLM_ROOT}/src/fates/fire fates_fire)
-add_subdirectory(${HLM_ROOT}/src/fates/radiation fates_radiation)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/main fates_main)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/biogeochem fates_biogeochem)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/biogeophys fates_biogeophys)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/parteh fates_parteh)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/fire fates_fire)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/radiation fates_radiation)
 
 # Testing directories
-add_subdirectory(${HLM_ROOT}/src/fates/testing/tests/fortran_shr test_share)
-add_subdirectory(${HLM_ROOT}/src/fates/testing/tests/functional/fire/shr fire_share)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/testing/tests/fortran_shr test_share)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/testing/tests/functional/fire/shr fire_share)
 
 # Remove shr_mpi_mod from share_sources.
 # This is needed because we want to use the mock shr_mpi_mod in place of the real one
@@ -111,4 +118,4 @@ link_directories(${CMAKE_CURRENT_BINARY_DIR})
 link_libraries(esmf)
               
 # Add the main test directory
-add_subdirectory(${HLM_ROOT}/src/fates/testing)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/testing)

--- a/testing/framework/utils/path.py
+++ b/testing/framework/utils/path.py
@@ -1,5 +1,6 @@
 """Utility functions related to getting paths to various important places"""
 
+import os
 import sys
 import importlib
 from pathlib import Path
@@ -38,12 +39,24 @@ def path_to_cime() -> Path:
         RuntimeError: can't find path to cime
 
     Returns:
-        str: full path to cime
+        Path: full path to cime
     """
+    # 1. Check HLM_ROOT environment variable if set
+    hlm_root = os.environ.get("HLM_ROOT")
+    if hlm_root:
+        cime_path = (Path(hlm_root) / "cime").resolve()
+        if cime_path.is_dir():
+            return cime_path
+
+    # 2. Fallback to nested location relative to FATES root
     cime_path = (path_to_fates_root() / "../../cime").resolve()
     if cime_path.is_dir():
         return cime_path
-    raise RuntimeError("Cannot find cime.")
+
+    raise RuntimeError(
+        "Cannot find cime. Please define the HLM_ROOT environment variable "
+        "pointing to the parent of your local CIME directory."
+    )
 
 
 def path_to_fates_root() -> Path:


### PR DESCRIPTION
### Description:
This change enhances CMake configuration and Python test suite path resolution to support building and testing FATES in standalone repository setups. `HLM_ROOT` path determination in `CMakeLists.txt` and CIME path resolution in `testing/framework/utils/path.py` now support an optional `HLM_ROOT` environment variable, falling back gracefully to the standard nested directory layout.

This allows both development scenarios:
1. **Editing a standalone FATES repository with the CTSM repository elsewhere:** Set the `HLM_ROOT` environment variable to point to the host model / CTSM installation directory.
2. **Editing a FATES repository inside a CTSM repository:** Do not set `HLM_ROOT` (the default fallback path logic automatically locates the host model / CIME directory relative to the FATES root).

### Specific notes

### Collaborators:
- @jpalex

**Parent PR (if stacked on a parent branch):**
- None

**Linked issues addressed, if any:**
- None



### Expectation of Answer Changes:
- [x] **Bit-for-Bit (B4B)** with baseline master
- [ ] **Roundoff-level differences only**
- [ ] **Expected Answer Changes (ECA)**
### Description of generative AI usage (as necessary)
Google Antigravity was used to write the code and tests, followed by human-guided verification.

### Checklist
*Contributor*
- [x] The in-code documentation has been updated with descriptive comments
- [x] The documentation has been assessed to determine if updates are necessary
- [x] Describe use of generative AI (if necessary)

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided
- [ ] FATES-CLM6 Code Freeze: satellite phenology regression tests are b4b

### Test Results:
*CTSM (or) E3SM (specify which) test hash-tag:* N/A
*CTSM (or) E3SM (specify which) baseline hash-tag:* N/A
*FATES baseline hash-tag:* `093b4f46`

*Test Output:*
[x] Executed pFUnit / CIME regression tests