### PR TITLE
Preventing efflux losses by passing directly to HLM output flux arrays

### DIFF
--- a/biogeochem/EDPhysiologyMod.F90
+++ b/biogeochem/EDPhysiologyMod.F90
@@ -3216,7 +3216,7 @@ contains
              years_per_day * SF_val_max_decomp(fuel_classes%dead_leaves()) * fragmentation_scaler(soil_layer_index)
 
        do ilyr = 1,nlev_eff_decomp
-           litt%root_fines_frag(dcmpy,ilyr) = litt%root_fines(dcmpy,ilyr) * &
+           litt%root_fines_frag(dcmpy,ilyr) = litt%root_fines_frag(dcmpy,ilyr) + litt%root_fines(dcmpy,ilyr) * &
                  years_per_day *  SF_val_max_decomp(fuel_classes%dead_leaves()) * fragmentation_scaler(ilyr)
        end do
     enddo


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description:

Exudation of N and P was being overwritten during the fragmentation flux scheme. See issue #1607. This fix makes the fragmentation flux additive to the exudation flux.  This was identified and solved by @jingtao-lbl .

<!--- Describe your changes in detail -->
<!--- please add issue number if one exists -->

### Collaborators:

@jingtao-lbl 

<!--- List names of collaborators or people who have interacted -->
<!--- in bringing about this set of changes -->
<!--- consultation, discussions, etc. -->

### Expectation of Answer Changes:

Will only affect nutrient limited CNP simulations.

<!--- Please describe under what conditions, if any, -->
<!--- the model is expected to generated different answers -->
<!--- from the master version of the code -->

### Description of generative AI usage (as necessary)
<!--- Please briefly describe usage of generative AI, such as  -->
<!--- platform, AI model, workflow, testing, etc. -->

Generative AI was not used to code or propose code changes. I believe AI was used as a consultant, human discussion was performed.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
*If this is your first time contributing, please read the [**CONTRIBUTING**](https://github.com/NGEET/fates/blob/main/CONTRIBUTING.md) document.*

All checklist items must be checked to enable merging this pull request:

*Contributor*
- [ ] The in-code documentation has been updated with descriptive comments
- [ ] The documentation has been assessed to determine if updates are necessary
- [ ] Describe use of generative AI (if necessary)

*Integrator*
- [ ] FATES PASS/FAIL regression tests were run
- [ ] Evaluation of test results for answer changes was performed and results provided
- [ ] FATES-CLM6 Code Freeze: satellite phenology regression tests are b4b

*If satellite phenology regressions are **not** b4b, please hold merge and notify the FATES development team.*

### Documentation
<!--- If this pull requests warrants an update to the tech doc or user's guide, and said changes have been made paste a link to the documentation pull request below.  -->
<!--- If documentation updates are needed, but changes do not yet have their own separate pull request, please create an issue on either repo so that we can keep track of necessary updates.-->
- [Technical Note](https://github.com/NGEET/fates-docs) update:
- [User's Guide](https://github.com/NGEET/fates-users-guide) update: 

### Test Results:
<!--- Non-trivial changes require the PASS/FAIL regression tests. -->
<!--- If changes to code are NOT expected to change answers, tests must -->
<!--- be run against a baseline. -->

*CTSM (or) E3SM (specify which) test hash-tag:*

*CTSM (or) E3SM (specify which) baseline hash-tag:*

*FATES baseline hash-tag:*

*Test Output:*

<!--- paste in test results here -->


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 

